### PR TITLE
Define a schema for manuals

### DIFF
--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "locale",
+    "public_updated_at"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "manual"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "child_section_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "child_sections"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "child_sections": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "title",
+                    "description",
+                    "base_path"
+                  ],
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "base_path": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "change_notes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "base_path",
+              "title",
+              "change_note",
+              "published_at"
+            ],
+            "properties": {
+              "base_path": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "change_note": {
+                "type": "string"
+              },
+              "published_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "abbreviation",
+              "web_url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "abbreviation": {
+                "type": "string"
+              },
+              "web_url": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "base_path": {
+            "type": "string"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "update_type",
+    "locale",
+    "public_updated_at"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "manual"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "child_section_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "child_sections"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "child_sections": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "title",
+                    "description",
+                    "base_path"
+                  ],
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "base_path": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "change_notes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "base_path",
+              "title",
+              "change_note",
+              "published_at"
+            ],
+            "properties": {
+              "base_path": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "change_note": {
+                "type": "string"
+              },
+              "published_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "abbreviation",
+              "web_url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "abbreviation": {
+                "type": "string"
+              },
+              "web_url": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/formats/manual/frontend/examples/content-design.json
+++ b/formats/manual/frontend/examples/content-design.json
@@ -1,0 +1,79 @@
+{
+  "base_path": "/guidance/content-design",
+  "title": "Content design: planning, writing and managing content",
+  "description": "Planning and managing digital content to meet the needs the public has of government.",
+  "format": "manual",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-04-27T12:54:38.685Z",
+  "public_updated_at": "2015-04-27T12:54:27.000+00:00",
+  "details": {
+    "body": "\n",
+    "child_section_groups": [
+      {
+        "title": "Contents",
+        "child_sections": [
+          {
+            "title": "What is content design?",
+            "description": "Introduction to content design.",
+            "base_path": "/guidance/content-design/what-is-content-design"
+          },
+          {
+            "title": "User needs",
+            "description": "How to write and record a user need for GOV.UK.",
+            "base_path": "/guidance/content-design/user-needs"
+          },
+          {
+            "title": "Planning content",
+            "description": "Find out how to decide if something is suitable for GOV.UK, what the content lifecycle is and why accessibility must be planned for.",
+            "base_path": "/guidance/content-design/planning-content"
+          }
+        ]
+      }
+    ],
+    "change_notes": [
+      {
+        "base_path": "/guidance/content-design/what-is-content-design",
+        "title": "What is content design?",
+        "change_note": "New section added.",
+        "published_at": "2014-10-06T19:49:25Z"
+      },
+      {
+        "base_path": "/guidance/content-design/user-needs",
+        "title": "User needs",
+        "change_note": "New section added.",
+        "published_at": "2014-10-06T19:49:25Z"
+      },
+      {
+        "base_path": "/guidance/content-design/planning-content",
+        "title": "Planning content",
+        "change_note": "New section added.",
+        "published_at": "2014-10-06T19:49:25Z"
+      },
+      {
+        "base_path": "/guidance/content-design/content-types",
+        "title": "Content types",
+        "change_note": "New section added.",
+        "published_at": "2014-10-06T19:49:25Z"
+      }
+    ],
+    "organisations": [
+      {
+        "title": "Government Digital Service",
+        "abbreviation": "GDS",
+        "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
+      }
+    ]
+  },
+  "links": {
+    "available_translations": [
+      {
+        "title": "Content design: planning, writing and managing content",
+        "base_path": "/guidance/content-design",
+        "api_url": "https://content-store.preview.alphagov.co.uk/content/guidance/content-design",
+        "web_url": "https://www.preview.alphagov.co.uk/guidance/content-design",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/manual/publisher/details.json
+++ b/formats/manual/publisher/details.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "body"
+  ],
+  "properties": {
+    "body": {
+      "type": "string"
+    },
+    "child_section_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "base_path": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "change_notes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "properties": {
+          "base_path": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "organisations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "abbreviation": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Another schema will be required for HMRC manuals as they are similar but
different (mainly additive).

I used the real content-design manual as a frontend example, but truncated it as it ran
to ~800 lines.

Using this schema in specialist-publisher will come in a Pull Request after this is merged (the tests can't pass until then), but is in a branch here: https://github.com/alphagov/specialist-publisher/compare/validate_manuals_against_schema?expand=1