### PR TITLE
Add some link types to mainstream_browse_page

### DIFF
--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -47,6 +47,15 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "top_level_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "top_level_browse_page": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "second_level_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "related_topics": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -78,6 +78,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "top_level_browse_pages": {
+          "description": "All top-level browse pages",
+          "$ref": "#/definitions/guid_list"
+        },
+        "top_level_browse_page": {
+          "description": "The top-level browse page (for second-level browse pages only).",
+          "$ref": "#/definitions/guid_list"
+        },
+        "second_level_browse_pages": {
+          "description": "All 2nd level browse pages for the top_level_browse_page (or self if this is a top-level browse page)",
+          "$ref": "#/definitions/guid_list"
+        },
         "related_topics": {
           "$ref": "#/definitions/guid_list"
         }

--- a/formats/mainstream_browse_page/publisher/links.json
+++ b/formats/mainstream_browse_page/publisher/links.json
@@ -3,6 +3,18 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "top_level_browse_pages": {
+      "description": "All top-level browse pages",
+      "$ref": "#/definitions/guid_list"
+    },
+    "top_level_browse_page": {
+      "description": "The top-level browse page (for second-level browse pages only).",
+      "$ref": "#/definitions/guid_list"
+    },
+    "second_level_browse_pages": {
+      "description": "All 2nd level browse pages for the top_level_browse_page (or self if this is a top-level browse page)",
+      "$ref": "#/definitions/guid_list"
+    },
     "related_topics": {
       "$ref": "#/definitions/guid_list"
     }


### PR DESCRIPTION
Needed to support rendering mainstream browse pages (eg
https://www.gov.uk/browse/benefits) from the content-store.

/cc @rboulton 