### PR TITLE
Normalise the api_url and web_url paths in examples

### DIFF
--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -37,7 +37,7 @@
       {
         "title": "Department for Work and Pensions",
         "base_path": "/government/organisations/department-for-work-pensions",
-        "api_url": "http://content-store/content/government/organisations/department-for-work-pensions",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-pensions",
         "web_url": "https://www.gov.uk/government/organisations/department-for-work-pensions",
         "locale": "en"
       }
@@ -46,7 +46,7 @@
       {
         "title": "Helping people to find and stay in work",
         "base_path": "/government/policies/helping-people-to-find-and-stay-in-work",
-        "api_url": "http://content-store/content/government/policies/helping-people-to-find-and-stay-in-work",
+        "api_url": "https://www.gov.uk/api/content/government/policies/helping-people-to-find-and-stay-in-work",
         "web_url": "https://www.gov.uk/government/policies/helping-people-to-find-and-stay-in-work",
         "locale": "en"
       }
@@ -59,7 +59,7 @@
       {
         "title": "Terence, age 33, Stoke-on-Trent",
         "base_path": "/government/case-studies/terence-age-33-stoke-on-trent",
-        "api_url": "http://content-store/content/government/case-studies/terence-age-33-stoke-on-trent",
+        "api_url": "https://www.gov.uk/api/content/government/case-studies/terence-age-33-stoke-on-trent",
         "web_url": "https://www.gov.uk/government/case-studies/terence-age-33-stoke-on-trent",
         "locale": "en"
       }
@@ -68,7 +68,7 @@
       {
         "title": "Work Programme real life stories",
         "base_path": "/government/collections/work-programme-real-life-stories",
-        "api_url": "http://content-store/content/government/collections/work-programme-real-life-stories",
+        "api_url": "https://www.gov.uk/api/content/government/collections/work-programme-real-life-stories",
         "web_url": "https://www.gov.uk/government/collections/work-programme-real-life-stories",
         "locale": "en"
       }

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -22,7 +22,7 @@
         {
           "title": "Department for International Development",
           "base_path": "/government/organisations/department-for-international-development",
-          "api_url": "http://content-store/organisations/department-for-international-development",
+          "api_url": "https://www.gov.uk/api/organisations/department-for-international-development",
           "web_url": "https://www.gov.uk/government/organisations/department-for-international-development",
           "locale": "en"
         }
@@ -33,7 +33,7 @@
         {
           "title": "Pakistan",
           "base_path": "/government/world/pakistan",
-          "api_url": "http://content-store/content/government/world/pakistan",
+          "api_url": "https://www.gov.uk/api/content/government/world/pakistan",
           "web_url": "https://www.gov.uk/government/world/pakistan",
           "locale": "en"
         }
@@ -42,7 +42,7 @@
         {
           "title": "DFID Pakistan",
           "base_path": "/government/world/organisations/dfid-pakistan",
-          "api_url": "http://content-store/content/government/world/organisations/dfid-pakistan",
+          "api_url": "https://www.gov.uk/api/content/government/world/organisations/dfid-pakistan",
           "web_url": "https://www.gov.uk/government/world/organisations/dfid-pakistan",
           "locale": "en"
         }
