### PR TITLE
Make public_updated_at required for renderable content

### DIFF
--- a/formats/case_study/frontend/schema.json
+++ b/formats/case_study/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/case_study/publisher/schema.json
+++ b/formats/case_study/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/coming_soon/frontend/examples/coming_soon.json
+++ b/formats/coming_soon/frontend/examples/coming_soon.json
@@ -5,5 +5,6 @@
     },
     "format": "coming_soon",
     "locale": "en",
-    "title": "Coming soon"
+    "title": "Coming soon",
+    "public_updated_at": "2014-12-15T12:31:00+00:00"
 }

--- a/formats/coming_soon/frontend/schema.json
+++ b/formats/coming_soon/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/coming_soon/publisher/schema.json
+++ b/formats/coming_soon/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/email_alert_signup/frontend/schema.json
+++ b/formats/email_alert_signup/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/email_alert_signup/publisher/schema.json
+++ b/formats/email_alert_signup/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/mainstream_browse_page/frontend/schema.json
+++ b/formats/mainstream_browse_page/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/mainstream_browse_page/publisher/schema.json
+++ b/formats/mainstream_browse_page/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/placeholder/frontend/schema.json
+++ b/formats/placeholder/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/placeholder/publisher/schema.json
+++ b/formats/placeholder/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/policy/frontend/schema.json
+++ b/formats/policy/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/policy/publisher/schema.json
+++ b/formats/policy/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/topic/frontend/schema.json
+++ b/formats/topic/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/topic/publisher/schema.json
+++ b/formats/topic/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/unpublishing/frontend/schema.json
+++ b/formats/unpublishing/frontend/schema.json
@@ -5,7 +5,8 @@
   "required": [
     "base_path",
     "format",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {

--- a/formats/unpublishing/publisher/schema.json
+++ b/formats/unpublishing/publisher/schema.json
@@ -7,7 +7,8 @@
     "publishing_app",
     "rendering_app",
     "update_type",
-    "locale"
+    "locale",
+    "public_updated_at"
   ],
   "properties": {
     "base_path": {


### PR DESCRIPTION
This is currently optional in content-store, making it required here is a route
to making it required there (and then backfilling the data).

We have been thinking of public_updated_at as "the updated date which users
see" and because some formats don't display this (eg gone/redirect items), it
has been optional.

However, it seems to me that it isn't about what the user sees, but when there
was last a (significant) semantic change to the content at the URL. Therefore,
everything should have a public_updated_at.

As an example, it being optional meant that a placeholder without a
public_updated_at was added by publisher which then broke an expectation in
email-alert-service and stopped it from consuming any more messages from the
queue.

To make the Whitehall tests pass for "coming soon" items, we'd need to do something like: https://github.com/alphagov/whitehall/compare/supply_public_updated_at_for_coming_soon?expand=1