### PR TITLE
Add new facets for policy finder example

### DIFF
--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -29,6 +29,28 @@
           "key": "government_name",
           "display_as_result_metadata": true,
           "filterable": false
+        },
+        {
+          "key": "public_timestamp",
+          "short_name": "Updated",
+          "type": "date",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "organisations",
+          "short_name": "From",
+          "type": "text",
+          "display_as_result_metadata": true,
+          "result_metadata_name_key": "title",
+          "filterable": false
+        },
+        {
+          "key": "display_type",
+          "short_name": "Type",
+          "type": "text",
+          "display_as_result_metadata": true,
+          "filterable": false
         }
       ]
    },

--- a/formats/policy/frontend/schema.json
+++ b/formats/policy/frontend/schema.json
@@ -99,6 +99,9 @@
                     }
                   }
                 }
+              },
+              "result_metadata_name_key": {
+                "type": "string"
               }
             }
           }


### PR DESCRIPTION
Policy finders should show result metadata including
the date updated, the organisations it's from, and
the document type.

This matches the display on existing policy filter
views, that will be replaced by the policy finder
eg, https://www.gov.uk/government/policies/fulfilling-the-commitments-of-the-armed-forces-covenant/activity

This adds a new facet option (result_metadata_name_key)
that will be documented in the finder-frontend repo