### PR TITLE
Add default order to Finders

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -73,6 +73,9 @@
         "logo_path": {
           "type": "string"
         },
+        "default_order": {
+          "type": "string"
+        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -104,6 +104,9 @@
         "logo_path": {
           "type": "string"
         },
+        "default_order": {
+          "type": "string"
+        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -52,6 +52,9 @@
         "email_signup_enabled": {
           "type": "boolean"
         },
+        "default_order": {
+          "type": "string"
+        },
         "filter": {
           "type": "object",
           "additionalProperties": true

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -83,6 +83,9 @@
         "email_signup_enabled": {
           "type": "boolean"
         },
+        "default_order": {
+          "type": "string"
+        },
         "filter": {
           "type": "object",
           "additionalProperties": true

--- a/formats/finder/frontend/examples/policies_finder.json
+++ b/formats/finder/frontend/examples/policies_finder.json
@@ -1,0 +1,324 @@
+{
+  "base_path": "/government/policies",
+  "title": "Policies",
+  "description": "",
+  "format": "finder",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-05-14T15:39:39.405Z",
+  "public_updated_at": "2015-05-14T11:04:29.000+00:00",
+  "details": {
+    "document_noun": "policy",
+    "default_order": "title",
+    "filter": {
+      "document_type": "policy"
+    },
+    "show_summaries": false,
+    "facets": [
+      {
+        "key": "organisations",
+        "short_name": "From",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Airports Commission",
+            "value": "airports-commission"
+          },
+          {
+            "label": "Animal and Plant Health Agency",
+            "value": "animal-and-plant-health-agency"
+          },
+          {
+            "label": "Border Force",
+            "value": "border-force"
+          },
+          {
+            "label": "Building Regulations Advisory Committee",
+            "value": "building-regulations-advisory-committee"
+          },
+          {
+            "label": "Cabinet Office",
+            "value": "cabinet-office"
+          },
+          {
+            "label": "Centre for Environment, Fisheries and Aquaculture Science",
+            "value": "centre-for-environment-fisheries-and-aquaculture-science"
+          },
+          {
+            "label": "Chief Fire and Rescue Adviser",
+            "value": "chief-fire-and-rescue-adviser-unit"
+          },
+          {
+            "label": "Civil Aviation Authority",
+            "value": "civil-aviation-authority"
+          },
+          {
+            "label": "Civil Service Fast Stream",
+            "value": "civil-service-fast-stream"
+          },
+          {
+            "label": "Coal Authority",
+            "value": "the-coal-authority"
+          },
+          {
+            "label": "Committee on Climate Change",
+            "value": "committee-on-climate-change"
+          },
+          {
+            "label": "Crown Agents Holding and Realisation Board",
+            "value": "crown-agents-holding-and-realisation-board"
+          },
+          {
+            "label": "Crown Commercial Service",
+            "value": "crown-commercial-service"
+          },
+          {
+            "label": "Department for Business, Innovation & Skills",
+            "value": "department-for-business-innovation-skills"
+          },
+          {
+            "label": "Department for Communities and Local Government",
+            "value": "department-for-communities-and-local-government"
+          },
+          {
+            "label": "Department for Culture, Media & Sport",
+            "value": "department-for-culture-media-sport"
+          },
+          {
+            "label": "Department for Education",
+            "value": "department-for-education"
+          },
+          {
+            "label": "Department for Environment, Food & Rural Affairs",
+            "value": "department-for-environment-food-rural-affairs"
+          },
+          {
+            "label": "Department for International Development",
+            "value": "department-for-international-development"
+          },
+          {
+            "label": "Department for Transport",
+            "value": "department-for-transport"
+          },
+          {
+            "label": "Department for Work and Pensions",
+            "value": "department-for-work-pensions"
+          },
+          {
+            "label": "Department of Energy & Climate Change",
+            "value": "department-of-energy-climate-change"
+          },
+          {
+            "label": "Department of Health",
+            "value": "department-of-health"
+          },
+          {
+            "label": "Disabled Persons Transport Advisory Committee",
+            "value": "disabled-persons-transport-advisory-committee"
+          },
+          {
+            "label": "Driver and Vehicle Licensing Agency",
+            "value": "driver-and-vehicle-licensing-agency"
+          },
+          {
+            "label": "Driver and Vehicle Standards Agency",
+            "value": "driver-and-vehicle-standards-agency"
+          },
+          {
+            "label": "Efficiency and Reform Group",
+            "value": "efficiency-and-reform-group"
+          },
+          {
+            "label": "Environment Agency",
+            "value": "environment-agency"
+          },
+          {
+            "label": "Foreign & Commonwealth Office",
+            "value": "foreign-commonwealth-office"
+          },
+          {
+            "label": "Forestry Commission",
+            "value": "forestry-commission"
+          },
+          {
+            "label": "Government Digital Service",
+            "value": "government-digital-service"
+          },
+          {
+            "label": "Government Equalities Office  ",
+            "value": "government-equalities-office"
+          },
+          {
+            "label": "Groceries Code Adjudicator",
+            "value": "groceries-code-adjudicator"
+          },
+          {
+            "label": "HM Courts and Tribunals Service",
+            "value": "hm-courts-and-tribunals-service"
+          },
+          {
+            "label": "HM Revenue & Customs",
+            "value": "hm-revenue-customs"
+          },
+          {
+            "label": "HM Treasury",
+            "value": "hm-treasury"
+          },
+          {
+            "label": "Health and Safety Executive",
+            "value": "health-and-safety-executive"
+          },
+          {
+            "label": "High Speed Two (HS2) Limited",
+            "value": "high-speed-two-limited"
+          },
+          {
+            "label": "Highways Agency",
+            "value": "highways-agency"
+          },
+          {
+            "label": "Home Office",
+            "value": "home-office"
+          },
+          {
+            "label": "Homes and Communities Agency",
+            "value": "homes-and-communities-agency"
+          },
+          {
+            "label": "Innovate UK",
+            "value": "innovate-uk"
+          },
+          {
+            "label": "Marine Management Organisation",
+            "value": "marine-management-organisation"
+          },
+          {
+            "label": "Maritime and Coastguard Agency",
+            "value": "maritime-and-coastguard-agency"
+          },
+          {
+            "label": "Ministry of Defence",
+            "value": "ministry-of-defence"
+          },
+          {
+            "label": "Ministry of Justice",
+            "value": "ministry-of-justice"
+          },
+          {
+            "label": "National security and intelligence",
+            "value": "national-security"
+          },
+          {
+            "label": "Natural England",
+            "value": "natural-england"
+          },
+          {
+            "label": "Northern Ireland Office",
+            "value": "northern-ireland-office"
+          },
+          {
+            "label": "Nuclear Decommissioning Authority",
+            "value": "nuclear-decommissioning-authority"
+          },
+          {
+            "label": "Office for Disability Issues",
+            "value": "office-for-disability-issues"
+          },
+          {
+            "label": "Office for Low Emission Vehicles",
+            "value": "office-for-low-emission-vehicles"
+          },
+          {
+            "label": "Office for National Statistics",
+            "value": "office-for-national-statistics"
+          },
+          {
+            "label": "Office of Rail and Road",
+            "value": "office-of-rail-and-road"
+          },
+          {
+            "label": "Office of the Advocate General for Scotland",
+            "value": "office-of-the-advocate-general-for-scotland"
+          },
+          {
+            "label": "Ofgem",
+            "value": "ofgem"
+          },
+          {
+            "label": "Oil and Gas Authority",
+            "value": "oil-and-gas-authority"
+          },
+          {
+            "label": "Rural Payments Agency",
+            "value": "rural-payments-agency"
+          },
+          {
+            "label": "Scotland Office",
+            "value": "scotland-office"
+          },
+          {
+            "label": "Sport England",
+            "value": "sport-england"
+          },
+          {
+            "label": "The Shareholder Executive",
+            "value": "the-shareholder-executive"
+          },
+          {
+            "label": "The Water Services Regulation Authority ",
+            "value": "the-water-services-regulation-authority"
+          },
+          {
+            "label": "Traffic Commissioners for Great Britain",
+            "value": "traffic-commissioners"
+          },
+          {
+            "label": "Transport Focus",
+            "value": "transport-focus"
+          },
+          {
+            "label": "UK Export Finance",
+            "value": "uk-export-finance"
+          },
+          {
+            "label": "UK Trade & Investment",
+            "value": "uk-trade-investment"
+          },
+          {
+            "label": "UK Visas and Immigration",
+            "value": "uk-visas-and-immigration"
+          },
+          {
+            "label": "Vehicle Certification Agency",
+            "value": "vehicle-certification-agency"
+          },
+          {
+            "label": "Veterans UK",
+            "value": "veterans-uk"
+          },
+          {
+            "label": "Wales Office",
+            "value": "wales-office"
+          }
+        ],
+        "preposition": "from",
+        "name": "Organisation"
+      }
+    ]
+  },
+  "links": {
+    "organisations": [],
+    "related": [],
+    "available_translations": [
+      {
+        "title": "Policies",
+        "base_path": "/government/policies",
+        "api_url": "http://content-store.dev.gov.uk/content/government/policies",
+        "web_url": "http://www.dev.gov.uk/government/policies",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -27,6 +27,9 @@
     "logo_path": {
       "type": "string"
     },
+    "default_order": {
+      "type": "string"
+    },
     "filter": {
       "description": "This is the fixed filter that scopes the finder",
       "type": "object",

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -14,6 +14,9 @@
     "email_signup_enabled": {
       "type": "boolean"
     },
+    "default_order": {
+      "type": "string"
+    },
     "filter": {
       "type": "object",
       "additionalProperties": true


### PR DESCRIPTION
For the Policies Finder, ordering by last update doesn't make sense as
the content being updated within each policy doesn't bubble up to update
the policy itself. This commit adds a `default_order` to the Finders and
Policy schemas along with adding an example to `/finders` of the Policy
Finder which uses this.