### PR TITLE
Add unpublishing format publishing schema/example

### DIFF
--- a/formats/unpublishing/frontend/examples/unpublishing.json
+++ b/formats/unpublishing/frontend/examples/unpublishing.json
@@ -1,0 +1,28 @@
+{
+  "base_path":"/government/case-studies/bubble-trouble",
+  "title":"Bubble and trouble",
+  "description":"A case study about bubble and trouble.",
+  "format":"unpublishing",
+  "need_ids":[
+
+  ],
+  "locale":"en",
+  "updated_at":"2014-12-10T14:50:13.372Z",
+  "public_updated_at":"2014-04-30T23:01:51.000+00:00",
+  "details":{
+    "explanation": "This is now redundant",
+    "unpublished_at":"2014-05-01T14:59:17+01:00",
+    "alternative_url": null
+  },
+  "links":{
+    "available_translations":[
+      {
+        "title":"Bubble and trouble",
+        "base_path":"/government/case-studies/bubble-trouble",
+        "api_url":"http://content-store/content/government/case-studies/bubble-trouble",
+        "web_url":"https://www.gov.uk/government/case-studies/bubble-trouble",
+        "locale":"en"
+      }
+    ]
+  }
+}

--- a/formats/unpublishing/publisher/schema.json
+++ b/formats/unpublishing/publisher/schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "update_type",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "enum": [ "unpublishing" ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [ "major", "minor", "republish" ]
+    },
+    "locale": {
+      "type": "String"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "explanation",
+        "unpublished_at",
+        "alternative_url"
+      ],
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "unpublished_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "alternative_url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [ "prefix", "exact" ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the "unpublishing" format schema and an example. Mainly so that I can use the example when running tests whilst trying to deliver: https://trello.com/c/o1EFKTaj/60-government-frontend-handles-unpublishing-format-content-items

Also in support of https://trello.com/c/BQodP4gq/58-handle-unpublished-splash-pages-in-the-new-publishing-2-0-stack.
