### PR TITLE
Add topics and mainstream browse page

### DIFF
--- a/formats/mainstream_browse_page/frontend/examples/level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page.json
@@ -1,0 +1,12 @@
+{
+    "base_path": "/browse/benefits/entitlement",
+    "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
+    "details": {},
+    "format": "mainstream_browse_page",
+    "links": {},
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Benefits entitlement",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
@@ -1,0 +1,22 @@
+{
+    "base_path": "/browse/benefits/families",
+    "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
+    "details": {},
+    "format": "mainstream_browse_page",
+    "links": {
+      "related_topics": [
+        {
+          "title": "Universal credit",
+          "base_path": "/benefits/universal-credit",
+          "api_url": "http://content-store/content/benefits/universal-credit",
+          "web_url": "https://www.gov.uk/benefits/universal-credit",
+          "locale": "en"
+        }
+      ]
+    },
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Benefits for families",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/mainstream_browse_page/frontend/examples/top_level_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/top_level_page.json
@@ -1,0 +1,12 @@
+{
+    "base_path": "/browse/benefits",
+    "description": "Includes tax credits, eligibility and appeals",
+    "details": {},
+    "format": "mainstream_browse_page",
+    "links": {},
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Benefits",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/mainstream_browse_page/frontend/schema.json
+++ b/formats/mainstream_browse_page/frontend/schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "mainstream_browse_page"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "related_topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "base_path": {
+            "type": "string"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/formats/mainstream_browse_page/publisher/details.json
+++ b/formats/mainstream_browse_page/publisher/details.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+  }
+}

--- a/formats/mainstream_browse_page/publisher/links.json
+++ b/formats/mainstream_browse_page/publisher/links.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "related_topics": {
+      "$ref": "#/definitions/guid_list"
+    }
+  },
+  "definitions": {
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    }
+  }
+}

--- a/formats/mainstream_browse_page/publisher/schema.json
+++ b/formats/mainstream_browse_page/publisher/schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "update_type",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "mainstream_browse_page"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "related_topics": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    }
+  }
+}

--- a/formats/topic/frontend/examples/curated_subtopic.json
+++ b/formats/topic/frontend/examples/curated_subtopic.json
@@ -1,0 +1,28 @@
+{
+    "base_path": "/oil-and-gas/offshore",
+    "description": "A page about offshore oil and gas",
+    "details": {
+      "groups": [
+        {
+          "name": "Oil rigs",
+          "contents": [
+            "https://www.gov.uk/oil-rig-safety-requirements",
+            "https://www.gov.uk/oil-rig-staffing"
+          ]
+        },
+        {
+          "name": "Piping",
+          "contents": [
+            "https://www.gov.uk/undersea-piping-restrictions"
+          ]
+        }
+      ]
+    },
+    "format": "topic",
+    "links": {},
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Oil and gas",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/topic/frontend/examples/topic.json
+++ b/formats/topic/frontend/examples/topic.json
@@ -1,0 +1,12 @@
+{
+    "base_path": "/oil-and-gas",
+    "description": "",
+    "details": {},
+    "format": "topic",
+    "links": {},
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Oil and gas",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/topic/frontend/examples/uncurated_subtopic.json
+++ b/formats/topic/frontend/examples/uncurated_subtopic.json
@@ -1,0 +1,13 @@
+{
+    "base_path": "/oil-and-gas/licensing",
+    "description": "A page about oil and gas licensing",
+    "details": {
+    },
+    "format": "topic",
+    "links": {},
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Oil and gas: Licensing",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/topic/frontend/schema.json
+++ b/formats/topic/frontend/schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "topic"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "contents"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "contents": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "base_path": {
+            "type": "string"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/formats/topic/publisher/details.json
+++ b/formats/topic/publisher/details.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "contents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/formats/topic/publisher/links.json
+++ b/formats/topic/publisher/links.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+  },
+  "definitions": {
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    }
+  }
+}

--- a/formats/topic/publisher/schema.json
+++ b/formats/topic/publisher/schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "update_type",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "topic"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "contents"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "contents": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add schemas for topics and mainstream browse pages.

These are (or will shortly be) sent from the collections-publisher app.  I'll be adding contract tests on collections-publisher, collections-api and collections (frontend) after this is merged.

We're likely to greatly expand the information included in these formats in the reasonably near future, but for now I've just included the fields we've planned to include in our current piece of work (which is for linking from mainstream browse to topic pages).

I separated the automatically generated files into a separate commit; only the two commits for adding the topics and mainstream browse manually-generated files need to be reviewed.