### PR TITLE
Add a summary to email alert signups

### DIFF
--- a/formats/email_alert_signup/frontend/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/email_alert_signup.json
@@ -1,7 +1,7 @@
 {
   "base_path": "/government/policies/employment/email-signup",
   "title": "Employment",
-  "description": "\n      You'll get an email each time any information on\n      this policy is published or updated.\n    ",
+  "description": "",
   "format": "email_alert_signup",
   "need_ids": [],
   "locale": "en",
@@ -14,6 +14,7 @@
         "link": "https://www.gov.uk/government/policies/employment"
       }
     ],
+    "summary": "You'll get an email each time any information on this policy is published or updated.",
     "tags": {
       "policy": [
         "employment"

--- a/formats/email_alert_signup/frontend/schema.json
+++ b/formats/email_alert_signup/frontend/schema.json
@@ -40,9 +40,13 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "summary",
         "tags"
       ],
       "properties": {
+        "summary": {
+          "type": "string"
+        },
         "tags": {
           "type": "object"
         },

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -3,9 +3,13 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "summary",
     "tags"
   ],
   "properties": {
+    "summary": {
+      "type": "string"
+    },
      "tags": {
        "type": "object"
     },

--- a/formats/email_alert_signup/publisher/schema.json
+++ b/formats/email_alert_signup/publisher/schema.json
@@ -71,9 +71,13 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "summary",
         "tags"
       ],
       "properties": {
+        "summary": {
+          "type": "string"
+        },
         "tags": {
           "type": "object"
         },


### PR DESCRIPTION
As we shouldn't be using the description for this purpose, I've changed email alert signup pages to have a summary in the details hash instead.