@@ -51,16 +51,16 @@
       "available_translations": [
         {
           "title": "Pakistan: In school for the first time",
-          "base_path":  "/government/case-studies/pakistan-in-school-for-the-first-time",
-          "api_url":  "http://content-store/content/government/case-studies/pakistan-in-school-for-the-first-time",
-          "web_url":  "https://www.gov.uk/government/case-studies/pakistan-in-school-for-the-first-time",
+          "base_path": "/government/case-studies/pakistan-in-school-for-the-first-time",
+          "api_url": "https://www.gov.uk/api/content/government/case-studies/pakistan-in-school-for-the-first-time",
+          "web_url": "https://www.gov.uk/government/case-studies/pakistan-in-school-for-the-first-time",
           "locale": "en"
         },
         {
           "title": "پاکستان: اسکول میں پہلی بارداخلہ",
-          "base_path":  "/government/case-studies/pakistan-in-school-for-the-first-time.ur",
-          "api_url":  "http://content-store/content/government/case-studies/pakistan-in-school-for-the-first-time.ur",
-          "web_url":  "https://www.gov.uk/government/case-studies/pakistan-in-school-for-the-first-time.ur",
+          "base_path": "/government/case-studies/pakistan-in-school-for-the-first-time.ur",
+          "api_url": "https://www.gov.uk/api/content/government/case-studies/pakistan-in-school-for-the-first-time.ur",
+          "web_url": "https://www.gov.uk/government/case-studies/pakistan-in-school-for-the-first-time.ur",
           "locale": "ur"
         }
       ],
@@ -68,7 +68,7 @@
         {
           "title": "Work Programme real life stories",
           "base_path": "/government/collections/work-programme-real-life-stories",
-          "api_url": "http://content-store/content/government/collections/work-programme-real-life-stories",
+          "api_url": "https://www.gov.uk/api/content/government/collections/work-programme-real-life-stories",
           "web_url": "https://www.gov.uk/government/collections/work-programme-real-life-stories",
           "locale": "en"
         }

