### PR TITLE
Add schemas for hmrc manuals

### DIFF
--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "locale",
+    "public_updated_at"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "child_section_groups"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "child_section_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "child_sections"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "child_sections": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "section_id",
+                    "title",
+                    "description",
+                    "base_path"
+                  ],
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "section_id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "base_path": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "change_notes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "section_id",
+              "base_path",
+              "title",
+              "change_note",
+              "published_at"
+            ],
+            "properties": {
+              "section_id": {
+                "type": "string"
+              },
+              "base_path": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "change_note": {
+                "type": "string"
+              },
+              "published_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "abbreviation",
+              "web_url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "abbreviation": {
+                "type": "string"
+              },
+              "web_url": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "base_path": {
+            "type": "string"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "update_type",
+    "locale",
+    "public_updated_at"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "child_section_groups"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "child_section_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "child_sections"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "child_sections": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "section_id",
+                    "title",
+                    "description",
+                    "base_path"
+                  ],
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "section_id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "base_path": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "change_notes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "section_id",
+              "base_path",
+              "title",
+              "change_note",
+              "published_at"
+            ],
+            "properties": {
+              "section_id": {
+                "type": "string"
+              },
+              "base_path": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "change_note": {
+                "type": "string"
+              },
+              "published_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "abbreviation",
+              "web_url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "abbreviation": {
+                "type": "string"
+              },
+              "web_url": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "locale",
+    "public_updated_at"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual_section"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "section_id",
+        "manual",
+        "organisations"
+      ],
+      "properties": {
+        "section_id": {
+          "type": "string"
+        },
+        "breadcrumbs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "base_path",
+              "section_id"
+            ],
+            "properties": {
+              "base_path": {
+                "type": "string"
+              },
+              "section_id": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "body": {
+          "type": "string"
+        },
+        "manual": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "base_path"
+          ],
+          "properties": {
+            "base_path": {
+              "type": "string"
+            }
+          }
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "abbreviation",
+              "web_url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "abbreviation": {
+                "type": "string"
+              },
+              "web_url": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "child_section_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "child_sections"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "child_sections": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "section_id",
+                    "title",
+                    "description",
+                    "base_path"
+                  ],
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "section_id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "base_path": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "base_path": {
+            "type": "string"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "update_type",
+    "locale",
+    "public_updated_at"
+  ],
+  "properties": {
+    "base_path": {
+      "type": "string"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual_section"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "section_id",
+        "manual",
+        "organisations"
+      ],
+      "properties": {
+        "section_id": {
+          "type": "string"
+        },
+        "breadcrumbs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "base_path",
+              "section_id"
+            ],
+            "properties": {
+              "base_path": {
+                "type": "string"
+              },
+              "section_id": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "body": {
+          "type": "string"
+        },
+        "manual": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "base_path"
+          ],
+          "properties": {
+            "base_path": {
+              "type": "string"
+            }
+          }
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "abbreviation",
+              "web_url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "abbreviation": {
+                "type": "string"
+              },
+              "web_url": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "child_section_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "child_sections"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "child_sections": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "section_id",
+                    "title",
+                    "description",
+                    "base_path"
+                  ],
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "section_id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "base_path": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/formats/hmrc_manual/frontend/examples/vat-government-public-bodies.json
+++ b/formats/hmrc_manual/frontend/examples/vat-government-public-bodies.json
@@ -1,0 +1,131 @@
+{
+  "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies",
+  "title": "VAT Government and Public Bodies",
+  "description": "Guidance on VAT as it applies to local authorities and other government and public bodies.",
+  "format": "hmrc_manual",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-03-05T15:16:29.904Z",
+  "public_updated_at": "2015-02-11T13:45:00.000+00:00",
+  "details": {
+    "child_section_groups": [
+      {
+        "child_sections": [
+          {
+            "section_id": "VATGPB1000",
+            "title": "Introduction: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000"
+          },
+          {
+            "section_id": "VATGPB2000",
+            "title": "Bodies governed by public law: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb2000"
+          },
+          {
+            "section_id": "VATGPB3000",
+            "title": "Non-business activities: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb3000"
+          },
+          {
+            "section_id": "VATGPB4000",
+            "title": "Section 33 bodies: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb4000"
+          },
+          {
+            "section_id": "VATGPB5000",
+            "title": "Police authorities: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5000"
+          },
+          {
+            "section_id": "VATGPB6000",
+            "title": "Local government partnership programmes: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb6000"
+          },
+          {
+            "section_id": "VATGPB7000",
+            "title": "Local authority education services: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb7000"
+          },
+          {
+            "section_id": "VATGPB8000",
+            "title": "Other local authority activities: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb8000"
+          },
+          {
+            "section_id": "VATGPB9000",
+            "title": "Government departments and health authorities: contents",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb9000"
+          }
+        ]
+      },
+      {
+        "child_sections": [
+          {
+            "section_id": "VATGPBUPDATE001",
+            "title": "VAT Government and public bodies: update index",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpbupdate001"
+          }
+        ],
+        "title": "Historic updates"
+      }
+    ],
+    "change_notes": [
+      {
+        "change_note": "Updated content",
+        "section_id": "VATGPB5390",
+        "title": "Police authorities: summary of activities: liabilities T to Z",
+        "published_at": "2015-03-05T15:16:20+00:00",
+        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5390"
+      },
+      {
+        "change_note": "Updated content",
+        "section_id": "VATGPB5370",
+        "title": "Police authorities: summary of activities: liabilities P",
+        "published_at": "2015-03-05T15:14:29+00:00",
+        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5370"
+      },
+      {
+        "change_note": "Updated content",
+        "section_id": "VATGPB5360",
+        "title": "Police authorities: summary of activities: liabilities N to O",
+        "published_at": "2015-03-05T15:12:55+00:00",
+        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5360"
+      },
+      {
+        "change_note": "Updated content",
+        "section_id": "VATGPB5350",
+        "title": "Police authorities: summary of activities: liabilities I to M",
+        "published_at": "2015-03-05T15:11:32+00:00",
+        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5350"
+      }
+    ],
+    "organisations": [
+      {
+        "title": "HM Revenue & Customs",
+        "abbreviation": "HMRC",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
+      }
+    ]
+  },
+  "links": {
+    "available_translations": [
+      {
+        "title": "VAT Government and Public Bodies",
+        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies",
+        "api_url": "https://content-store.preview.alphagov.co.uk/content/hmrc-internal-manuals/vat-government-and-public-bodies",
+        "web_url": "https://www.preview.alphagov.co.uk/hmrc-internal-manuals/vat-government-and-public-bodies",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/hmrc_manual/publisher/details.json
+++ b/formats/hmrc_manual/publisher/details.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "child_section_groups"
+  ],
+  "properties": {
+    "body": {
+      "type": "string"
+    },
+    "child_section_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "child_sections"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "base_path": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "change_notes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "properties": {
+          "section_id": {
+            "type": "string"
+          },
+          "base_path": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "organisations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "abbreviation": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/formats/hmrc_manual_section/frontend/examples/vatgpb1000.json
+++ b/formats/hmrc_manual_section/frontend/examples/vatgpb1000.json
@@ -1,0 +1,78 @@
+{
+  "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+  "title": "Introduction: contents",
+  "description": "",
+  "format": "hmrc_manual_section",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-03-03T10:54:03.662Z",
+  "public_updated_at": "2015-02-10T14:52:10.000+00:00",
+  "details": {
+    "body": "\n",
+    "section_id": "VATGPB1000",
+    "breadcrumbs": [],
+    "child_section_groups": [
+      {
+        "child_sections": [
+          {
+            "section_id": "VATGPB1100",
+            "title": "Introduction: scope of the manual",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1100"
+          },
+          {
+            "section_id": "VATGPB1200",
+            "title": "Introduction: release of information",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1200"
+          },
+          {
+            "section_id": "VATGPB1300",
+            "title": "Introduction: how to use the manual",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1300"
+          },
+          {
+            "section_id": "VATGPB1400",
+            "title": "Introduction: Notice 749",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1400"
+          },
+          {
+            "section_id": "VATGPB1500",
+            "title": "Introduction: representative bodies",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1500"
+          },
+          {
+            "section_id": "VATGPB1600",
+            "title": "Introduction: HMRC contacts",
+            "description": "",
+            "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1600"
+          }
+        ]
+      }
+    ],
+    "manual": {
+      "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies"
+    },
+    "organisations": [
+      {
+        "title": "HM Revenue & Customs",
+        "abbreviation": "HMRC",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
+      }
+    ]
+  },
+  "links": {
+    "available_translations": [
+      {
+        "title": "Introduction: contents",
+        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+        "api_url": "https://content-store.preview.alphagov.co.uk/content/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+        "web_url": "https://www.preview.alphagov.co.uk/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/hmrc_manual_section/publisher/details.json
+++ b/formats/hmrc_manual_section/publisher/details.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "section_id",
+    "manual",
+    "organisations"
+  ],
+  "properties": {
+    "section_id": {
+      "type": "string"
+    },
+    "breadcrumbs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "properties": {
+          "base_path": {
+            "type": "string"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "body": {
+      "type": "string"
+    },
+    "manual": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "base_path"
+      ],
+      "properties": {
+        "base_path": {
+          "type": "string"
+        }
+      }
+    },
+    "organisations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "abbreviation": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "child_section_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "child_sections"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "base_path": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I decided to do this as there wasn't much effort required (mainly copying and pasting) but it guards against us changing things in such a way that breaks hmrc-manuals-api, which is something of an odd-one-out.

Contract tests for hmrc-manuals-api in a branch here pending the merge of the schemas: https://github.com/alphagov/hmrc-manuals-api/compare/add_schema_tests 

and the same for manuals-frontend: https://github.com/alphagov/manuals-frontend/compare/contract_tests_for_hmrc_manuals?expand=1