### PR TITLE
Add govdelivery_title to email alert signup

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -70,6 +70,9 @@
               }
             }
           }
+        },
+        "govdelivery_title": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -101,6 +101,9 @@
               }
             }
           }
+        },
+        "govdelivery_title": {
+          "type": "string"
         }
       }
     },

--- a/formats/email_alert_signup/frontend/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/email_alert_signup.json
@@ -19,7 +19,8 @@
       "policy": [
         "employment"
       ]
-    }
+    },
+    "govdelivery_title": "Employment policy"
   },
   "links": {}
 }

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -32,6 +32,9 @@
           }
         }
       }
+    },
+    "govdelivery_title": {
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
As we want to make Email Alert Signup work even when there are duplicate
topic names (thanks Govdelivery) we want to use a `govdelivery_title` to
allow us to specify something different to use when creating the topic
in govdelivery if it is a duplicate of an existing topic.