### PR TITLE
Add EU logo_path to finders schema

### DIFF
--- a/formats/finder/frontend/examples/esi-funds.json
+++ b/formats/finder/frontend/examples/esi-funds.json
@@ -1,0 +1,195 @@
+{
+  "base_path": "/european-structural-investment-funds",
+  "title": "European Structural and Investment Funds (ESIF)",
+  "description": "",
+  "format": "finder",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-04-10T13:29:08.695Z",
+  "public_updated_at": "2015-04-01T11:42:34.000+00:00",
+  "details": {
+    "beta": true,
+    "beta_message": null,
+    "document_noun": "call",
+    "logo_path": "European Structural and Investment Funds",
+    "filter": {
+      "document_type": "european_structural_investment_fund"
+    },
+    "format_name": "ESIF call for proposals",
+    "signup_link": null,
+    "show_summaries": false,
+    "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"http://www.dfpni.gov.uk/index/finance/european-funding/content_-_european_funding-future-funding.htm\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Stuctural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
+    "facets": [
+      {
+        "key": "fund_state",
+        "name": "Fund state",
+        "type": "text",
+        "preposition": "which are",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Open",
+            "value": "open"
+          },
+          {
+            "label": "Closed",
+            "value": "closed"
+          }
+        ]
+      },
+      {
+        "key": "fund_type",
+        "name": "Type",
+        "type": "text",
+        "preposition": "of type",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Access to work",
+            "value": "access-to-work"
+          },
+          {
+            "label": "Business support",
+            "value": "business-support"
+          },
+          {
+            "label": "Climate change",
+            "value": "climate-change"
+          },
+          {
+            "label": "Environment",
+            "value": "environment"
+          },
+          {
+            "label": "IT and broadband",
+            "value": "it-and-broadband"
+          },
+          {
+            "label": "Learning and skills",
+            "value": "learning-and-skills"
+          },
+          {
+            "label": "Low carbon",
+            "value": "low-carbon"
+          },
+          {
+            "label": "Renewable energy",
+            "value": "renewable-energy"
+          },
+          {
+            "label": "Research and innovation",
+            "value": "research-and-innovation"
+          },
+          {
+            "label": "Social inclusion",
+            "value": "social-inclusion"
+          },
+          {
+            "label": "Transport",
+            "value": "transport"
+          },
+          {
+            "label": "Technical assistance",
+            "value": "techincal-assistance"
+          },
+          {
+            "label": "Tourism",
+            "value": "tourism"
+          }
+        ]
+      },
+      {
+        "key": "location",
+        "name": "Location",
+        "type": "text",
+        "preposition": "in",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "North East",
+            "value": "north-east"
+          },
+          {
+            "label": "North West",
+            "value": "north-west"
+          },
+          {
+            "label": "Yorkshire and Humber",
+            "value": "yorkshire-and-humber"
+          },
+          {
+            "label": "East Midlands",
+            "value": "east-midlands"
+          },
+          {
+            "label": "West Midlands",
+            "value": "west-midlands"
+          },
+          {
+            "label": "East of England",
+            "value": "east-of-england"
+          },
+          {
+            "label": "South East",
+            "value": "south-east"
+          },
+          {
+            "label": "South West",
+            "value": "south-west"
+          },
+          {
+            "label": "London",
+            "value": "london"
+          }
+        ]
+      },
+      {
+        "key": "funding_source",
+        "name": "Funding source",
+        "type": "text",
+        "preposition": "from",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "European Social Fund",
+            "value": "european-social-fund"
+          },
+          {
+            "label": "European Regional Development Fund",
+            "value": "european-regional-development-fund"
+          },
+          {
+            "label": "European Agricultural Fund for Rural Development",
+            "value": "european-agricoltural-fund-for-rural"
+          }
+        ]
+      },
+      {
+        "key": "closing_date",
+        "name": "Closing date",
+        "short_name": "Closing",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": false
+      }
+    ]
+  },
+  "links": {
+    "organisations": [],
+    "related": [],
+    "email_alert_signup": [],
+    "available_translations": [
+      {
+        "title": "European Structural and Investment Funds (ESIF)",
+        "base_path": "/european-structural-investment-funds",
+        "api_url": "http://content-store.dev.gov.uk/content/european-structural-investment-funds",
+        "web_url": "http://www.dev.gov.uk/european-structural-investment-funds",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -70,6 +70,9 @@
           "type": "string",
           "additionalProperties": false
         },
+        "logo_path": {
+          "type": "string"
+        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -24,6 +24,9 @@
       "type": "string",
       "additionalProperties": false
     },
+    "logo_path": {
+      "type": "string"
+    },
     "filter": {
       "description": "This is the fixed filter that scopes the finder",
       "type": "object",

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -101,6 +101,9 @@
           "type": "string",
           "additionalProperties": false
         },
+        "logo_path": {
+          "type": "string"
+        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",


### PR DESCRIPTION
European Structural and Investment funds must comply with EU legislations and they therefore need to display the EU logo.

Quote from the legislation: "the Union emblem and the reference to the Union shall be visible, when landing on the website, inside the viewing area of a digital device, without requiring a user to scroll down the page".

ticket:
https://www.pivotaltracker.com/story/show/92225774
linked to:
alphagov/finder-frontend#189
https://github.com/alphagov/specialist-publisher/pull/474