### PR TITLE
Add support for access limiting

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -36,6 +36,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -67,6 +67,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -37,6 +37,21 @@
         "type": "string"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -68,6 +68,21 @@
         "$ref": "#/definitions/route"
       }
     },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/docs/suggested-workflows.md
+++ b/docs/suggested-workflows.md
@@ -15,7 +15,7 @@
 
 ## Adding a new field
 
-Follow the General worklow described above. You are now free to add support for the field to apps. If you are adding a mandatory field you will need to additionally:
+Follow the General workflow described above. You are now free to add support for the field to apps. If you are adding a mandatory field you will need to additionally:
 
 * deploy the publishing app with changes to always populate the field
 * populate the field in any records inside content-store

--- a/formats/case_study/frontend/examples/access_limited.json
+++ b/formats/case_study/frontend/examples/access_limited.json
@@ -1,0 +1,84 @@
+{
+  "base_path": "/government/case-studies/2013-elections-in-swaziland",
+  "title": "2013 elections in Swaziland",
+  "description": "A case study on the September 2013 elections in Swaziland from the 2013 Human Rights and Democracy Report. ",
+  "format": "case_study",
+  "need_ids": [],
+  "access_limited": {
+    "users": [
+      "M6GdNZggrbGiJrLjMSbKqA",
+      "f17250b0-7540-0131-f036-005056030202"
+    ]
+  },
+  "locale": "en",
+  "updated_at": "2015-06-08T12:52:43.785Z",
+  "public_updated_at": "2014-04-10T09:04:53.000+00:00",
+  "details": {
+    "change_note": "",
+    "tags": {
+      "browse_pages": [],
+      "policies": [],
+      "topics": []
+    },
+    "body": "<div class=\"govspeak\"><p>The September elections in Swaziland attracted international attention. Two high-profile reports were released before the elections, which criticised the governance and human rights picture in the country: Chatham House\u2019s \u201cSwaziland: Southern Africa\u2019s Forgotten Crisis\u201d and Freedom House\u2019s \u201cSwaziland: a Failed Feudal State\u201d. Election observers confirmed that the elections passed peacefully but many, including the Commonwealth and the African Union, were critical of aspects of the elections, particularly the ban on participation by political parties. Local chiefs also had influence over the nomination process for candidates.  Our concerns remain over the refusal by the government of Swaziland to engage in a genuine process of national dialogue about the role of political parties. This is something we will continue to raise with the government of Swaziland and international partners.  </p>\n\n<p>The Commonwealth was actively engaged in Swaziland through the Secretary General\u2019s Adviser on Swaziland. The Commonwealth EOM report on the September elections noted that the elections fell short of meeting Swaziland\u2019s key international obligations for democratic elections, and recommended revisiting the 2005 constitution to ensure that Swaziland\u2019s commitment to political pluralism is clear.  We maintain close contact with the Commonwealth team in-country and in the UK.</p>\n\n<p>The September elections also highlighted continuing gender inequality in Swaziland. Only one woman was elected in 55 constituencies. The King\u2019s nomination of just three additional women to the lower chamber of parliament leaves female participation in parliament short of the 30% target. Constitutional provisions to increase the number of women when this target has not been met have so far been ignored. The British High Commission in South Africa covers our relations with Swaziland, and continues to work with international partners including the EU, Commonwealth and the South African Development Community to exert international pressure for change. </p>\n\n<h4 id=\"this-case-study-is-part-of-the-2013-human-rights-and-democracy-reporthttpswwwgovukgovernmentpublicationshuman-rights-and-democracy-report-2013human-rights-and-democracy-report-2013\">This case study is part of the <a rel=\"external\" href=\"https://www.gov.uk/government/publications/human-rights-and-democracy-report-2013/human-rights-and-democracy-report-2013\">2013 Human Rights and Democracy Report</a>.</h4>\n\n<div class=\"call-to-action\">\n<p><a rel=\"external\" href=\"http://hrdreport.fco.gov.uk/2013-elections-in-swaziland\">Submit a question or comment on the report</a></p>\n</div>\n\n</div>",
+    "format_display_type": "case_study",
+    "first_public_at": "2014-04-10T10:04:53.000+01:00",
+    "change_history": [
+      {
+        "public_timestamp": "2014-04-10T10:04:53.000+01:00",
+        "note": "First published."
+      }
+    ],
+    "image": {
+      "url": "http://static.dev.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/102/s300_Main-building-gov.uk.jpg",
+      "alt_text": "placeholder",
+      "caption": ""
+    }
+  },
+  "links": {
+    "lead_organisations": [
+      {
+        "title": "Foreign & Commonwealth Office",
+        "base_path": "/government/organisations/foreign-commonwealth-office",
+        "description": "",
+        "api_url": "https://www.gov.uk/api/government/organisations/foreign-commonwealth-office",
+        "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
+        "locale": "en"
+      }
+    ],
+    "related_policies": [
+      {
+        "title": "Promoting human rights internationally",
+        "base_path": "/government/policies/promoting-human-rights-internationally",
+        "description": "Promoting human rights, and political and economic freedom around the world.",
+        "api_url": "https://www.gov.uk/api/government/policies/promoting-human-rights-internationally",
+        "web_url": "https://www.gov.uk/government/policies/promoting-human-rights-internationally",
+        "locale": "en"
+      }
+    ],
+    "supporting_organisations": [],
+    "document_collections": [],
+    "world_locations": [
+      {
+        "title": "Swaziland",
+        "base_path": "/government/world/swaziland",
+        "description": "",
+        "api_url": "https://www.gov.uk/api/government/world/swaziland",
+        "web_url": "https://www.gov.uk/government/world/swaziland",
+        "locale": "en"
+      }
+    ],
+    "worldwide_organisations": [],
+    "worldwide_priorities": [],
+    "available_translations": [
+      {
+        "title": "2013 elections in Swaziland",
+        "base_path": "/government/case-studies/2013-elections-in-swaziland",
+        "description": "A case study on the September 2013 elections in Swaziland from the 2013 Human Rights and Democracy Report. ",
+        "api_url": "https://www.gov.uk/api/government/case-studies/2013-elections-in-swaziland",
+        "web_url": "https://www.gov.uk/government/case-studies/2013-elections-in-swaziland",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -60,6 +60,19 @@
       "items": {
         "$ref": "#/definitions/route"
       }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [ "users" ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
Adds an `access_limited` object to the metadata, which appears as the top level in all generated schemas. This currently consists of a single value, `users`, which is a list of user IDs.

(Note that user IDs generated from signon are inconsistent; some are GUIDs and some are what looks like hashed strings, so there is no attempt to enforce a format here.)

Also adds an example of access limiting in a case study.