### PR TITLE
Drop email alert signup enabled from Finders

### DIFF
--- a/formats/finder/frontend/examples/cma-cases.json
+++ b/formats/finder/frontend/examples/cma-cases.json
@@ -11,7 +11,6 @@
     "beta": false,
     "beta_message": null,
     "document_noun": "case",
-    "email_signup_enabled": true,
     "filter": {
       "document_type": "cma_case"
     },

--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -69,9 +69,6 @@
           "type": "string",
           "additionalProperties": false
         },
-        "email_signup_enabled": {
-          "type": "boolean"
-        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -24,9 +24,6 @@
       "type": "string",
       "additionalProperties": false
     },
-    "email_signup_enabled": {
-      "type": "boolean"
-    },
     "filter": {
       "description": "This is the fixed filter that scopes the finder",
       "type": "object",

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -100,9 +100,6 @@
           "type": "string",
           "additionalProperties": false
         },
-        "email_signup_enabled": {
-          "type": "boolean"
-        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",


### PR DESCRIPTION
As all Finders that want it now have email alert signup being live, we don't care about keeping this feature hidden. This commit removes it from the schema and the example that had it.