### PR TITLE
Add documents_per_page to Finders

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -70,6 +70,9 @@
           "type": "string",
           "additionalProperties": false
         },
+        "default_documents_per_page": {
+          "type": "integer"
+        },
         "logo_path": {
           "type": "string"
         },

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -116,6 +116,9 @@
           "type": "string",
           "additionalProperties": false
         },
+        "default_documents_per_page": {
+          "type": "integer"
+        },
         "logo_path": {
           "type": "string"
         },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -49,6 +49,9 @@
         "document_noun": {
           "type": "string"
         },
+        "default_documents_per_page": {
+          "type": "integer"
+        },
         "email_signup_enabled": {
           "type": "boolean"
         },

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -95,6 +95,9 @@
         "document_noun": {
           "type": "string"
         },
+        "default_documents_per_page": {
+          "type": "integer"
+        },
         "email_signup_enabled": {
           "type": "boolean"
         },

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -24,6 +24,9 @@
       "type": "string",
       "additionalProperties": false
     },
+    "default_documents_per_page": {
+      "type": "integer"
+    },
     "logo_path": {
       "type": "string"
     },

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -9,6 +9,7 @@
    "public_updated_at": "2015-03-10T11:55:11.066+00:00",
    "details": {
       "document_noun": "document",
+      "default_documents_per_page": 10,
       "email_signup_enabled": false,
       "filter": {
          "policies": [

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -11,6 +11,9 @@
     "document_noun": {
       "type": "string"
     },
+    "default_documents_per_page": {
+      "type": "integer"
+    },
     "email_signup_enabled": {
       "type": "boolean"
     },


### PR DESCRIPTION
As we are introducing Pagination to Finders we need to be able to
specify the amount per page of the results. This commit adds it to both
the Finder and Policy formats and adds it to the Policy Area example.