### PR TITLE
Add curated links to mainstream browse pages

### DIFF
--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -41,6 +41,28 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "contents"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "contents": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "links": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -72,6 +72,28 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "contents"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "contents": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "links": {

--- a/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
@@ -1,0 +1,31 @@
+{
+    "base_path": "/browse/benefits/entitlement-with-list",
+    "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
+    "details": {},
+    "format": "mainstream_browse_page",
+    "details": {
+      "groups": [
+        {
+          "name": "Fraud",
+          "contents": [
+            "https://www.gov.uk/benefit-fraud",
+            "https://www.gov.uk/national-benefit-fraud-hotline",
+            "https://www.gov.uk/benefit-integrity-centres"
+          ]
+        },
+        {
+          "name": "Complaints",
+          "contents": [
+            "https://www.gov.uk/complain-debt-management",
+            "https://www.gov.uk/complain-independent-case-examiner"
+          ]
+        }
+      ]
+    },
+    "links": {},
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Benefits entitlement",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/mainstream_browse_page/publisher/details.json
+++ b/formats/mainstream_browse_page/publisher/details.json
@@ -3,5 +3,27 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "contents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Some mainstream browse pages will be getting curated lists of links, instead of a flat list.

This commit adds an optional `groups` array to the `mainstream_browse_page` schema. Specification for this is copied from the `topic` schema.

FAO @rboulton 

Trello: https://trello.com/c/dsgpdVKG