### PR TITLE
Add format type to email alert signup

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -42,7 +42,8 @@
       "additionalProperties": false,
       "required": [
         "summary",
-        "tags"
+        "tags",
+        "format_type"
       ],
       "properties": {
         "summary": {
@@ -70,6 +71,9 @@
               }
             }
           }
+        },
+        "format_type": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -73,7 +73,8 @@
       "additionalProperties": false,
       "required": [
         "summary",
-        "tags"
+        "tags",
+        "format_type"
       ],
       "properties": {
         "summary": {
@@ -101,6 +102,9 @@
               }
             }
           }
+        },
+        "format_type": {
+          "type": "string"
         }
       }
     },

--- a/formats/email_alert_signup/frontend/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/email_alert_signup.json
@@ -19,7 +19,8 @@
       "policy": [
         "employment"
       ]
-    }
+    },
+    "format_type": "policy"
   },
   "links": {}
 }

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -4,7 +4,8 @@
   "additionalProperties": false,
   "required": [
     "summary",
-    "tags"
+    "tags",
+    "format_type"
   ],
   "properties": {
     "summary": {
@@ -32,6 +33,9 @@
           }
         }
       }
+    },
+    "format_type": {
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
As we want to make Email Alert Signup work even when there are duplicate
topic names (thanks Govdelivery) we want to prepend a `format_type`
string to the topic name to prevent duplications across different format
on GOV.UK. This commit adds it to the schema and examples.