### PR TITLE
Add nation_applicability to Policies

### DIFF
--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -19,7 +19,16 @@
       "signup_link": "",
       "summary": "The government believes that the current benefits system is too complex, and there are insufficient incentives to encourage people on benefits to start paid work or increase their hours.",
       "show_summaries": false,
-      "facets":[]
+      "facets":[],
+      "nation_applicability": {
+        "applies_to": [
+          "england",
+          "northern_ireland",
+          "scotland",
+          "wales"
+        ],
+        "alternative_policies": []
+      }
    },
    "links": {
       "organisations":[

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -1,6 +1,6 @@
 {
-   "base_path": "/government/policies/universal-credit",
-   "title": "Universal Credit",
+   "base_path": "/government/policies/keeping-northern-ireland-safe",
+   "title": "Keeping Northern Ireland safe",
    "description": "",
    "format": "policy",
    "need_ids": [],
@@ -12,22 +12,29 @@
       "email_signup_enabled": false,
       "filter": {
          "policies": [
-            "universal-credit"
+            "keeping-northern-ireland-safe"
          ]
       },
       "human_readable_finder_format": "Policy",
       "signup_link": "",
-      "summary": "Universal Credit brings together 6 benefits for people who are out of work or on a low income into a single payment. It's being introduced in stages, starting in October 2013. By the end of 2017 it's expected to be available across England and Wales.",
+      "summary": "While day-to-day policing and justice functions are devolved to the Northern Ireland Executive, the UK government retains responsibility for national security issues in Northern Ireland.",
       "show_summaries": false,
       "facets":[],
       "nation_applicability": {
         "applies_to": [
           "england",
-          "northern_ireland",
-          "scotland",
-          "wales"
+          "northern_ireland"
         ],
-        "alternative_policies": []
+        "alternative_policies": [
+          {
+            "nation": "scotland",
+            "alt_policy_url": "http://www.gov.scot/"
+          },
+          {
+            "nation": "wales",
+            "alt_policy_url": "http://wales.gov.uk/"
+          }
+        ]
       }
    },
    "links": {

--- a/formats/policy/frontend/schema.json
+++ b/formats/policy/frontend/schema.json
@@ -116,6 +116,40 @@
         },
         "summary": {
           "type": "string"
+        },
+        "nation_applicability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "applies_to",
+            "alternative_policies"
+          ],
+          "properties": {
+            "applies_to": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "alternative_policies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "nation",
+                  "alt_policy_url"
+                ],
+                "properties": {
+                  "nation": {
+                    "type": "string"
+                  },
+                  "alt_policy_url": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -79,6 +79,40 @@
     },
     "summary": {
       "type": "string"
+    },
+    "nation_applicability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "applies_to",
+        "alternative_policies"
+      ],
+      "properties": {
+        "applies_to": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "alternative_policies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "nation",
+              "alt_policy_url"
+            ],
+            "properties": {
+              "nation": {
+                "type": "string"
+              },
+              "alt_policy_url": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/formats/policy/publisher/schema.json
+++ b/formats/policy/publisher/schema.json
@@ -147,6 +147,40 @@
         },
         "summary": {
           "type": "string"
+        },
+        "nation_applicability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "applies_to",
+            "alternative_policies"
+          ],
+          "properties": {
+            "applies_to": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "alternative_policies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "nation",
+                  "alt_policy_url"
+                ],
+                "properties": {
+                  "nation": {
+                    "type": "string"
+                  },
+                  "alt_policy_url": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
This commit updates the schema for Policies to have nation applicability. The `nation_applicability` hash contains an array of strings which the nations that the Policy applies to along with an array of hashes with the nation and alt_poicy_url for each nation that the policy isn't applicable to.