### PR TITLE
Base paths need a leading slash.

### DIFF
--- a/formats/specialist_document/frontend/examples/aaib-reports.json
+++ b/formats/specialist_document/frontend/examples/aaib-reports.json
@@ -42,7 +42,7 @@
 			}
 		]
 	},
-	"base_path" : "aaib-reports/aaib-investigation-to-rotorsport-uk-calidus-g-pcpc",
+	"base_path" : "/aaib-reports/aaib-investigation-to-rotorsport-uk-calidus-g-pcpc",
 	"description" : "Overturned after rotor struck tailplane during preparation for takeoff, Damyns Hall Aerodrome, Essex, 8 April 2015.",
 	"title" : "AAIB investigation to Rotorsport UK Calidus, G-PCPC\t",
 	"updated_at" : "2015-07-09T08:54:30+00:00"

--- a/formats/specialist_document/frontend/examples/cma-cases.json
+++ b/formats/specialist_document/frontend/examples/cma-cases.json
@@ -1,7 +1,7 @@
 {
 	"format": "specialist_document",
 	"locale": "en",
-	"base_path" : "cma-cases/richemont-yoox-net-a-porter-merger-inquiry",
+	"base_path" : "/cma-cases/richemont-yoox-net-a-porter-merger-inquiry",
 	"title" : "Richemont / Yoox / Net-A-Porter merger inquiry",
 	"description" : "The CMA is investigating the anticipated acquisition relating to Compagnie Financière Richemont S.A., Yoox S.p.A and The Net-A-Porter Group Limited. ",
 	"details" : {

--- a/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
@@ -1,7 +1,7 @@
 {
 	"format": "specialist_document",
 	"locale": "en",
-	"base_path" : "countryside-stewardship-grants/nectar-flower-mix-ab1",
+	"base_path" : "/countryside-stewardship-grants/nectar-flower-mix-ab1",
 	"title" : "Nectar flower mix (AB1)",
 	"description" : "Find out about eligibility and requirements for the nectar flower mix option.\r\n",
 	"details" : {

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -1,7 +1,7 @@
 {
 	"format": "specialist_document",
 	"locale": "en",
-	"base_path" : "drug-device-alerts/transwarmer-infant-transport-mattress-novaplus-transwarmer-infant-heat-therapy-mattress-with-warmgel-infant-heel-warmer-risk-of-serious-burn",
+	"base_path" : "/drug-device-alerts/transwarmer-infant-transport-mattress-novaplus-transwarmer-infant-heat-therapy-mattress-with-warmgel-infant-heel-warmer-risk-of-serious-burn",
 	"title" : "TransWarmer infant transport mattress,  NovaPlus TransWarmer infant heat therapy mattress with WarmGel, infant heel warmer  - risk of serious burn",
 	"description" : "(CooperSurgical under different brand names) Risk of serious burn if device is used past its expiry date (MDA/2015/025)",
 	"details" : {

--- a/formats/specialist_document/frontend/examples/drug-safety-update.json
+++ b/formats/specialist_document/frontend/examples/drug-safety-update.json
@@ -34,7 +34,7 @@
 			}
 		]
 	},
-	"base_path" : "drug-safety-update/sglt2-inhibitors-canagliflozin-dapagliflozin-empagliflozin-risk-of-diabetic-ketoacidosis",
+	"base_path" : "/drug-safety-update/sglt2-inhibitors-canagliflozin-dapagliflozin-empagliflozin-risk-of-diabetic-ketoacidosis",
 	"description" : "Test for raised ketones in patients with acidosis symptoms, even if plasma glucose levels are near-normal.",
 	"title" : "SGLT2 inhibitors (canagliflozin, dapagliflozin, empagliflozin): risk of diabetic ketoacidosis",
 	"public_updated_at" : "2015-07-08T14:08:17+00:00"

--- a/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
+++ b/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
@@ -100,7 +100,7 @@
 			}
 		]
 	},
-	"base_path" : "european-structural-investment-funds/access-to-employment-tees-valley",
+	"base_path" : "/european-structural-investment-funds/access-to-employment-tees-valley",
 	"description" : "To deliver Personalised Education, Employment and Enterprise Pathways – for young people who are NEET (15-29) across the Tees Valley LEP area.",
 	"title" : "CLOSED Access to employment: Tees Valley",
 	"public_updated_at" : "2015-06-01T08:26:26+00:00"

--- a/formats/specialist_document/frontend/examples/international-development-funding.json
+++ b/formats/specialist_document/frontend/examples/international-development-funding.json
@@ -83,7 +83,7 @@
 			}
 		]
 	},
-	"base_path" : "international-development-funding/forest-governance-markets-and-climate-2015-grants-round",
+	"base_path" : "/international-development-funding/forest-governance-markets-and-climate-2015-grants-round",
 	"description" : "FGMC will provide a new round of grants for projects that support governance and market reforms that reduce the illegal use of forest resources and benefit poor people.",
 	"title" : "Forest Governance, Markets and Climate 2015 Grants Round",
 	"public_updated_at" : "2015-07-09T12:00:46+00:00"

--- a/formats/specialist_document/frontend/examples/maib-reports.json
+++ b/formats/specialist_document/frontend/examples/maib-reports.json
@@ -39,7 +39,7 @@
 			}
 		]
 	},
-	"base_path" : "maib-reports/collision-between-chemical-tanker-orakai-and-beam-trawler-margriet",
+	"base_path" : "/maib-reports/collision-between-chemical-tanker-orakai-and-beam-trawler-margriet",
 	"description" : "Location: North Hinder Junction, North Sea, UK",
 	"title" : "Collision between chemical tanker Orakai and beam trawler Margriet",
 	"public_updated_at" : "2015-07-09T09:13:18+00:00"

--- a/formats/specialist_document/frontend/examples/raib-reports.json
+++ b/formats/specialist_document/frontend/examples/raib-reports.json
@@ -1,7 +1,7 @@
 {
 	"format": "specialist_document",
 	"locale": "en",
-	"base_path" : "raib-reports/train-driver-receiving-a-severe-electric-shock-at-sutton-weaver",
+	"base_path" : "/raib-reports/train-driver-receiving-a-severe-electric-shock-at-sutton-weaver",
 	"title" : "Train driver receiving a severe electric shock at Sutton Weaver",
 	"description" : "At 19:04 hrs on Tuesday 23 September 2014, a train driver received a severe electric shock at Sutton Weaver, Cheshire. ",
 	"details" : {


### PR DESCRIPTION
In the specialist document examples, all the base_path values need to start with a slash for consistency and compatibility with the dummy-content-store.