### PR TITLE
Add feed_enabled boolean for Finders

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -76,6 +76,9 @@
         "default_order": {
           "type": "string"
         },
+        "feed_enabled": {
+          "type": "boolean"
+        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -107,6 +107,9 @@
         "default_order": {
           "type": "string"
         },
+        "feed_enabled": {
+          "type": "boolean"
+        },
         "filter": {
           "description": "This is the fixed filter that scopes the finder",
           "type": "object",

--- a/formats/finder/frontend/examples/policies_finder.json
+++ b/formats/finder/frontend/examples/policies_finder.json
@@ -10,6 +10,7 @@
   "details": {
     "document_noun": "policy",
     "default_order": "title",
+    "feed_enabled": false,
     "filter": {
       "document_type": "policy"
     },

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -30,6 +30,9 @@
     "default_order": {
       "type": "string"
     },
+    "feed_enabled": {
+      "type": "boolean"
+    },
     "filter": {
       "description": "This is the fixed filter that scopes the finder",
       "type": "object",


### PR DESCRIPTION
For some Finder that don't have results order by when they were last
updated, a feed doesn't really make sense. This commit adds a
feed_enabled boolean to the Finder schema to allow this to be set.