--- a/formats/case_study/frontend/examples/translated.json
+++ b/formats/case_study/frontend/examples/translated.json
@@ -26,52 +26,52 @@
     "links": {
         "available_translations": [
             {
-                "api_url": "http://localhost:3068/content/government/case-studies/doing-business-in-spain",
+                "api_url": "https://www.gov.uk/api/content/government/case-studies/doing-business-in-spain",
                 "base_path": "/government/case-studies/doing-business-in-spain",
                 "locale": "en",
                 "title": "Doing business in Spain",
-                "web_url": "https://www.preview.alphagov.co.uk/government/case-studies/doing-business-in-spain"
+                "web_url": "https://www.gov.uk/government/case-studies/doing-business-in-spain"
             },
             {
-                "api_url": "http://localhost:3068/content/government/case-studies/doing-business-in-spain.es",
+                "api_url": "https://www.gov.uk/api/content/government/case-studies/doing-business-in-spain.es",
                 "base_path": "/government/case-studies/doing-business-in-spain.es",
                 "locale": "es",
                 "title": "\u00bfQu\u00e9 puede hacer UKTI por t\u00ed?",
-                "web_url": "https://www.preview.alphagov.co.uk/government/case-studies/doing-business-in-spain.es"
+                "web_url": "https://www.gov.uk/government/case-studies/doing-business-in-spain.es"
             },
             {
-                "api_url": "http://localhost:3068/content/government/case-studies/doing-business-in-spain.ar",
+                "api_url": "https://www.gov.uk/api/content/government/case-studies/doing-business-in-spain.ar",
                 "base_path": "/government/case-studies/doing-business-in-spain.ar",
                 "locale": "ar",
                 "title": "البحرين - تحديث دراسة حالة دولة",
-                "web_url": "https://www.preview.alphagov.co.uk/government/case-studies/doing-business-in-spain.ar"
+                "web_url": "https://www.gov.uk/government/case-studies/doing-business-in-spain.ar"
             }
         ],
         "lead_organisations": [
             {
-                "api_url": "http://localhost:3068/content/government/organisations/uk-trade-investment",
+                "api_url": "https://www.gov.uk/api/content/government/organisations/uk-trade-investment",
                 "base_path": "/government/organisations/uk-trade-investment",
                 "locale": "en",
                 "title": "UK Trade & Investment",
-                "web_url": "https://www.preview.alphagov.co.uk/government/organisations/uk-trade-investment"
+                "web_url": "https://www.gov.uk/government/organisations/uk-trade-investment"
             }
         ],
         "supporting_organisations": [
             {
-                "api_url": "http://localhost:3068/content/government/organisations/foreign-commonwealth-office",
+                "api_url": "https://www.gov.uk/api/content/government/organisations/foreign-commonwealth-office",
                 "base_path": "/government/organisations/foreign-commonwealth-office",
                 "locale": "en",
                 "title": "Foreign & Commonwealth Office",
-                "web_url": "https://www.preview.alphagov.co.uk/government/organisations/foreign-commonwealth-office"
+                "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office"
             }
         ],
         "world_locations": [
             {
-                "api_url": "http://localhost:3068/content/government/world/spain.es",
+                "api_url": "https://www.gov.uk/api/content/government/world/spain.es",
                 "base_path": "/government/world/spain.es",
                 "locale": "es",
                 "title": "Espa\u00f1a",
-                "web_url": "https://www.preview.alphagov.co.uk/government/world/spain.es"
+                "web_url": "https://www.gov.uk/government/world/spain.es"
             }
         ],
         "worldwide_organisations": []

--- a/formats/finder/frontend/examples/cma-cases.json
+++ b/formats/finder/frontend/examples/cma-cases.json
@@ -116,7 +116,7 @@
       {
         "title": "Competition and Markets Authority",
         "base_path": "/government/organisations/competition-and-markets-authority",
-        "api_url": "http://content-store/content/government/organisations/competition-and-markets-authority",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
         "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority",
         "locale": "en"
       }
@@ -126,7 +126,7 @@
       {
         "title": "Competition and Markets Authority cases",
         "base_path": "/cma-cases/email-signup",
-        "api_url": "http://content-store/content/cma-cases/email-signup",
+        "api_url": "https://www.gov.uk/api/content/cma-cases/email-signup",
         "web_url": "https://www.gov.uk/cma-cases/email-signup",
         "locale": "en"
       }
@@ -135,7 +135,7 @@
       {
         "title": "Competition and Markets Authority cases",
         "base_path": "/cma-cases",
-        "api_url": "http://content-store/content/cma-cases",
+        "api_url": "https://www.gov.uk/api/content/cma-cases",
         "web_url": "https://www.gov.uk/cma-cases",
         "locale": "en"
       }

--- a/formats/finder/frontend/examples/contacts.json
+++ b/formats/finder/frontend/examples/contacts.json
@@ -42,8 +42,8 @@
       {
         "title": "HM Cheese & Biscuits",
         "base_path": "/government/organisations/hm-cheese-biscuits",
-        "api_url": "http://content-store.dev.gov.uk/content/government/organisations/government/organisations/hm-cheese-biscuits",
-        "web_url": "http://www.dev.gov.uk/government/organisations/government/organisations/hm-cheese-biscuits",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/government/organisations/hm-cheese-biscuits",
+        "web_url": "https://www.gov.uk/government/organisations/government/organisations/hm-cheese-biscuits",
         "locale": "en"
       }
     ],

--- a/formats/finder/frontend/examples/finder.json
+++ b/formats/finder/frontend/examples/finder.json
@@ -86,8 +86,8 @@
       {
         "title": "Ministry of Silly Walks",
         "base_path": "/government/organisations/ministry-of-silly-walks",
-        "api_url": "http://content-store.dev.gov.uk/content/government/organisations//government/organisations/ministry-of-silly-walks",
-        "web_url": "http://www.dev.gov.uk/government/organisations//government/organisations/ministry-of-silly-walks",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/government/organisations/ministry-of-silly-walks",
+        "web_url": "https://www.gov.uk/government/organisations/government/organisations/ministry-of-silly-walks",
         "locale": "en"
       }
     ],
@@ -96,8 +96,8 @@
       {
         "title": "Ministry of Silly Walks reports",
         "base_path": "/mosw-reports/email-signup",
-        "api_url": "http://content-store.dev.gov.uk/content/mosw-reports/email-signup",
-        "web_url": "http://www.dev.gov.uk/mosw-reports/email-signup",
+        "api_url": "https://www.gov.uk/api/content/mosw-reports/email-signup",
+        "web_url": "https://www.gov.uk/mosw-reports/email-signup",
         "locale": "en"
       }
     ],
