### PR TITLE
Add 'result_metadata_name_key' finder facet option

### DIFF
--- a/formats/finder/frontend/schema.json
+++ b/formats/finder/frontend/schema.json
@@ -138,6 +138,9 @@
                     }
                   }
                 }
+              },
+              "result_metadata_name_key": {
+                "type": "string"
               }
             }
           }

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -93,6 +93,9 @@
                 }
               }
             }
+          },
+          "result_metadata_name_key": {
+            "type": "string"
           }
         }
       }

--- a/formats/finder/publisher/schema.json
+++ b/formats/finder/publisher/schema.json
@@ -169,6 +169,9 @@
                     }
                   }
                 }
+              },
+              "result_metadata_name_key": {
+                "type": "string"
               }
             }
           }

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -29,6 +29,28 @@
           "key": "government_name",
           "display_as_result_metadata": true,
           "filterable": false
+        },
+        {
+          "key": "public_timestamp",
+          "short_name": "Updated",
+          "type": "date",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "organisations",
+          "short_name": "From",
+          "type": "text",
+          "display_as_result_metadata": true,
+          "result_metadata_name_key": "title",
+          "filterable": false
+        },
+        {
+          "key": "display_type",
+          "short_name": "Type",
+          "type": "text",
+          "display_as_result_metadata": true,
+          "filterable": false
         }
       ]
    },

--- a/formats/policy/frontend/schema.json
+++ b/formats/policy/frontend/schema.json
@@ -99,6 +99,9 @@
                     }
                   }
                 }
+              },
+              "result_metadata_name_key": {
+                "type": "string"
               }
             }
           }

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -62,6 +62,9 @@
                 }
               }
             }
+          },
+          "result_metadata_name_key": {
+            "type": "string"
           }
         }
       }

--- a/formats/policy/publisher/schema.json
+++ b/formats/policy/publisher/schema.json
@@ -130,6 +130,9 @@
                     }
                   }
                 }
+              },
+              "result_metadata_name_key": {
+                "type": "string"
               }
             }
           }


### PR DESCRIPTION
For rummager fields which are objects/hashes, this option
specifies which key contains the value to use for display.

Existing spec-pub finders (cma, etc), use the 'label' key
by convention, which was hard coded into finder-frontend,
but some fields used in policy finders (like organisation)
use a different key for the display value.

This option allows policy finders to fix that through the
schema, and updates example policy content to use it and
adds two other options that will be used in policy finders.

Policies are a based on the finders schema, so the change
is duplicated in both.