### PR TITLE
Deprecate base_path in body in the publishing context

### DIFF
--- a/formats/case_study/frontend/schema.json
+++ b/formats/case_study/frontend/schema.json
@@ -3,14 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
-    "locale"
+    "locale",
+    "base_path"
   ],
   "properties": {
-    "base_path": {
-      "type": "string"
-    },
     "title": {
       "type": "string"
     },
@@ -175,6 +172,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "type": "string"
     }
   },
   "definitions": {

--- a/formats/case_study/publisher/schema.json
+++ b/formats/case_study/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",
@@ -11,9 +10,6 @@
     "locale"
   ],
   "properties": {
-    "base_path": {
-      "type": "string"
-    },
     "content_id": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"

--- a/formats/coming_soon/frontend/schema.json
+++ b/formats/coming_soon/frontend/schema.json
@@ -3,14 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
-    "locale"
+    "locale",
+    "base_path"
   ],
   "properties": {
-    "base_path": {
-      "type": "string"
-    },
     "title": {
       "type": "string"
     },
@@ -61,6 +58,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "type": "string"
     }
   },
   "definitions": {

--- a/formats/coming_soon/publisher/schema.json
+++ b/formats/coming_soon/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",
@@ -11,9 +10,6 @@
     "locale"
   ],
   "properties": {
-    "base_path": {
-      "type": "string"
-    },
     "content_id": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",
@@ -11,9 +10,6 @@
     "locale"
   ],
   "properties": {
-    "base_path": {
-      "type": "string"
-    },
     "content_id": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -3,16 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "update_type",
     "redirects"
   ],
   "properties": {
-    "base_path": {
-      "type": "string"
-    },
     "format": {
       "enum": [ "redirect" ]
     },

--- a/formats/unpublishing/frontend/schema.json
+++ b/formats/unpublishing/frontend/schema.json
@@ -3,14 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
-    "locale"
+    "locale",
+    "base_path"
   ],
   "properties": {
-    "base_path": {
-      "type": "string"
-    },
     "title": {
       "type": "string"
     },
@@ -74,6 +71,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "type": "string"
     }
   },
   "definitions": {

--- a/formats/unpublishing/publisher/schema.json
+++ b/formats/unpublishing/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",
@@ -11,9 +10,6 @@
     "locale"
   ],
   "properties": {
-    "base_path": {
-      "type": "string"
-    },
     "content_id": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -39,14 +39,15 @@ private
 
   def required_properties
     return [] unless @publisher_schema.schema.has_key?('required')
-    @publisher_schema.schema['required'].reject { |property_name| internal?(property_name) }
+    (@publisher_schema.schema['required'] - INTERNAL_PROPERTIES) + ['base_path']
   end
 
   def frontend_properties
     excluding_internal = @publisher_schema.schema['properties'].reject { |property_name| internal?(property_name) }
     excluding_internal.merge(
       'links' => frontend_links,
-      'updated_at' => updated_at
+      'updated_at' => updated_at,
+      'base_path' => { 'type' => 'string' }
     )
   end
 

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
 
   let(:publisher_properties) {
     %w{
-      base_path
       content_id
       description
       details
@@ -26,7 +25,6 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
 
   let(:required_properties) {
     %w{
-      base_path
       format
       locale
       publishing_app
@@ -76,6 +74,17 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
         "type" => "string",
         "format" => "date-time"
       }
+    )
+  end
+
+  it "adds base_path as a required string property" do
+    expect(generated.schema['properties']).to include(
+      "base_path" => {
+        "type" => "string"
+      }
+    )
+    expect(generated.schema["required"]).to include(
+      "base_path"
     )
   end
 


### PR DESCRIPTION
The documentation implies that the base_path must be included in the request
body for write requests as well as in the URL. This is not true and in fact if
supplied in the body it is discarded by content-store, otherwise it is ignored
- the base_path in the URL is used instead.

Leading developers to believe that it is required but not performing any
validation on it seems likely to be a source of errors, so let's get rid of it.