### PR TITLE
Dummy server for example content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 gem 'json-schema'
 gem 'rake'
 gem 'rspec'
+gem 'rack'
+gem 'rack-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,9 @@ GEM
     diff-lcs (1.2.5)
     json-schema (2.5.0)
       addressable (~> 2.3)
+    rack (1.5.2)
+    rack-contrib (1.2.0)
+      rack (>= 0.9.1)
     rake (10.4.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -24,5 +27,7 @@ PLATFORMS
 
 DEPENDENCIES
   json-schema
+  rack
+  rack-contrib
   rake
   rspec

--- a/README.md
+++ b/README.md
@@ -151,3 +151,8 @@ See [suggested-workflows.md](docs/suggested-workflows.md)
 ## Why do contract testing?
 
 See [why-contract-testing.md](docs/why-contract-testing.md)
+
+## Running your frontend against the examples (content-store not needed)
+
+See [dummy_content_store/README.md](dummy_content_store/README.md)
+

--- a/dummy_content_store/README.md
+++ b/dummy_content_store/README.md
@@ -1,0 +1,20 @@
+# Dummy content store
+
+The dummy content store allows you to run a frontend using the examples from
+the `govuk-content-schemas` repo. You will not need to run the content store
+itself.
+
+To run the dummy content store:
+
+```sh
+$ ./dummy_content_store/startup.sh
+```
+
+by default it will use the examples from the `formats` folder.
+
+To use a different folder set the `EXAMPLES_PATH` environment variable:
+
+```sh
+$ EXAMPLES_PATH=/path/to/my/examples ./dummy_content_store/startup.sh
+```
+

--- a/dummy_content_store/config.ru
+++ b/dummy_content_store/config.ru
@@ -1,0 +1,9 @@
+#\ -p 3068
+$LOAD_PATH << File.dirname(__FILE__) + "/lib"
+require 'dummy_content_store/app'
+
+examples_path = ENV['EXAMPLES_PATH'] || File.dirname(__FILE__) + "/../formats"
+
+map '/content' do
+  run DummyContentStore::App.new(examples_path)
+end

--- a/dummy_content_store/lib/dummy_content_store/app.rb
+++ b/dummy_content_store/lib/dummy_content_store/app.rb
@@ -1,0 +1,55 @@
+require 'pathname'
+require 'json'
+require 'dummy_content_store/example_content_item'
+
+module DummyContentStore
+  class App
+    attr_reader :formats_path
+
+    def initialize(formats_path)
+      @formats_path = Pathname.new(formats_path)
+    end
+
+    def call(env)
+      example = find_example(env["PATH_INFO"])
+      if example
+        present_example(example)
+      else
+        present_not_found
+      end
+    end
+
+    def find_example(url_path)
+      all_examples.find { |e| e.base_path == url_path }
+    end
+
+  private
+    def present_example(example)
+      headers = {
+        'Content-Type' => 'application/json; charset=utf-8',
+        'Content-Length' => example.raw_data.bytesize.to_s,
+        'Cache-control' => 'no-cache'
+      }
+
+      [200, headers, [example.raw_data]]
+    end
+
+    def present_not_found
+      body = 'Not found'
+      headers = {
+        'Content-Type' => 'text/plain',
+        'Content-Length' => body.size.to_s,
+        'Cache-control' => 'no-cache'
+      }
+      [404, headers, [body]]
+    end
+
+    def all_example_paths
+      Dir[formats_path + "**" + "examples" + "*.json"]
+    end
+
+    def all_examples
+      all_example_paths.lazy.map { |path| ExampleContentItem.new(path) }
+    end
+  end
+end

--- a/dummy_content_store/lib/dummy_content_store/example_content_item.rb
+++ b/dummy_content_store/lib/dummy_content_store/example_content_item.rb
@@ -1,0 +1,21 @@
+module DummyContentStore
+  class ExampleContentItem
+    attr_reader :path
+
+    def initialize(path)
+      @path = path
+    end
+
+    def base_path
+      data["base_path"]
+    end
+
+    def data
+      JSON.parse(raw_data)
+    end
+
+    def raw_data
+      File.read(path)
+    end
+  end
+end

--- a/dummy_content_store/startup.sh
+++ b/dummy_content_store/startup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+SCRIPT_PATH="`realpath "$0"`"
+DUMMY_CONTENT_STORE_DIR=`dirname "${SCRIPT_PATH}"`
+
+bundle install
+bundle exec rackup "${DUMMY_CONTENT_STORE_DIR}"/config.ru -p 3068


### PR DESCRIPTION
This is a self-contained rack app which will read example files from the
example folder.

It can be run either using the `startup.sh` shell script, or as a rack
up directly using rackup and the `config.ru` file.

We ensure that file changes propogate immediately by doing the
following:

- Set the `Cache-control: no-cache` header to ensure that the content
  store client does not cache the fetched items.
- Always read the file from disk so that changes propogate immediately.

It runs on port 3068 (the content store port) and serves the examples using the urls in the example files themselves. Example urls are required to be unique.
