### PR TITLE
Add 'result_metadata_name_key' to finder schemas

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -121,6 +121,9 @@
               "type": {
                 "type": "string"
               },
+              "result_metadata_name_key": {
+                "type": "string"
+              },
               "allowed_values": {
                 "type": "array",
                 "items": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -152,6 +152,9 @@
               "type": {
                 "type": "string"
               },
+              "result_metadata_name_key": {
+                "type": "string"
+              },
               "allowed_values": {
                 "type": "array",
                 "items": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -82,6 +82,9 @@
               "type": {
                 "type": "string"
               },
+              "result_metadata_name_key": {
+                "type": "string"
+              },
               "allowed_values": {
                 "type": "array",
                 "items": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -113,6 +113,9 @@
               "type": {
                 "type": "string"
               },
+              "result_metadata_name_key": {
+                "type": "string"
+              },
               "allowed_values": {
                 "type": "array",
                 "items": {

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -75,6 +75,9 @@
           "type": {
             "type": "string"
           },
+          "result_metadata_name_key": {
+            "type": "string"
+          },
           "allowed_values": {
             "type": "array",
             "items": {

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -44,6 +44,9 @@
           "type": {
             "type": "string"
           },
+          "result_metadata_name_key": {
+            "type": "string"
+          },
           "allowed_values": {
             "type": "array",
             "items": {


### PR DESCRIPTION
This is used on policy finders and the finder of policies.

It's causing https://github.com/alphagov/policy-publisher/pull/60 to fail at the moment.