### PR TITLE
Add policies filter to finder

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -92,6 +92,12 @@
               "items": {
                 "type": "string"
               }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -138,6 +138,12 @@
               "items": {
                 "type": "string"
               }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -46,6 +46,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
As we want to create a Finder which is a firehose of all policy tagged
content on GOVUK, we need to add `policies` to the `filter` hash within
the Finder.