### PR TITLE
Add policy areas in programmes

### DIFF
--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -177,6 +177,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -208,6 +208,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     }

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -83,6 +83,15 @@
           "locale": "en"
         }
       ],
+      "policy_areas":[
+        {
+          "title": "Benefits Reform",
+          "base_path": "/government/policies/benefits-reform",
+          "api_url": "https://www.gov.uk/api/content/government/policies/benefits-reform",
+          "web_url": "https://www.gov.uk/government/policies/benefits-reform",
+          "locale": "en"
+        }
+      ],
       "available_translations":[
          {
             "title": "Unveirsal Credit",

--- a/formats/policy/publisher/links.json
+++ b/formats/policy/publisher/links.json
@@ -21,6 +21,9 @@
     },
     "available_translations": {
       "$ref": "#/definitions/guid_list"
+    },
+    "policy_areas": {
+      "$ref": "#/definitions/guid_list"
     }
   },
   "definitions": {


### PR DESCRIPTION
In order to allow us to infer tagging from programmes to policy areas we
need to send the content ids of the parent policy in a programme.