### PR TITLE
Add document_collections to links

### DIFF
--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -63,6 +63,15 @@
         "web_url": "https://www.gov.uk/government/case-studies/terence-age-33-stoke-on-trent",
         "locale": "en"
       }
+    ],
+    "document_collections": [
+      {
+        "title": "Work Programme real life stories",
+        "base_path": "/government/collections/work-programme-real-life-stories",
+        "api_url": "http://content-store/content/government/collections/work-programme-real-life-stories",
+        "web_url": "https://www.gov.uk/government/collections/work-programme-real-life-stories",
+        "locale": "en"
+      }
     ]
   }
 }

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -63,6 +63,15 @@
           "web_url":  "https://www.gov.uk/government/case-studies/pakistan-in-school-for-the-first-time.ur",
           "locale": "ur"
         }
+      ],
+      "document_collections": [
+        {
+          "title": "Work Programme real life stories",
+          "base_path": "/government/collections/work-programme-real-life-stories",
+          "api_url": "http://content-store/content/government/collections/work-programme-real-life-stories",
+          "web_url": "https://www.gov.uk/government/collections/work-programme-real-life-stories",
+          "locale": "en"
+        }
       ]
     },
     "locale": "en",

--- a/formats/case_study/frontend/schema.json
+++ b/formats/case_study/frontend/schema.json
@@ -167,6 +167,9 @@
         "worldwide_priorities": {
           "$ref": "#/definitions/frontend_links"
         },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
         }

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -23,6 +23,9 @@
     },
     "worldwide_priorities": {
       "$ref": "#/definitions/guid_list"
+    },
+    "document_collections": {
+      "$ref": "#/definitions/guid_list"
     }
   },
   "definitions": {

--- a/formats/case_study/publisher/schema.json
+++ b/formats/case_study/publisher/schema.json
@@ -197,6 +197,9 @@
         },
         "worldwide_priorities": {
           "$ref": "#/definitions/guid_list"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     }


### PR DESCRIPTION
https://trello.com/c/pfvFRgg5

`government-frontend` doesn't display document collection membership next to 'Part of:' in the metadata section in the header or footer as shown here:
https://www.gov.uk/government/case-studies/clever-engineering-macrete-bridges-the-technology-gap

this field should carry that bit of information so that it gets displayed on government-frontend.