### PR TITLE
Add `beta` attribute to topic 

### DIFF
--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -41,6 +41,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "beta": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -72,6 +72,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "beta": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/formats/topic/frontend/examples/topic-in-beta.json
+++ b/formats/topic/frontend/examples/topic-in-beta.json
@@ -1,0 +1,14 @@
+{
+    "base_path": "/oil-and-gas-beta",
+    "description": "",
+    "details": {
+      "beta": true
+    },
+    "format": "topic",
+    "links": {},
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Oil and gas",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/topic/publisher/details.json
+++ b/formats/topic/publisher/details.json
@@ -3,6 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "beta": {
+      "anyOf": [
+        { "type": "boolean" },
+        { "type": "null" }
+      ]
+    },
     "groups": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Topics can be in beta now, so we need a boolean. It can also be null/empty, since older topics don't have the `beta` label set. Used the `finder` schema as an example ([source](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/finder/publisher/details.json#L11)).

Trello: https://trello.com/c/H9UMp051/139-allow-topic-subtopics-to-be-labelled-as-beta