### PR TITLE
Add base policies finder as an example

### DIFF
--- a/formats/finder/frontend/examples/policies.json
+++ b/formats/finder/frontend/examples/policies.json
@@ -1,0 +1,37 @@
+{
+   "base_path": "/government/policies",
+   "format":"finder",
+   "title":"Policies",
+   "description":"",
+   "updated_at": "2015-02-20T10:31:55.529Z",
+   "public_updated_at":"2015-03-09T14:09:25.000+00:00",
+   "locale":"en",
+   "details":{
+      "document_noun":"policy",
+      "email_signup_enabled":false,
+      "filter":{
+         "format":"policy"
+      },
+      "show_summaries":false,
+      "facets":[
+
+      ]
+   },
+   "links":{
+      "organisations":[
+
+      ],
+      "related":[
+
+      ],
+      "available_translations": [
+        {
+          "title": "Policies",
+          "base_path": "/government/policies",
+          "api_url": "http://content-store.dev.gov.uk/content/government/policies",
+          "web_url": "http://www.dev.gov.uk/government/policies",
+          "locale": "en"
+        }
+      ]
+   }
+}


### PR DESCRIPTION
This is mainly so that we have a finder example that filters on format.