### PR TITLE
Add child ordering to mainstream browse page

### DIFF
--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -41,6 +41,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "2nd_level_ordering": {
+          "enum": [
+            "alphabetical",
+            "curated"
+          ]
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -87,6 +87,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "2nd_level_ordering": {
+          "enum": [
+            "alphabetical",
+            "curated"
+          ]
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/formats/mainstream_browse_page/frontend/examples/top_level_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/top_level_page.json
@@ -1,7 +1,9 @@
 {
     "base_path": "/browse/benefits",
     "description": "Includes tax credits, eligibility and appeals",
-    "details": {},
+    "details": {
+      "2nd_level_ordering": "alphabetical"
+    },
     "format": "mainstream_browse_page",
     "links": {
       "top_level_browse_pages": [

--- a/formats/mainstream_browse_page/frontend/examples/top_level_page_with_child_pages_in_curated_order.json
+++ b/formats/mainstream_browse_page/frontend/examples/top_level_page_with_child_pages_in_curated_order.json
@@ -1,0 +1,67 @@
+{
+    "base_path": "/browse/visas-immigration",
+    "description": "Visas, settlement, asylum and sponsorship",
+    "details": {
+      "2nd_level_ordering": "curated"
+    },
+    "format": "mainstream_browse_page",
+    "links": {
+      "top_level_browse_pages": [
+        {
+          "title": "Money and tax",
+          "base_path": "/browse/tax",
+          "description": "Includes VAT, debt and inheritance tax",
+          "api_url": "https://www.gov.uk/api/content/browse/tax",
+          "web_url": "https://www.gov.uk/browse/tax",
+          "locale": "en"
+        },
+        {
+          "title": "Passports, travel and living abroad",
+          "base_path": "/browse/abroad",
+          "description": "Includes renewing passports and travel advice by country",
+          "api_url": "https://www.gov.uk/api/content/browse/abroad",
+          "web_url": "https://www.gov.uk/browse/abroad",
+          "locale": "en"
+        },
+        {
+          "title": "Visas and immigration",
+          "base_path": "/browse/visas-immigration",
+          "description": "Visas, settlement, asylum and sponsorship",
+          "api_url": "https://www.gov.uk/api/content/browse/visas-immigration",
+          "web_url": "https://www.gov.uk/browse/visas-immigration",
+          "locale": "en"
+        }
+      ],
+      "second_level_browse_pages": [
+        {
+          "title": "Work visas",
+          "base_path": "/browse/visas-immigration/work-visas",
+          "description": "Paid and voluntary work visas (eg Tier 1, Tier 2, Tier 5)",
+          "api_url": "https://www.gov.uk/api/content/browse/visas-immigration/work-visas",
+          "web_url": "https://www.gov.uk/browse/visas-immigration/work-visas",
+          "locale": "en"
+        },
+        {
+          "title": "Asylum",
+          "base_path": "/browse/visas-immigration/asylum",
+          "description": "Claiming asylum as a refugee, the asylum process and support",
+          "api_url": "https://www.gov.uk/api/content/browse/visas-immigration/asylum",
+          "web_url": "https://www.gov.uk/browse/visas-immigration/asylum",
+          "locale": "en"
+        },
+        {
+          "title": "Transit visas",
+          "base_path": "/browse/visas-immigration/transit-visas",
+          "description": "In transit through the UK: airside, landside or the common travel area",
+          "api_url": "https://www.gov.uk/api/content/browse/visas-immigration/transit-visas",
+          "web_url": "https://www.gov.uk/browse/visas-immigration/transit-visas",
+          "locale": "en"
+        }
+      ]
+    },
+    "locale": "en",
+    "need_ids": [],
+    "public_updated_at": "2015-04-20T15:46:10.000+00:00",
+    "title": "Benefits",
+    "updated_at": "2015-04-20T15:50:11.000+00:00"
+}

--- a/formats/mainstream_browse_page/publisher/details.json
+++ b/formats/mainstream_browse_page/publisher/details.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "2nd_level_ordering": {
+      "enum": [ "alphabetical", "curated" ]
+    },
     "groups": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Currently, all 2nd level mainstream browse columns have the label "A to Z" on them. When a page has been curated, we shouldn't display this label, because it won't be true.
Therefore, collections,  needs to know the child ordering type for a top level mainstream browse pages in order to display related labels.

https://trello.com/c/bcTrheDZ/244-don-t-show-a-to-z-on-mainstream-browse-columns-which-aren-t-in-alphabetical-order