### PR TITLE
Change finder and policy metadata

### DIFF
--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -96,9 +96,7 @@
             "required": [
               "key",
               "filterable",
-              "display_as_result_metadata",
-              "name",
-              "type"
+              "display_as_result_metadata"
             ],
             "properties": {
               "key": {

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -51,9 +51,7 @@
         "required": [
           "key",
           "filterable",
-          "display_as_result_metadata",
-          "name",
-          "type"
+          "display_as_result_metadata"
         ],
         "properties": {
           "key": {

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -127,9 +127,7 @@
             "required": [
               "key",
               "filterable",
-              "display_as_result_metadata",
-              "name",
-              "type"
+              "display_as_result_metadata"
             ],
             "properties": {
               "key": {

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -19,7 +19,18 @@
       "signup_link": "",
       "summary": "The government believes that the current benefits system is too complex, and there are insufficient incentives to encourage people on benefits to start paid work or increase their hours.",
       "show_summaries": false,
-      "facets":[]
+      "facets": [
+        {
+          "key": "is_historic",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "government_name",
+          "display_as_result_metadata": true,
+          "filterable": false
+        }
+      ]
    },
    "links": {
       "organisations":[

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -19,7 +19,18 @@
       "signup_link": "",
       "summary": "Universal Credit brings together 6 benefits for people who are out of work or on a low income into a single payment. It's being introduced in stages, starting in October 2013. By the end of 2017 it's expected to be available across England and Wales.",
       "show_summaries": false,
-      "facets":[]
+      "facets": [
+        {
+          "key": "is_historic",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "government_name",
+          "display_as_result_metadata": true,
+          "filterable": false
+        }
+      ]
    },
    "links": {
       "organisations":[

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -19,7 +19,18 @@
       "signup_link": "",
       "summary": "While day-to-day policing and justice functions are devolved to the Northern Ireland Executive, the UK government retains responsibility for national security issues in Northern Ireland.",
       "show_summaries": false,
-      "facets":[],
+      "facets": [
+        {
+          "key": "is_historic",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "government_name",
+          "display_as_result_metadata": true,
+          "filterable": false
+        }
+      ],
       "nation_applicability": {
         "applies_to": [
           "england",

--- a/formats/policy/frontend/schema.json
+++ b/formats/policy/frontend/schema.json
@@ -63,9 +63,7 @@
             "required": [
               "key",
               "filterable",
-              "display_as_result_metadata",
-              "name",
-              "type"
+              "display_as_result_metadata"
             ],
             "properties": {
               "key": {

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -26,9 +26,7 @@
         "required": [
           "key",
           "filterable",
-          "display_as_result_metadata",
-          "name",
-          "type"
+          "display_as_result_metadata"
         ],
         "properties": {
           "key": {

--- a/formats/policy/publisher/schema.json
+++ b/formats/policy/publisher/schema.json
@@ -94,9 +94,7 @@
             "required": [
               "key",
               "filterable",
-              "display_as_result_metadata",
-              "name",
-              "type"
+              "display_as_result_metadata"
             ],
             "properties": {
               "key": {


### PR DESCRIPTION
This PR changes the Finder and Policy schemas to allow for Facets which don't have a `name` or `type`. This is the case in the update to the Policy examples which has `is_historic` and `government_name` which aren't treated as normal metadata by Finder Frontend and as such don't require these to be present.