@@ -105,8 +105,8 @@
       {
         "title": "Ministry of Silly Walks reports",
         "base_path": "/mosw-reports",
-        "api_url": "http://content-store.dev.gov.uk/content/mosw-reports",
-        "web_url": "http://www.dev.gov.uk/mosw-reports",
+        "api_url": "https://www.gov.uk/api/content/mosw-reports",
+        "web_url": "https://www.gov.uk/mosw-reports",
         "locale": "en"
       }
     ]

--- a/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
@@ -8,7 +8,7 @@
         {
           "title": "Universal credit",
           "base_path": "/benefits/universal-credit",
-          "api_url": "http://content-store/content/benefits/universal-credit",
+          "api_url": "https://www.gov.uk/api/content/benefits/universal-credit",
           "web_url": "https://www.gov.uk/benefits/universal-credit",
           "locale": "en"
         }

--- a/formats/policy/frontend/examples/minimal_policy_area.json
+++ b/formats/policy/frontend/examples/minimal_policy_area.json
@@ -24,8 +24,8 @@
         {
           "title": "Minimal Benefits Reform",
           "base_path": "/government/policies/minimal-benefits-reform/email-signup",
-          "api_url": "http://content-store.dev.gov.uk/content/government/policies/minimal-benefits-reform/email-signup",
-          "web_url": "http://www.dev.gov.uk/government/policies/minimal-benefits-reform/email-signup",
+          "api_url": "https://www.gov.uk/api/content/government/policies/minimal-benefits-reform/email-signup",
+          "web_url": "https://www.gov.uk/government/policies/minimal-benefits-reform/email-signup",
           "locale": "en"
         }
       ]

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -37,7 +37,7 @@
         {
           "title": "Department for Work and Pensions",
           "base_path": "/government/organisations/department-for-work-and-pensions",
-          "api_url": "http://content-store/organisations/department-for-work-and-pensions",
+          "api_url": "https://www.gov.uk/api/organisations/department-for-work-and-pensions",
           "web_url": "https://www.gov.uk/government/organisations/department-for-work-and-pensions",
           "locale": "en"
         }
@@ -48,8 +48,8 @@
         {
           "title": "Benefits Reform",
           "base_path": "/government/policies/benefits-reform/email-signup",
-          "api_url": "http://content-store.dev.gov.uk/content/government/policies/benefits-reform/email-signup",
-          "web_url": "http://www.dev.gov.uk/government/policies/benefits-reform/email-signup",
+          "api_url": "https://www.gov.uk/api/content/government/policies/benefits-reform/email-signup",
+          "web_url": "https://www.gov.uk/government/policies/benefits-reform/email-signup",
           "locale": "en"
         }
       ],
@@ -57,8 +57,8 @@
          {
             "title": "Benefits Reform",
             "base_path": "/government/policies/benefits-reform",
-            "api_url": "http://content-store.dev.gov.uk/content/government/policies/benefits-reform",
-            "web_url": "http://www.dev.gov.uk/government/policies/benefits-reform",
+            "api_url": "https://www.gov.uk/api/content/government/policies/benefits-reform",
+            "web_url": "https://www.gov.uk/government/policies/benefits-reform",
             "locale": "en"
          }
       ]

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -37,7 +37,7 @@
         {
           "title": "Department for Work and Pensions",
           "base_path": "/government/organisations/department-for-work-and-pensions",
-          "api_url": "http://content-store/organisations/department-for-work-and-pensions",
+          "api_url": "https://www.gov.uk/api/organisations/department-for-work-and-pensions",
           "web_url": "https://www.gov.uk/government/organisations/department-for-work-and-pensions",
           "locale": "en"
         }
