### PR TITLE
Add format for "placeholder" items

### DIFF
--- a/bin/combine_publisher_schema
+++ b/bin/combine_publisher_schema
@@ -17,7 +17,7 @@ def report_errors(path, errors)
 end
 
 def format_name(publisher_schema_path)
-  publisher_schema_path.dirname.basename
+  publisher_schema_path.dirname.basename.to_s
 end
 
 if ARGV.count != 1

--- a/formats/placeholder/frontend/schema.json
+++ b/formats/placeholder/frontend/schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "placeholder"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "primary_topic": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "additional_topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "base_path": {
+            "type": "string"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/formats/placeholder/frontend/schema.json
+++ b/formats/placeholder/frontend/schema.json
@@ -19,9 +19,8 @@
     },
     "format": {
       "type": "string",
-      "enum": [
-        "placeholder"
-      ]
+      "pattern": "^(placeholder|placeholder_.+)$",
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
     },
     "public_updated_at": {
       "type": "string",

--- a/formats/placeholder/publisher/details.json
+++ b/formats/placeholder/publisher/details.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "change_note": {
+      "type": ["string", "null"]
+    },
+    "tags": {
+      "type": "object",
+      "properties": {
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/formats/placeholder/publisher/links.json
+++ b/formats/placeholder/publisher/links.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+  },
+  "definitions": {
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    }
+  }
+}

--- a/formats/placeholder/publisher/schema.json
+++ b/formats/placeholder/publisher/schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "update_type",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "placeholder"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "primary_topic": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "additional_topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    }
+  }
+}

--- a/formats/placeholder/publisher/schema.json
+++ b/formats/placeholder/publisher/schema.json
@@ -25,9 +25,8 @@
     },
     "format": {
       "type": "string",
-      "enum": [
-        "placeholder"
-      ]
+      "pattern": "^(placeholder|placeholder_.+)$",
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
     },
     "public_updated_at": {
       "type": "string",

--- a/lib/govuk_content_schemas/schema_combiner.rb
+++ b/lib/govuk_content_schemas/schema_combiner.rb
@@ -18,10 +18,18 @@ class GovukContentSchemas::SchemaCombiner
     combined = clone_schema(metadata_schema)
     combined.schema['properties']['details'] = embed(details_schema) if details_schema
     combined.schema['properties']['links'] = embed(links_schema) if links_schema
-    combined.schema['properties']['format'] = {
-      "type" => "string",
-      "enum" => [format_name]
-    }
+    if format_name == "placeholder"
+      combined.schema['properties']['format'] = {
+        "type" => "string",
+        "pattern" => "^(placeholder|placeholder_.+)$",
+        "description" => "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility.",
+      }
+    else
+      combined.schema['properties']['format'] = {
+        "type" => "string",
+        "enum" => [format_name]
+      }
+    end
     combined.schema['definitions'] = combine_definitions if combine_definitions.any?
     combined
   end


### PR DESCRIPTION
We have around ~~149,161~~ 153,236 placeholder items, but we don't have a schema for the
format. I've developed this against the placeholders produced by (mainstream)
publisher and whitehall. Some small changes will be required for publisher to
supply additional fields like "locale", but Whitehall's placeholders are already valid against this schema.

Once this is merged, I'll open PRs to test Whitehall's placeholders and to add schema tests to Publisher.