### PR TITLE
Disallow unspecified properties in finders

### DIFF
--- a/formats/finder/frontend/examples/contacts.json
+++ b/formats/finder/frontend/examples/contacts.json
@@ -1,0 +1,53 @@
+{
+  "base_path": "/government/organisations/hm-cheese-biscuits/contact",
+  "format": "finder",
+  "title": "HM Cheese & Biscuits Contacts",
+  "description": "",
+  "public_updated_at": "2015-03-05T16:48:34.000Z",
+  "details": {
+    "document_noun": "contact",
+    "filter": {
+      "document_type": "contact",
+      "organisations": [
+        "hm-cheese-biscuits"
+      ]
+    },
+    "facets": [
+      {
+        "key": "contact_group",
+        "name": "Topic",
+        "filterable": true,
+        "type": "text",
+        "display_as_result_metadata": true,
+        "preposition": "in topic",
+        "allowed_values": [
+          {
+            "label": "Stinking Bishop",
+            "value": "stinking-bishop"
+          },
+          {
+            "label": "Digestives",
+            "value": "digestives"
+          },
+          {
+            "label": "Quince",
+            "value": "quince"
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "organisations": [
+      {
+        "title": "HM Cheese & Biscuits",
+        "base_path": "/government/organisations/hm-cheese-biscuits",
+        "api_url": "http://content-store.dev.gov.uk/content/government/organisations/government/organisations/hm-cheese-biscuits",
+        "web_url": "http://www.dev.gov.uk/government/organisations/government/organisations/hm-cheese-biscuits",
+        "locale": "en"
+      }
+    ],
+    "related": []
+  },
+  "locale": "en"
+}

--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -49,6 +49,9 @@
           "type": "string",
           "additionalProperties": false
         },
+        "email_signup_enabled": {
+          "type": "boolean"
+        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",
@@ -143,6 +146,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -38,7 +38,7 @@
     },
     "details": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": [
         "document_noun",
         "filter",
@@ -51,13 +51,13 @@
         },
         "filter": {
           "type": "object",
-          "additionalProperties": true
+          "additionalProperties": false
         },
         "facets": {
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": true,
+            "additionalProperties": false,
             "required": [
               "key",
               "filterable",

--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -56,6 +56,12 @@
           "properties": {
             "document_type": {
               "type": "string"
+            },
+            "organisations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -50,8 +50,14 @@
           "additionalProperties": false
         },
         "filter": {
+          "description": "This is the fixed filter that scopes the finder",
           "type": "object",
-          "additionalProperties": false
+          "additionalProperties": false,
+          "properties": {
+            "document_type": {
+              "type": "string"
+            }
+          }
         },
         "facets": {
           "type": "array",
@@ -78,6 +84,12 @@
               "name": {
                 "type": "string"
               },
+              "preposition": {
+                "type": "string"
+              },
+              "short_name": {
+                "type": "string"
+              },
               "type": {
                 "type": "string"
               },
@@ -102,6 +114,12 @@
               }
             }
           }
+        },
+        "show_summaries": {
+          "type": "boolean"
+        },
+        "summary": {
+          "type": "string"
         }
       }
     },

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -12,6 +12,9 @@
       "type": "string",
       "additionalProperties": false
     },
+    "email_signup_enabled": {
+      "type": "boolean"
+    },
     "filter": {
       "description": "This is the fixed filter that scopes the finder",
       "type": "object",

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -19,6 +19,12 @@
       "properties": {
         "document_type": {
           "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -13,8 +13,14 @@
       "additionalProperties": false
     },
     "filter": {
+      "description": "This is the fixed filter that scopes the finder",
       "type": "object",
-      "additionalProperties": false
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        }
+      }
     },
     "facets": {
       "type": "array",
@@ -41,6 +47,12 @@
           "name": {
             "type": "string"
           },
+          "preposition": {
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
           "type": {
             "type": "string"
           },
@@ -65,6 +77,12 @@
           }
         }
       }
+    },
+    "show_summaries": {
+      "type": "boolean"
+    },
+    "summary": {
+      "type": "string"
     }
   }
 }

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": [
     "document_noun",
     "filter",
@@ -14,13 +14,13 @@
     },
     "filter": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "facets": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "key",
           "filterable",

--- a/formats/finder/publisher/links.json
+++ b/formats/finder/publisher/links.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "organisations": {
       "$ref": "#/definitions/guid_list"

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -87,6 +87,12 @@
           "properties": {
             "document_type": {
               "type": "string"
+            },
+            "organisations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -81,8 +81,14 @@
           "additionalProperties": false
         },
         "filter": {
+          "description": "This is the fixed filter that scopes the finder",
           "type": "object",
-          "additionalProperties": false
+          "additionalProperties": false,
+          "properties": {
+            "document_type": {
+              "type": "string"
+            }
+          }
         },
         "facets": {
           "type": "array",
@@ -109,6 +115,12 @@
               "name": {
                 "type": "string"
               },
+              "preposition": {
+                "type": "string"
+              },
+              "short_name": {
+                "type": "string"
+              },
               "type": {
                 "type": "string"
               },
@@ -133,6 +145,12 @@
               }
             }
           }
+        },
+        "show_summaries": {
+          "type": "boolean"
+        },
+        "summary": {
+          "type": "string"
         }
       }
     },

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -69,7 +69,7 @@
     },
     "details": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": [
         "document_noun",
         "filter",
@@ -82,13 +82,13 @@
         },
         "filter": {
           "type": "object",
-          "additionalProperties": true
+          "additionalProperties": false
         },
         "facets": {
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": true,
+            "additionalProperties": false,
             "required": [
               "key",
               "filterable",
@@ -138,7 +138,7 @@
     },
     "links": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "organisations": {
           "$ref": "#/definitions/guid_list"

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -80,6 +80,9 @@
           "type": "string",
           "additionalProperties": false
         },
+        "email_signup_enabled": {
+          "type": "boolean"
+        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",
@@ -174,6 +177,9 @@
           "$ref": "#/definitions/guid_list"
         },
         "available_translations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
           "$ref": "#/definitions/guid_list"
         }
       }


### PR DESCRIPTION
Allowing unspecified properties leaves the way open for typos in field names,
undocumented fields and other errors. I found some problems in contacts-admin
after making this change.

I've also added an example for a Contact finder as they are a bit different.

cc @evilstreak @edds @tommyp 