### PR TITLE
Allow description to be included in linked item expansion

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -227,6 +227,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -218,6 +218,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -98,6 +98,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -89,6 +89,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -121,6 +121,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -130,6 +130,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -237,6 +237,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -228,6 +228,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -194,6 +194,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -185,6 +185,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -189,6 +189,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -198,6 +198,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -91,6 +91,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -100,6 +100,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -187,6 +187,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -178,6 +178,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -134,6 +134,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -125,6 +125,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -122,6 +122,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -131,6 +131,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -225,6 +225,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -216,6 +216,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -110,6 +110,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -119,6 +119,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -111,6 +111,9 @@
           "title": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "base_path": {
             "type": "string"
           },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -102,6 +102,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "title",
+          "base_path",
+          "locale"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -13,6 +13,9 @@
       "title": {
         "type": "string"
       },
+      "description": {
+        "type": "string"
+      },
       "base_path": {
         "type": "string"
       },

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -4,6 +4,11 @@
   "items": {
     "type": "object",
     "additionalProperties": false,
+    "required": [
+      "title",
+      "base_path",
+      "locale"
+    ],
     "properties": {
       "title": {
         "type": "string"


### PR DESCRIPTION
Necessary to allow rendering mainstream browse pages (eg https://www.gov.uk/browse/benefits) from the content-store.

This also includes an update to make the `title`, `base_path` and `locale` fields mandatory in the expansion.

Once this is merged, I'll raise a follow-up PR on content-store to include this field in the expansion.