### PR TITLE
Add examples for browse page context links

### DIFF
--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -72,7 +72,7 @@
         "top_level_browse_pages": {
           "$ref": "#/definitions/frontend_links"
         },
-        "top_level_browse_page": {
+        "active_top_level_browse_page": {
           "$ref": "#/definitions/frontend_links"
         },
         "second_level_browse_pages": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -104,7 +104,7 @@
           "description": "All top-level browse pages",
           "$ref": "#/definitions/guid_list"
         },
-        "top_level_browse_page": {
+        "active_top_level_browse_page": {
           "description": "The top-level browse page (for second-level browse pages only).",
           "$ref": "#/definitions/guid_list"
         },

--- a/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
@@ -23,7 +23,7 @@
       ]
     },
     "links": {
-      "top_level_browse_page": [
+      "active_top_level_browse_page": [
         {
           "title": "Benefits",
           "base_path": "/browse/benefits",

--- a/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
@@ -22,7 +22,70 @@
         }
       ]
     },
-    "links": {},
+    "links": {
+      "top_level_browse_page": [
+        {
+          "title": "Benefits",
+          "base_path": "/browse/benefits",
+          "description": "Includes tax credits, eligibility and appeals",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits",
+          "web_url": "https://www.gov.uk/browse/benefits",
+          "locale": "en"
+        }
+      ],
+      "top_level_browse_pages": [
+        {
+          "title": "Benefits",
+          "base_path": "/browse/benefits",
+          "description": "Includes tax credits, eligibility and appeals",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits",
+          "web_url": "https://www.gov.uk/browse/benefits",
+          "locale": "en"
+        },
+        {
+          "title": "Births, deaths, marriages and care",
+          "base_path": "/browse/births-deaths-marriages",
+          "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+          "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+          "web_url": "https://www.gov.uk/browse/births-deaths-marriages",
+          "locale": "en"
+        },
+        {
+          "title": "Business and self-employed",
+          "base_path": "/browse/business",
+          "description": "Information about starting up and running a business in the UK, including help if you're self employed or a sole trader.",
+          "api_url": "https://www.gov.uk/api/content/browse/business",
+          "web_url": "https://www.gov.uk/browse/business",
+          "locale": "en"
+        }
+      ],
+      "second_level_browse_pages": [
+        {
+          "title": "Benefits entitlement",
+          "base_path": "/browse/benefits/entitlement",
+          "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/entitlement",
+          "web_url": "https://www.gov.uk/browse/benefits/entitlement",
+          "locale": "en"
+        },
+        {
+          "title": "Benefits for families",
+          "base_path": "/browse/benefits/families",
+          "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/families",
+          "web_url": "https://www.gov.uk/browse/benefits/families",
+          "locale": "en"
+        },
+        {
+          "title": "Carers and disability benefits",
+          "base_path": "/browse/benefits/disability",
+          "description": "Includes Disability Living Allowance, Carer's Allowance and Employment and Support Allowance",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/disability",
+          "web_url": "https://www.gov.uk/browse/benefits/disability",
+          "locale": "en"
+        }
+      ]
+    },
     "locale": "en",
     "need_ids": [],
     "public_updated_at": "2015-04-20T15:46:10.000+00:00",

--- a/formats/mainstream_browse_page/frontend/examples/level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page.json
@@ -3,7 +3,70 @@
     "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
     "details": {},
     "format": "mainstream_browse_page",
-    "links": {},
+    "links": {
+      "top_level_browse_page": [
+        {
+          "title": "Benefits",
+          "base_path": "/browse/benefits",
+          "description": "Includes tax credits, eligibility and appeals",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits",
+          "web_url": "https://www.gov.uk/browse/benefits",
+          "locale": "en"
+        }
+      ],
+      "top_level_browse_pages": [
+        {
+          "title": "Benefits",
+          "base_path": "/browse/benefits",
+          "description": "Includes tax credits, eligibility and appeals",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits",
+          "web_url": "https://www.gov.uk/browse/benefits",
+          "locale": "en"
+        },
+        {
+          "title": "Births, deaths, marriages and care",
+          "base_path": "/browse/births-deaths-marriages",
+          "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+          "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+          "web_url": "https://www.gov.uk/browse/births-deaths-marriages",
+          "locale": "en"
+        },
+        {
+          "title": "Business and self-employed",
+          "base_path": "/browse/business",
+          "description": "Information about starting up and running a business in the UK, including help if you're self employed or a sole trader.",
+          "api_url": "https://www.gov.uk/api/content/browse/business",
+          "web_url": "https://www.gov.uk/browse/business",
+          "locale": "en"
+        }
+      ],
+      "second_level_browse_pages": [
+        {
+          "title": "Benefits entitlement",
+          "base_path": "/browse/benefits/entitlement",
+          "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/entitlement",
+          "web_url": "https://www.gov.uk/browse/benefits/entitlement",
+          "locale": "en"
+        },
+        {
+          "title": "Benefits for families",
+          "base_path": "/browse/benefits/families",
+          "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/families",
+          "web_url": "https://www.gov.uk/browse/benefits/families",
+          "locale": "en"
+        },
+        {
+          "title": "Carers and disability benefits",
+          "base_path": "/browse/benefits/disability",
+          "description": "Includes Disability Living Allowance, Carer's Allowance and Employment and Support Allowance",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/disability",
+          "web_url": "https://www.gov.uk/browse/benefits/disability",
+          "locale": "en"
+        }
+      ]
+    },
     "locale": "en",
     "need_ids": [],
     "public_updated_at": "2015-04-20T15:46:10.000+00:00",

--- a/formats/mainstream_browse_page/frontend/examples/level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page.json
@@ -4,7 +4,7 @@
     "details": {},
     "format": "mainstream_browse_page",
     "links": {
-      "top_level_browse_page": [
+      "active_top_level_browse_page": [
         {
           "title": "Benefits",
           "base_path": "/browse/benefits",

--- a/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
@@ -13,7 +13,7 @@
           "locale": "en"
         }
       ],
-      "top_level_browse_page": [
+      "active_top_level_browse_page": [
         {
           "title": "Benefits",
           "base_path": "/browse/benefits",

--- a/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
@@ -12,6 +12,68 @@
           "web_url": "https://www.gov.uk/benefits/universal-credit",
           "locale": "en"
         }
+      ],
+      "top_level_browse_page": [
+        {
+          "title": "Benefits",
+          "base_path": "/browse/benefits",
+          "description": "Includes tax credits, eligibility and appeals",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits",
+          "web_url": "https://www.gov.uk/browse/benefits",
+          "locale": "en"
+        }
+      ],
+      "top_level_browse_pages": [
+        {
+          "title": "Benefits",
+          "base_path": "/browse/benefits",
+          "description": "Includes tax credits, eligibility and appeals",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits",
+          "web_url": "https://www.gov.uk/browse/benefits",
+          "locale": "en"
+        },
+        {
+          "title": "Births, deaths, marriages and care",
+          "base_path": "/browse/births-deaths-marriages",
+          "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+          "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+          "web_url": "https://www.gov.uk/browse/births-deaths-marriages",
+          "locale": "en"
+        },
+        {
+          "title": "Business and self-employed",
+          "base_path": "/browse/business",
+          "description": "Information about starting up and running a business in the UK, including help if you're self employed or a sole trader.",
+          "api_url": "https://www.gov.uk/api/content/browse/business",
+          "web_url": "https://www.gov.uk/browse/business",
+          "locale": "en"
+        }
+      ],
+      "second_level_browse_pages": [
+        {
+          "title": "Benefits entitlement",
+          "base_path": "/browse/benefits/entitlement",
+          "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/entitlement",
+          "web_url": "https://www.gov.uk/browse/benefits/entitlement",
+          "locale": "en"
+        },
+        {
+          "title": "Benefits for families",
+          "base_path": "/browse/benefits/families",
+          "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/families",
+          "web_url": "https://www.gov.uk/browse/benefits/families",
+          "locale": "en"
+        },
+        {
+          "title": "Carers and disability benefits",
+          "base_path": "/browse/benefits/disability",
+          "description": "Includes Disability Living Allowance, Carer's Allowance and Employment and Support Allowance",
+          "api_url": "https://www.gov.uk/api/content/browse/benefits/disability",
+          "web_url": "https://www.gov.uk/browse/benefits/disability",
+          "locale": "en"
+        }
       ]
     },
     "locale": "en",

--- a/formats/mainstream_browse_page/frontend/examples/root_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/root_page.json
@@ -1,6 +1,6 @@
 {
-    "base_path": "/browse/benefits",
-    "description": "Includes tax credits, eligibility and appeals",
+    "base_path": "/browse",
+    "description": "Almost everything on GOV.UK.",
     "details": {},
     "format": "mainstream_browse_page",
     "links": {
@@ -29,37 +29,11 @@
           "web_url": "https://www.gov.uk/browse/business",
           "locale": "en"
         }
-      ],
-      "second_level_browse_pages": [
-        {
-          "title": "Benefits entitlement",
-          "base_path": "/browse/benefits/entitlement",
-          "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
-          "api_url": "https://www.gov.uk/api/content/browse/benefits/entitlement",
-          "web_url": "https://www.gov.uk/browse/benefits/entitlement",
-          "locale": "en"
-        },
-        {
-          "title": "Benefits for families",
-          "base_path": "/browse/benefits/families",
-          "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
-          "api_url": "https://www.gov.uk/api/content/browse/benefits/families",
-          "web_url": "https://www.gov.uk/browse/benefits/families",
-          "locale": "en"
-        },
-        {
-          "title": "Carers and disability benefits",
-          "base_path": "/browse/benefits/disability",
-          "description": "Includes Disability Living Allowance, Carer's Allowance and Employment and Support Allowance",
-          "api_url": "https://www.gov.uk/api/content/browse/benefits/disability",
-          "web_url": "https://www.gov.uk/browse/benefits/disability",
-          "locale": "en"
-        }
       ]
     },
     "locale": "en",
     "need_ids": [],
     "public_updated_at": "2015-04-20T15:46:10.000+00:00",
-    "title": "Benefits",
+    "title": "Browse",
     "updated_at": "2015-04-20T15:50:11.000+00:00"
 }

--- a/formats/mainstream_browse_page/publisher/links.json
+++ b/formats/mainstream_browse_page/publisher/links.json
@@ -7,7 +7,7 @@
       "description": "All top-level browse pages",
       "$ref": "#/definitions/guid_list"
     },
-    "top_level_browse_page": {
+    "active_top_level_browse_page": {
       "description": "The top-level browse page (for second-level browse pages only).",
       "$ref": "#/definitions/guid_list"
     },


### PR DESCRIPTION
Browse pages need to be able to render themselves, therefore we're adding the links to sibling, parent and child pages to the schema.