### PR TITLE
Email alert signup on policy

### DIFF
--- a/formats/policy/frontend/examples/minimal_policy_area.json
+++ b/formats/policy/frontend/examples/minimal_policy_area.json
@@ -19,6 +19,15 @@
    "links": {
       "organisations":[],
       "people": [],
-      "related":[]
+      "related":[],
+      "email_alert_signup":[
+        {
+          "title": "Minimal Benefits Reform",
+          "base_path": "/government/policies/minimal-benefits-reform/email-signup",
+          "api_url": "http://content-store.dev.gov.uk/content/government/policies/minimal-benefits-reform/email-signup",
+          "web_url": "http://www.dev.gov.uk/government/policies/minimal-benefits-reform/email-signup",
+          "locale": "en"
+        }
+      ]
    }
 }

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -43,8 +43,15 @@
         }
       ],
       "people": [],
-      "related":[
-
+      "related":[],
+      "email_alert_signup":[
+        {
+          "title": "Benefits Reform",
+          "base_path": "/government/policies/benefits-reform/email-signup",
+          "api_url": "http://content-store.dev.gov.uk/content/government/policies/benefits-reform/email-signup",
+          "web_url": "http://www.dev.gov.uk/government/policies/benefits-reform/email-signup",
+          "locale": "en"
+        }
       ],
       "available_translations":[
          {

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -51,8 +51,15 @@
           "locale": "en"
         }
       ],
-      "related":[
-
+      "related":[],
+      "email_alert_signup":[
+        {
+          "title": "Universal Credit",
+          "base_path": "/government/policies/universal-credit/email-signup",
+          "api_url": "http://content-store.dev.gov.uk/content/government/policies/universal-credit/email-signup",
+          "web_url": "http://www.dev.gov.uk/government/policies/universal-credit/email-signup",
+          "locale": "en"
+        }
       ],
       "available_translations":[
          {

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -51,10 +51,10 @@
    "links": {
       "organisations":[
         {
-          "title": "Department for Work and Pensions",
-          "base_path": "/government/organisations/department-for-work-and-pensions",
-          "api_url": "http://content-store/organisations/department-for-work-and-pensions",
-          "web_url": "https://www.gov.uk/government/organisations/department-for-work-and-pensions",
+          "title": "Northern Ireland Office",
+          "base_path": "/government/organisations/northern-ireland-office",
+          "api_url": "http://content-store/organisations/northern-ireland-office",
+          "web_url": "https://www.gov.uk/government/organisations/northern-ireland-office",
           "locale": "en"
         }
       ],
@@ -67,15 +67,13 @@
           "locale": "en"
         }
       ],
-      "related":[
-
-      ],
+      "related":[],
       "available_translations":[
          {
-            "title": "Unveirsal Credit",
-            "base_path": "/government/policies/universal-credit",
-            "api_url": "http://content-store.dev.gov.uk/content/government/policies/universal-credit",
-            "web_url": "http://www.dev.gov.uk/government/policies/universal-credit",
+            "title": "Keeping Northern Ireland safe",
+            "base_path": "/government/policies/keeping-northern-ireland-safe",
+            "api_url": "http://content-store.dev.gov.uk/content/government/policies/keeping-northern-ireland-safe",
+            "web_url": "http://www.dev.gov.uk/government/policies/keeping-northern-ireland-safe",
             "locale": "en"
          }
       ]

--- a/formats/policy/frontend/schema.json
+++ b/formats/policy/frontend/schema.json
@@ -168,6 +168,9 @@
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
+        "email_alert_signup": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
         }

--- a/formats/policy/publisher/links.json
+++ b/formats/policy/publisher/links.json
@@ -16,6 +16,9 @@
     "related": {
       "$ref": "#/definitions/guid_list"
     },
+    "email_alert_signup": {
+      "$ref": "#/definitions/guid_list"
+    },
     "available_translations": {
       "$ref": "#/definitions/guid_list"
     }

--- a/formats/policy/publisher/schema.json
+++ b/formats/policy/publisher/schema.json
@@ -199,6 +199,9 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "email_alert_signup": {
+          "$ref": "#/definitions/guid_list"
+        },
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         }


### PR DESCRIPTION
This PR adds the `email_alert_signup` as an entry in the links array to policies. This is marked as being required as all policies should have a signup page.

I've also cleaned up some mismatched data in one of the policy examples.