### PR TITLE
Enforce that singular link types are singular.

### DIFF
--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -121,7 +121,8 @@
         },
         "active_top_level_browse_page": {
           "description": "The top-level browse page which is active",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "second_level_browse_pages": {
           "description": "All 2nd level browse pages under active_top_level_browse_page",

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -127,7 +127,8 @@
       "properties": {
         "parent": {
           "description": "The parent topic",
-          "$ref": "#/definitions/guid_list"
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         }
       }
     }

--- a/formats/mainstream_browse_page/publisher/links.json
+++ b/formats/mainstream_browse_page/publisher/links.json
@@ -9,7 +9,8 @@
     },
     "active_top_level_browse_page": {
       "description": "The top-level browse page which is active",
-      "$ref": "#/definitions/guid_list"
+      "$ref": "#/definitions/guid_list",
+      "maxItems": 1
     },
     "second_level_browse_pages": {
       "description": "All 2nd level browse pages under active_top_level_browse_page",

--- a/formats/topic/publisher/links.json
+++ b/formats/topic/publisher/links.json
@@ -5,7 +5,8 @@
   "properties": {
     "parent": {
       "description": "The parent topic",
-      "$ref": "#/definitions/guid_list"
+      "$ref": "#/definitions/guid_list",
+      "maxItems": 1
     }
   },
   "definitions": {


### PR DESCRIPTION
Both the mainstream_browse_page active_top_level_browse_page, and the
topic parent link types are singuler types, and therefore should never
have more than one item in them.  This adds this restriction to the
schema.