### PR TITLE
Deprecate base_path in publishing context

### DIFF
--- a/formats/case_study/publisher/schema.json
+++ b/formats/case_study/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",

--- a/formats/coming_soon/publisher/schema.json
+++ b/formats/coming_soon/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",

--- a/formats/unpublishing/publisher/schema.json
+++ b/formats/unpublishing/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "base_path",
     "format",
     "publishing_app",
     "rendering_app",

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -39,14 +39,15 @@ private
 
   def required_properties
     return [] unless @publisher_schema.schema.has_key?('required')
-    @publisher_schema.schema['required'].reject { |property_name| internal?(property_name) }
+    ['base_path'] + (@publisher_schema.schema['required'] - INTERNAL_PROPERTIES)
   end
 
   def frontend_properties
     excluding_internal = @publisher_schema.schema['properties'].reject { |property_name| internal?(property_name) }
     excluding_internal.merge(
       'links' => frontend_links,
-      'updated_at' => updated_at
+      'updated_at' => updated_at,
+      'base_path' => { 'type' => 'string' }
     )
   end
 

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
 
   let(:publisher_properties) {
     %w{
-      base_path
       content_id
       description
       details
@@ -26,7 +25,6 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
 
   let(:required_properties) {
     %w{
-      base_path
       format
       locale
       publishing_app
@@ -76,6 +74,17 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
         "type" => "string",
         "format" => "date-time"
       }
+    )
+  end
+
+  it "adds base_path as a required string property" do
+    expect(generated.schema['properties']).to include(
+      "base_path" => {
+        "type" => "string"
+      }
+    )
+    expect(generated.schema["required"]).to include(
+      "base_path"
     )
   end
 


### PR DESCRIPTION
We want to remove base_path from the request body in the publishing context as
it is a potential source of error. Making it optional is the first step to
removing it.

The frontend representation will continue to include `base_path`. This will be
automatically inserted by the content store.