### PR TITLE
Update archived to be withdrawn

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -135,6 +135,18 @@
             }
           }
         },
+        "withdrawn_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "explanation": {
+              "type": "string"
+            },
+            "withdrawn_at": {
+              "format": "date-time"
+            }
+          }
+        },
         "archive_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -166,6 +166,18 @@
             }
           }
         },
+        "withdrawn_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "explanation": {
+              "type": "string"
+            },
+            "withdrawn_at": {
+              "format": "date-time"
+            }
+          }
+        },
         "archive_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -28,9 +28,9 @@
       "alt_text": "Terence",
       "caption": null
     },
-    "archive_notice": {
-      "explanation": "<div class=\"govspeak\"><p>We’ve archived this case study and published newer <a href=\"https://www.gov.uk/government/collections/work-programme-real-life-stories\">Work Programme real life stories</a>.</p></div>",
-      "archived_at": "2014-08-22T10:29:02+01:00"
+    "withdrawn_notice": {
+      "explanation": "<div class=\"govspeak\"><p>We’ve withdrawn this case study and published newer <a href=\"https://www.gov.uk/government/collections/work-programme-real-life-stories\">Work Programme real life stories</a>.</p></div>",
+      "withdrawn_at": "2014-08-22T10:29:02+01:00"
     }
   },
   "links": {

--- a/formats/case_study/publisher/details.json
+++ b/formats/case_study/publisher/details.json
@@ -87,6 +87,18 @@
         }
       }
     },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
     "archive_notice": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
"archived" documents are now referred to as "withdrawn" in whitehall.
This lets us send withdrawn content to the content store as well as
archived. Once all content has been updated to start sending withdrawn a
further commit will be added to remove archived.