### PR TITLE
Remove required nation applicability

### DIFF
--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -19,16 +19,7 @@
       "signup_link": "",
       "summary": "The government believes that the current benefits system is too complex, and there are insufficient incentives to encourage people on benefits to start paid work or increase their hours.",
       "show_summaries": false,
-      "facets":[],
-      "nation_applicability": {
-        "applies_to": [
-          "england",
-          "northern_ireland",
-          "scotland",
-          "wales"
-        ],
-        "alternative_policies": []
-      }
+      "facets":[]
    },
    "links": {
       "organisations":[

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -19,16 +19,7 @@
       "signup_link": "",
       "summary": "Universal Credit brings together 6 benefits for people who are out of work or on a low income into a single payment. It's being introduced in stages, starting in October 2013. By the end of 2017 it's expected to be available across England and Wales.",
       "show_summaries": false,
-      "facets":[],
-      "nation_applicability": {
-        "applies_to": [
-          "england",
-          "northern_ireland",
-          "scotland",
-          "wales"
-        ],
-        "alternative_policies": []
-      }
+      "facets":[]
    },
    "links": {
       "organisations":[


### PR DESCRIPTION
With changes to Policy Publisher, `nation_applicability` is only part of the published content item if it doesn't apply to all nations. This commit removes it from the Policy Area and Programme examples.