@@ -46,7 +46,7 @@
         {
           "title": "George Dough",
           "base_path": "/government/people/george-dough",
-          "api_url": "http://content-store/people/george-dough",
+          "api_url": "https://www.gov.uk/api/people/george-dough",
           "web_url": "https://www.gov.uk/people/george-dough",
           "locale": "en"
         }
@@ -56,8 +56,8 @@
         {
           "title": "Universal Credit",
           "base_path": "/government/policies/universal-credit/email-signup",
-          "api_url": "http://content-store.dev.gov.uk/content/government/policies/universal-credit/email-signup",
-          "web_url": "http://www.dev.gov.uk/government/policies/universal-credit/email-signup",
+          "api_url": "https://www.gov.uk/api/content/government/policies/universal-credit/email-signup",
+          "web_url": "https://www.gov.uk/government/policies/universal-credit/email-signup",
           "locale": "en"
         }
       ],
@@ -65,8 +65,8 @@
          {
             "title": "Unveirsal Credit",
             "base_path": "/government/policies/universal-credit",
-            "api_url": "http://content-store.dev.gov.uk/content/government/policies/universal-credit",
-            "web_url": "http://www.dev.gov.uk/government/policies/universal-credit",
+            "api_url": "https://www.gov.uk/api/content/government/policies/universal-credit",
+            "web_url": "https://www.gov.uk/government/policies/universal-credit",
             "locale": "en"
          }
       ]

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -53,7 +53,7 @@
         {
           "title": "Northern Ireland Office",
           "base_path": "/government/organisations/northern-ireland-office",
-          "api_url": "http://content-store/organisations/northern-ireland-office",
+          "api_url": "https://www.gov.uk/api/organisations/northern-ireland-office",
           "web_url": "https://www.gov.uk/government/organisations/northern-ireland-office",
           "locale": "en"
         }
@@ -62,7 +62,7 @@
         {
           "title": "George Dough",
           "base_path": "/government/people/george-dough",
-          "api_url": "http://content-store/people/george-dough",
+          "api_url": "https://www.gov.uk/api/people/george-dough",
           "web_url": "https://www.gov.uk/people/george-dough",
           "locale": "en"
         }
@@ -72,8 +72,8 @@
          {
             "title": "Keeping Northern Ireland safe",
             "base_path": "/government/policies/keeping-northern-ireland-safe",
-            "api_url": "http://content-store.dev.gov.uk/content/government/policies/keeping-northern-ireland-safe",
-            "web_url": "http://www.dev.gov.uk/government/policies/keeping-northern-ireland-safe",
+            "api_url": "https://www.gov.uk/api/content/government/policies/keeping-northern-ireland-safe",
+            "web_url": "https://www.gov.uk/government/policies/keeping-northern-ireland-safe",
             "locale": "en"
          }
       ]

--- a/formats/unpublishing/frontend/examples/unpublishing.json
+++ b/formats/unpublishing/frontend/examples/unpublishing.json
@@ -19,7 +19,7 @@
       {
         "title":"Bubble and trouble",
         "base_path":"/government/case-studies/bubble-trouble",
-        "api_url":"http://content-store/content/government/case-studies/bubble-trouble",
+        "api_url": "https://www.gov.uk/api/content/government/case-studies/bubble-trouble",
         "web_url":"https://www.gov.uk/government/case-studies/bubble-trouble",
         "locale":"en"
       }


### PR DESCRIPTION
Now that the content store API is public, make all the `api_url` fields
in links point at it (ie, start with the
`https://www.gov.uk/api/content/` prefix).  Also, make all the `web_url`
fields point at `https://www.gov.uk` - most of these already did, but a
few pointed at `dev.gov.uk` or other places.

Previously, the examples were inconsistent in what environment they
pointed to.

This makes the examples consistent, and if applications use them they'll
be more likely to work correctly to at least some extent.

It would be nice in future PRs to validate that all examples used these
standard prefixes, and to make the dummy_content_store app parse these
to return the appropriate initial prefixes for the environment.
However, I would like to get this tidyup merged without waiting for such
refinements.