### PR TITLE
Update policy finder examples

### DIFF
--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -29,6 +29,27 @@
           "key": "government_name",
           "display_as_result_metadata": true,
           "filterable": false
+        },
+        {
+          "key": "public_timestamp",
+          "short_name": "Updated",
+          "type": "date",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "organisations",
+          "short_name": "From",
+          "type": "text",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "display_type",
+          "short_name": "Type",
+          "type": "text",
+          "display_as_result_metadata": true,
+          "filterable": false
         }
       ]
    },

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -29,6 +29,27 @@
           "key": "government_name",
           "display_as_result_metadata": true,
           "filterable": false
+        },
+        {
+          "key": "public_timestamp",
+          "short_name": "Updated",
+          "type": "date",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "organisations",
+          "short_name": "From",
+          "type": "text",
+          "display_as_result_metadata": true,
+          "filterable": false
+        },
+        {
+          "key": "display_type",
+          "short_name": "Type",
+          "type": "text",
+          "display_as_result_metadata": true,
+          "filterable": false
         }
       ]
    },


### PR DESCRIPTION
Policy finders are going to display metadata for orgs, document type and date updated.

This adds the facet options required to show them to both the policy and program example content, so they can be used by finder frontend as test fixtures and for manual testing against dummy content store.

Originally I took the approach of a `result_metadata_name_key` facet option that allowed `finder-frontend` to use config to decide which key to use. 

After discussion with @evilstreak and @rboulton I decided it would cleaner/simpler to keep this display logic in `finder-frontend`. Putting it in schemas feels more complicated, and would only get more complex/add many more options, for other display logic.

The long term solution is standardised field representations in rummager, but in the mean time localising the how-to-display-field logic in finder-fronted.