### PR TITLE
Make examples have distinct base_paths

### DIFF
--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -1,77 +1,68 @@
 {
-    "base_path": "/government/case-studies/get-britain-building-carlisle-park",
-    "description": "Nearly 400 homes are set to be built on the site of a former tar distillery thanks to Gleeson Homes and HCA investment.",
-    "details": {
-      "archive_notice": {
-        "explanation": "This document is no longer current government policy",
-        "archived_at": "2012-12-17T15:45:44+00:00"
-      },
-      "body": "<div class=\"govspeak\"><p>A new community of nearly 400 homes is set to be built on the site of a former tar distillery thanks to Gleeson Homes and investment from the Homes and Communities Agency (<abbr title=\"Homes and Communities Agency\">HCA</abbr>).</p>\n\n<p>The Croda Tar Distillery, on the border between Kilnhurst and Swinton, closed in the early 1990s. Over the past 2 decades the 31 acre site has lain derelict with the heavily contaminated site proving a challenge for developers.</p>\n\n<p>However in 2010 Gleeson identified the site, which is adjacent to the Sheffield &amp; South Yorkshire Navigation Canal, as having great potential for new low cost homes.</p>\n\n<p>Working with Rotherham Borough Council and remediation specialists, work is now underway to clean up the site. </p>\n\n<p>Once the clean-up has been completed Gleeson Homes will begin to transform the area into 381 new 2, 3 and 4 bedroom homes.  The developer will be making use of \u00a32.2 million of investment from the Homes and Communities Agency\u2019s (<abbr title=\"Homes and Communities Agency\">HCA</abbr>) Get Britain Building programme to start the first phase of 125 homes.</p>\n\n<p>Craig Johns, Area Manager at the <abbr title=\"Homes and Communities Agency\">HCA</abbr> said: </p>\n\n<p>\u201cThe development at Carlisle Park offers a real choice of quality homes to local residents where they want to live at a price they can afford. Our investment will ensure that a local firm will provide these homes which will help safeguard jobs in South Yorkshire.\u201d</p>\n\n<p>The development will feature a mix of first time buyer and family homes, set among public open space and children\u2019s play areas.</p>\n\n<p>Steve Gamble, Gleeson Homes Group Land Director said: </p>\n\n<p>\u201cWe are delighted that Carlisle Park is part of the Get Britain Building programme. The programme will help us to deliver the first tranche of 125 new homes which are built and priced to suit local people.  </p>\n\n<p>\u201cThe project will also have a positive effect of the wider community with the creation of new jobs, apprenticeship opportunities for local young people and investment back into the local area.\u201d</p>\n\n<p>A recoverable investment, the Get Britain Building programme helps developers access finance, and to help bring forward marginal sites by sharing risk. </p>\n\n<p>Up to 16,000 homes on stalled sites across England will be built by March 2015 thanks to this programme.</p></div>",
-      "change_note": null,
-      "first_public_at": "2012-12-17T15:45:44+00:00",
-      "image": {
-          "alt_text": "Carlisle Park",
-          "caption": "Carlisle Park",
-          "url": "http://static.dev.gov.uk/government/uploads/system/uploads/image_data/file/5693/s300_Carlisle_Park_1_960x640.jpg"
-      },
-      "tags": {
-          "browse_pages": [],
-          "topics": []
-      },
-      "format_display_type":"case_study"
+  "base_path": "/government/case-studies/terence-age-33-stoke-on-trent",
+  "title": "Terence, age 33, Stoke-on-Trent",
+  "description": "'My experience with Shaw Trust was very positive and I received all the support I needed to get back into work.'",
+  "format": "case_study",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2014-12-08T15:26:28.258Z",
+  "public_updated_at": "2013-04-15T16:12:55.000+00:00",
+  "details": {
+    "change_note": null,
+    "tags": {
+      "browse_pages": [],
+      "topics": []
     },
-    "format": "case_study",
-    "links": {
-      "lead_organisations": [
-        {
-          "title": "Department for International Development",
-          "base_path": "/government/organisations/department-for-international-development",
-          "api_url": "http://content-store/organisations/department-for-international-development",
-          "web_url": "https://www.gov.uk/government/organisations/department-for-international-development",
-          "locale": "en"
-        }
-      ],
-      "related_policies": [],
-      "supporting_organisations": [],
-      "world_locations": [
-        {
-          "title": "Pakistan",
-          "base_path": "/government/world/pakistan",
-          "api_url": "http://content-store/content/government/world/pakistan",
-          "web_url": "https://www.gov.uk/government/world/pakistan",
-          "locale": "en"
-        }
-      ],
-      "worldwide_organisations": [
-        {
-          "title": "DFID Pakistan",
-          "base_path": "/government/world/organisations/dfid-pakistan",
-          "api_url": "http://content-store/content/government/world/organisations/dfid-pakistan",
-          "web_url": "https://www.gov.uk/government/world/organisations/dfid-pakistan",
-          "locale": "en"
-        }
-      ],
-      "worldwide_priorities": [],
-      "available_translations": [
-        {
-          "title": "Pakistan: In school for the first time",
-          "base_path":  "/government/case-studies/pakistan-in-school-for-the-first-time",
-          "api_url":  "http://content-store/content/government/case-studies/pakistan-in-school-for-the-first-time",
-          "web_url":  "https://www.gov.uk/government/case-studies/pakistan-in-school-for-the-first-time",
-          "locale": "en"
-        },
-        {
-          "title": "پاکستان: اسکول میں پہلی بارداخلہ",
-          "base_path":  "/government/case-studies/pakistan-in-school-for-the-first-time.ur",
-          "api_url":  "http://content-store/content/government/case-studies/pakistan-in-school-for-the-first-time.ur",
-          "web_url":  "https://www.gov.uk/government/case-studies/pakistan-in-school-for-the-first-time.ur",
-          "locale": "ur"
-        }
-      ]
+    "body": "<div class=\"govspeak\"><p>Following the death of his wife Terence has been caring full-time for his two children, one of whom has a physical disability and medical condition and requires a lot of support.</p>\n\n<p>Terence was unemployed for over 14 years when he joined the Work Programme with Shaw Trust.</p>\n\n<p>Terence was keen to find work in the care industry but was concerned that his lack of qualifications, his childcare commitments and long period of unemployment could impact on him finding a job.</p>\n\n<p>An adviser worked with Terence so that he received tailored support with his CV to reflect the type of work he was looking for, as well as interview preparation and basic IT skills.</p>\n\n<p>Terence was delighted when he secured a permanent job as a support worker that allowed him to continue caring for his children.</p>\n\n<p>Terence found the support he received from the Shaw Trust made all the difference: </p>\n\n<blockquote>\n  <p class=\"last-child\">The fact that my adviser rang me after interviews and the ongoing support I received really helped build my confidence.</p>\n</blockquote>\n\n<p>The Work Programme is part funded by the European Social Fund.</p></div>",
+    "format_display_type": "case_study",
+    "first_public_at": "2013-04-15T17:12:55+01:00",
+    "change_history": [
+      {
+        "public_timestamp": "2013-04-15T17:12:55+01:00",
+        "note": "First published."
+      }
+    ],
+    "image": {
+      "url": "https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/image_data/file/6029/s300_terence-stoke-960.jpg",
+      "alt_text": "Terence",
+      "caption": null
     },
-    "locale": "en",
-    "need_ids": [],
-    "public_updated_at": "2012-12-17T15:45:44.000+00:00",
-    "title": "Get Britain Building: Carlisle Park",
-    "updated_at": "2014-11-17T14:19:42.460Z"
+    "archive_notice": {
+      "explanation": "<div class=\"govspeak\"><p>We’ve archived this case study and published newer <a href=\"https://www.gov.uk/government/collections/work-programme-real-life-stories\">Work Programme real life stories</a>.</p></div>",
+      "archived_at": "2014-08-22T10:29:02+01:00"
+    }
+  },
+  "links": {
+    "lead_organisations": [
+      {
+        "title": "Department for Work and Pensions",
+        "base_path": "/government/organisations/department-for-work-pensions",
+        "api_url": "http://content-store/content/government/organisations/department-for-work-pensions",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-work-pensions",
+        "locale": "en"
+      }
+    ],
+    "related_policies": [
+      {
+        "title": "Helping people to find and stay in work",
+        "base_path": "/government/policies/helping-people-to-find-and-stay-in-work",
+        "api_url": "http://content-store/content/government/policies/helping-people-to-find-and-stay-in-work",
+        "web_url": "https://www.gov.uk/government/policies/helping-people-to-find-and-stay-in-work",
+        "locale": "en"
+      }
+    ],
+    "supporting_organisations": [],
+    "world_locations": [],
+    "worldwide_organisations": [],
+    "worldwide_priorities": [],
+    "available_translations": [
+      {
+        "title": "Terence, age 33, Stoke-on-Trent",
+        "base_path": "/government/case-studies/terence-age-33-stoke-on-trent",
+        "api_url": "http://content-store/content/government/case-studies/terence-age-33-stoke-on-trent",
+        "web_url": "https://www.gov.uk/government/case-studies/terence-age-33-stoke-on-trent",
+        "locale": "en"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This means that all of the existing examples can be uniquely identified by the
base_path. This makes it easier to tell which is which, and also means that the
base_path can be used as a key in a hash or test name.