### PR TITLE
Support the /api/content route

### DIFF
--- a/dummy_content_store/config.ru
+++ b/dummy_content_store/config.ru
@@ -7,3 +7,6 @@ examples_path = ENV['EXAMPLES_PATH'] || File.dirname(__FILE__) + "/../formats"
 map '/content' do
   run DummyContentStore::App.new(examples_path)
 end
+map '/api/content' do
+  run DummyContentStore::App.new(examples_path)
+end


### PR DESCRIPTION
When the content store is accessed via the public API, it receives
requests on /api/content, instead of just on /content.  Support this
route in the dummy server, so that we can test things in that context.