### PR TITLE
Update policy examples with date filtering facets

### DIFF
--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -32,10 +32,11 @@
         },
         {
           "key": "public_timestamp",
+          "name": "Published",
           "short_name": "Updated",
           "type": "date",
           "display_as_result_metadata": true,
-          "filterable": false
+          "filterable": true
         },
         {
           "key": "organisations",

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -32,10 +32,11 @@
         },
         {
           "key": "public_timestamp",
+          "name": "Published",
           "short_name": "Updated",
           "type": "date",
           "display_as_result_metadata": true,
-          "filterable": false
+          "filterable": true
         },
         {
           "key": "organisations",


### PR DESCRIPTION
These are being added in the policy publisher and will be on all policy finders.

Policy publisher updated in https://github.com/alphagov/policy-publisher/pull/54