### PR TITLE
Add filter facets for type and org to policy example

### DIFF
--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -40,18 +40,20 @@
         },
         {
           "key": "organisations",
+          "name": "Organisations",
           "short_name": "From",
           "type": "text",
           "display_as_result_metadata": true,
-          "filterable": false
+          "filterable": true
         },
         {
-          "key": "display_type",
+          "key": "detailed_format",
+          "name": "Type",
           "short_name": "Type",
           "type": "text",
           "display_as_result_metadata": true,
-          "filterable": false
-        }
+          "filterable": true
+      }
       ]
    },
    "links": {


### PR DESCRIPTION
These are being included by policy-publisher when it published
policy content items.

Related: https://github.com/alphagov/policy-publisher/pull/82