### PR TITLE
Add remaining meta data to case study format

### DIFF
--- a/formats/case_study/backend/schema.json
+++ b/formats/case_study/backend/schema.json
@@ -165,6 +165,9 @@
         "lead_organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
         "supporting_organisations": {
           "$ref": "#/definitions/guid_list"
         },
@@ -172,6 +175,9 @@
           "$ref": "#/definitions/guid_list"
         },
         "worldwide_organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_priorities": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -28,6 +28,7 @@
           "locale": "en"
         }
       ],
+      "related_policies": [],
       "supporting_organisations": [],
       "world_locations": [
         {
@@ -47,6 +48,7 @@
           "locale": "en"
         }
       ],
+      "worldwide_priorities": [],
       "available_translations": [
         {
           "title": "Pakistan: In school for the first time",


### PR DESCRIPTION
This adds the last two bits of meta data (related policies and worldwide priorities) to the case study schema.

**Note that this includes commits in github.com/alphagov/govuk-content-schemas/pull/1. Assuming that is merged first, this pull request will consist of the final commit only**.

Story: https://trello.com/c/16aW6TD4/73-add-remaining-meta-data-to-case-study-format
