### PR TITLE
Correct comments about browse page links fields

### DIFF
--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -105,11 +105,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "active_top_level_browse_page": {
-          "description": "The top-level browse page (for second-level browse pages only).",
+          "description": "The top-level browse page which is active",
           "$ref": "#/definitions/guid_list"
         },
         "second_level_browse_pages": {
-          "description": "All 2nd level browse pages for the top_level_browse_page (or self if this is a top-level browse page)",
+          "description": "All 2nd level browse pages under active_top_level_browse_page",
           "$ref": "#/definitions/guid_list"
         },
         "related_topics": {

--- a/formats/mainstream_browse_page/publisher/links.json
+++ b/formats/mainstream_browse_page/publisher/links.json
@@ -8,11 +8,11 @@
       "$ref": "#/definitions/guid_list"
     },
     "active_top_level_browse_page": {
-      "description": "The top-level browse page (for second-level browse pages only).",
+      "description": "The top-level browse page which is active",
       "$ref": "#/definitions/guid_list"
     },
     "second_level_browse_pages": {
-      "description": "All 2nd level browse pages for the top_level_browse_page (or self if this is a top-level browse page)",
+      "description": "All 2nd level browse pages under active_top_level_browse_page",
       "$ref": "#/definitions/guid_list"
     },
     "related_topics": {


### PR DESCRIPTION
We've changed the semantics of these a bit, so the descriptions needed
to be updated.  The main change is that we're always going to send
active_top_level_browse_page, except for on the root browse page.