### PR TITLE
Update topic examples with new namespace

### DIFF
--- a/formats/topic/frontend/examples/curated_subtopic.json
+++ b/formats/topic/frontend/examples/curated_subtopic.json
@@ -1,5 +1,5 @@
 {
-    "base_path": "/oil-and-gas/offshore",
+    "base_path": "/topic/oil-and-gas/offshore",
     "description": "A page about offshore oil and gas",
     "details": {
       "groups": [
@@ -22,10 +22,10 @@
     "links": {
       "parent": [
         {
-          "base_path": "/oil-and-gas",
+          "base_path": "/topic/oil-and-gas",
           "title": "Oil and gas",
-          "api_url": "https://www.gov.uk/api/content/oil-and-gas",
-          "web_url": "https://www.gov.uk/oil-and-gas",
+          "api_url": "https://www.gov.uk/api/content/topic/oil-and-gas",
+          "web_url": "https://www.gov.uk/topic/oil-and-gas",
           "locale": "en"
         }
       ]

--- a/formats/topic/frontend/examples/topic-in-beta.json
+++ b/formats/topic/frontend/examples/topic-in-beta.json
@@ -1,5 +1,5 @@
 {
-    "base_path": "/oil-and-gas-beta",
+    "base_path": "/topic/oil-and-gas-beta",
     "description": "",
     "details": {
       "beta": true

--- a/formats/topic/frontend/examples/topic.json
+++ b/formats/topic/frontend/examples/topic.json
@@ -1,22 +1,22 @@
 {
-    "base_path": "/oil-and-gas",
+    "base_path": "/topic/oil-and-gas",
     "description": "",
     "details": {},
     "format": "topic",
     "links": {
       "children": [
         {
-          "base_path": "/oil-and-gas/fields-and-wells",
+          "base_path": "/topic/oil-and-gas/fields-and-wells",
           "title": "Fields and wells",
-          "api_url": "https://www.gov.uk/api/content/oil-and-gas/fields-and-wells",
-          "web_url": "https://www.gov.uk/oil-and-gas/fields-and-wells",
+          "api_url": "https://www.gov.uk/api/content/topic/oil-and-gas/fields-and-wells",
+          "web_url": "https://www.gov.uk/topic/oil-and-gas/fields-and-wells",
           "locale": "en"
         },
         {
-          "base_path": "/oil-and-gas/licensing",
+          "base_path": "/topic/oil-and-gas/licensing",
           "title": "Licensing",
-          "api_url": "https://www.gov.uk/api/content/oil-and-gas/licensing",
-          "web_url": "https://www.gov.uk/oil-and-gas/licensing",
+          "api_url": "https://www.gov.uk/api/content/topic/oil-and-gas/licensing",
+          "web_url": "https://www.gov.uk/topic/oil-and-gas/licensing",
           "locale": "en"
         }
       ]

--- a/formats/topic/frontend/examples/uncurated_subtopic.json
+++ b/formats/topic/frontend/examples/uncurated_subtopic.json
@@ -1,5 +1,5 @@
 {
-    "base_path": "/oil-and-gas/licensing",
+    "base_path": "/topic/oil-and-gas/licensing",
     "description": "A page about oil and gas licensing",
     "details": {
     },
@@ -7,10 +7,10 @@
     "links": {
       "parent": [
         {
-          "base_path": "/oil-and-gas",
+          "base_path": "/topic/oil-and-gas",
           "title": "Oil and gas",
-          "api_url": "https://www.gov.uk/api/content/oil-and-gas",
-          "web_url": "https://www.gov.uk/oil-and-gas",
+          "api_url": "https://www.gov.uk/api/content/topic/oil-and-gas",
+          "web_url": "https://www.gov.uk/topic/oil-and-gas",
           "locale": "en"
         }
       ]


### PR DESCRIPTION
We've moved topics to the /topic namespace. This commit updates the examples so they match the real world.