### PR TITLE
Enforce unique base path in examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,19 @@ validation_records := $(examples:.json=.json.valid)
 combiner_bin := bundle exec ./bin/combine_publisher_schema
 frontend_generator_bin := bundle exec ./bin/generate_frontend_schema
 validation_bin := bundle exec ./bin/validate
+ensure_example_base_paths_unique_bin := bundle exec ./bin/ensure_example_base_paths_unique
 
 # The tasks run as part of the default make process
-default: $(publisher_schemas) $(frontend_schemas) $(validation_records)
+default: $(publisher_schemas) $(frontend_schemas) validate_unique_base_path $(validation_records)
 
 # A task to remove all intermediary files and force a complete rebuild
 clean:
 	rm -f $(validation_records)
 	rm -f $(frontend_schemas)
 	rm -f $(publisher_schemas)
+
+validate_unique_base_path: $(frontend_schemas)
+	$(ensure_example_base_paths_unique_bin) $(examples)
 
 # Recipe for building publisher schemas from the metadata, details and links schemas
 %/publisher/schema.json: %/../metadata.json %/publisher/details.json $(wildcard %/publisher/links.json)

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,41 @@
+# All of the publisher details schemas used as input
 details_schemas := $(wildcard formats/*/publisher/details.json)
+
+# All of the example files
 examples := $(wildcard formats/*/frontend/examples/*.json)
 
+# Derive the publisher schema files from the details schemas by substitution
 publisher_schemas := $(details_schemas:details.json=schema.json)
+
+# Derive the frontend schemas from the details schemas by substitution
 frontend_schemas := $(details_schemas:publisher/details.json=frontend/schema.json)
+
+# The validation records are temporary files which are created to indicate that a given
+# example has been validated.
 validation_records := $(examples:.json=.json.valid)
 
+# The various scripts used in the build process
 combiner_bin := bundle exec ./bin/combine_publisher_schema
 frontend_generator_bin := bundle exec ./bin/generate_frontend_schema
 validation_bin := bundle exec ./bin/validate
 
+# The tasks run as part of the default make process
 default: $(publisher_schemas) $(frontend_schemas) $(validation_records)
+
+# A task to remove all intermediary files and force a complete rebuild
 clean:
 	rm -f $(validation_records)
 	rm -f $(frontend_schemas)
 	rm -f $(publisher_schemas)
 
+# Recipe for building publisher schemas from the metadata, details and links schemas
 %/publisher/schema.json: %/../metadata.json %/publisher/details.json $(wildcard %/publisher/links.json)
 	$(combiner_bin) ${@:schema.json=}
 
+# Recipe for building the frontend schema from the publisher schema and frontend links definition
 %/frontend/schema.json: %/publisher/schema.json %/../frontend_links_definition.json
 	$(frontend_generator_bin) -f ${@:frontend/schema.json=../frontend_links_definition.json} ${@:frontend/schema.json=publisher/schema.json} > ${@}
 
+# Recipe for validating frontend examples (the build target is the `.valid` file)
 %.valid: $(frontend_schemas) %
 	$(validation_bin) ${@:.valid=} && touch ${@}

--- a/bin/ensure_example_base_paths_unique
+++ b/bin/ensure_example_base_paths_unique
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.dirname(__FILE__) + "/../lib"
+require 'json'
+
+def usage
+  $stderr.puts "USAGE: #{File.basename(__FILE__)} <path/to/examples/>"
+  $stderr.puts
+  $stderr.puts "Checks that all examples have a unique base path"
+end
+
+if ARGV.count == 0
+  usage
+  exit(1)
+end
+
+def base_path(example_file)
+  JSON.parse(File.read(example_file))['base_path']
+end
+
+grouped = ARGV.group_by {|file| base_path(file) }
+
+duplicates = grouped.select {|base_path, group| group.count > 1 }
+
+if duplicates.any?
+  puts "#{duplicates.count} duplicate(s) found:"
+
+  duplicates.each do |base_path, group|
+    group.each do |filename|
+      puts "  #{filename}"
+    end
+  end
+  exit(1)
+else
+  puts "OK: All example base_paths are unique"
+  exit(0)
+end

--- a/spec/bin/ensure_example_base_paths_unique_spec.rb
+++ b/spec/bin/ensure_example_base_paths_unique_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe 'ensure_exaple_base_paths_unique' do
+  let(:executable_path) {
+    Pathname.new('../../bin/ensure_example_base_paths_unique').expand_path(File.dirname(__FILE__))
+  }
+
+  let(:tmpdir) { Pathname.new(Dir.mktmpdir) }
+
+  def generate_example(name, base_path)
+    example_path = tmpdir + name
+    File.write(example_path, JSON.dump({"base_path" => base_path}))
+    example_path
+  end
+
+  def invoke_ensure_example_base_paths_unique(*arguments)
+    cmd = ([executable_path.to_s] + arguments.map { |a| %Q("#{a}") } + ["2>&1"]).join(" ")
+    @output = `#{cmd}`
+    $?.success?
+  end
+
+  after(:each) { FileUtils.remove_entry_secure(tmpdir) }
+
+  context "all examples have unique base_paths" do
+    let(:examples) {
+      [
+        generate_example("a.json", "/letter_a"),
+        generate_example("b.json", "/letter_b")
+      ]
+    }
+
+    it "exits with zero exit status" do
+      succeeded = invoke_ensure_example_base_paths_unique(*examples)
+      expect(succeeded).to be_truthy
+    end
+  end
+
+  context "some examples have duplicate base_paths" do
+    let(:examples) {
+      [
+        generate_example("a.json", "/letter_a"),
+        generate_example("b.json", "/letter_a")
+      ]
+    }
+
+    it "exits with non-zero exit status" do
+      succeeded = invoke_ensure_example_base_paths_unique(*examples)
+      expect(succeeded).to be_falsy
+    end
+
+    it "outputs a list of the duplicates" do
+      invoke_ensure_example_base_paths_unique(*examples)
+      expect(@output).to include("a.json")
+      expect(@output).to include("b.json")
+    end
+  end
+end


### PR DESCRIPTION
It's convenient to ensure that all examples have unique base paths because then they can be referenced in tests by url.