### PR TITLE
Strict base path specification

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -200,6 +200,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -247,7 +247,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -239,6 +239,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -106,7 +106,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -65,6 +65,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -98,6 +98,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -91,6 +91,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -138,7 +138,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -130,6 +130,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -207,6 +207,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -254,7 +254,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -249,6 +249,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -161,6 +161,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -202,7 +202,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -81,7 +81,7 @@
                       "type": "string"
                     },
                     "base_path": {
-                      "type": "string"
+                      "$ref": "#/definitions/absolute_path"
                     }
                   }
                 }
@@ -106,7 +106,7 @@
                 "type": "string"
               },
               "base_path": {
-                "type": "string"
+                "$ref": "#/definitions/absolute_path"
               },
               "title": {
                 "type": "string"

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -194,6 +194,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -127,7 +127,7 @@
                       "type": "string"
                     },
                     "base_path": {
-                      "type": "string"
+                      "$ref": "#/definitions/absolute_path"
                     }
                   }
                 }
@@ -152,7 +152,7 @@
                 "type": "string"
               },
               "base_path": {
-                "type": "string"
+                "$ref": "#/definitions/absolute_path"
               },
               "title": {
                 "type": "string"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -206,7 +206,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -165,6 +165,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -60,7 +60,7 @@
             ],
             "properties": {
               "base_path": {
-                "type": "string"
+                "$ref": "#/definitions/absolute_path"
               },
               "section_id": {
                 "type": "string"
@@ -79,7 +79,7 @@
           ],
           "properties": {
             "base_path": {
-              "type": "string"
+              "$ref": "#/definitions/absolute_path"
             }
           }
         },
@@ -140,7 +140,7 @@
                       "type": "string"
                     },
                     "base_path": {
-                      "type": "string"
+                      "$ref": "#/definitions/absolute_path"
                     }
                   }
                 }

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -106,7 +106,7 @@
             ],
             "properties": {
               "base_path": {
-                "type": "string"
+                "$ref": "#/definitions/absolute_path"
               },
               "section_id": {
                 "type": "string"
@@ -125,7 +125,7 @@
           ],
           "properties": {
             "base_path": {
-              "type": "string"
+              "$ref": "#/definitions/absolute_path"
             }
           }
         },
@@ -186,7 +186,7 @@
                       "type": "string"
                     },
                     "base_path": {
-                      "type": "string"
+                      "$ref": "#/definitions/absolute_path"
                     }
                   }
                 }

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -198,6 +198,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -98,6 +98,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -145,7 +145,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -141,6 +141,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -78,7 +78,7 @@
                       "type": "string"
                     },
                     "base_path": {
-                      "type": "string"
+                      "$ref": "#/definitions/absolute_path"
                     }
                   }
                 }
@@ -99,7 +99,7 @@
             ],
             "properties": {
               "base_path": {
-                "type": "string"
+                "$ref": "#/definitions/absolute_path"
               },
               "title": {
                 "type": "string"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -195,7 +195,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -154,6 +154,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -187,6 +187,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -124,7 +124,7 @@
                       "type": "string"
                     },
                     "base_path": {
-                      "type": "string"
+                      "$ref": "#/definitions/absolute_path"
                     }
                   }
                 }
@@ -145,7 +145,7 @@
             ],
             "properties": {
               "base_path": {
-                "type": "string"
+                "$ref": "#/definitions/absolute_path"
               },
               "title": {
                 "type": "string"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -57,7 +57,7 @@
           ],
           "properties": {
             "base_path": {
-              "type": "string"
+              "$ref": "#/definitions/absolute_path"
             }
           }
         },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -142,7 +142,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -101,6 +101,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -103,7 +103,7 @@
           ],
           "properties": {
             "base_path": {
-              "type": "string"
+              "$ref": "#/definitions/absolute_path"
             }
           }
         },

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -134,6 +134,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -139,7 +139,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -92,6 +92,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -131,6 +131,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -242,7 +242,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -195,6 +195,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -237,6 +237,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -854,7 +854,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -96,6 +96,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -135,6 +135,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -96,6 +96,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -143,7 +143,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -138,6 +138,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "title": {
       "type": "string"
@@ -78,6 +78,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -119,7 +119,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "api_url": {
             "type": "string",

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -111,6 +111,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -17,7 +17,7 @@
         "type": "string"
       },
       "base_path": {
-        "type": "string"
+        "$ref" : "#/definitions/absolute_path"
       },
       "api_url": {
         "type": "string",

--- a/formats/hmrc_manual/publisher/details.json
+++ b/formats/hmrc_manual/publisher/details.json
@@ -43,7 +43,7 @@
                   "type": "string"
                 },
                 "base_path": {
-                  "type": "string"
+                  "$ref": "#/definitions/absolute_path"
                 }
               }
             }
@@ -68,7 +68,7 @@
             "type": "string"
           },
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "title": {
             "type": "string"

--- a/formats/hmrc_manual_section/publisher/details.json
+++ b/formats/hmrc_manual_section/publisher/details.json
@@ -22,7 +22,7 @@
         ],
         "properties": {
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "section_id": {
             "type": "string"
@@ -41,7 +41,7 @@
       ],
       "properties": {
         "base_path": {
-          "type": "string"
+          "$ref": "#/definitions/absolute_path"
         }
       }
     },
@@ -102,7 +102,7 @@
                   "type": "string"
                 },
                 "base_path": {
-                  "type": "string"
+                  "$ref": "#/definitions/absolute_path"
                 }
               }
             }

--- a/formats/manual/publisher/details.json
+++ b/formats/manual/publisher/details.json
@@ -40,7 +40,7 @@
                   "type": "string"
                 },
                 "base_path": {
-                  "type": "string"
+                  "$ref": "#/definitions/absolute_path"
                 }
               }
             }
@@ -61,7 +61,7 @@
         ],
         "properties": {
           "base_path": {
-            "type": "string"
+            "$ref": "#/definitions/absolute_path"
           },
           "title": {
             "type": "string"

--- a/formats/manual_section/publisher/details.json
+++ b/formats/manual_section/publisher/details.json
@@ -19,7 +19,7 @@
       ],
       "properties": {
         "base_path": {
-          "type": "string"
+          "$ref": "#/definitions/absolute_path"
         }
       }
     },

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref" : "#/definitions/absolute_path"
     },
     "content_id": {
       "type": "string",
@@ -76,6 +76,10 @@
     }
   },
   "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "base_path": {
-      "type": "string"
+      "$ref": "#/definitions/absolute_path"
     },
     "format": {
       "enum": [ "redirect" ]

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -48,7 +48,7 @@ private
     excluding_internal.merge(
       'links' => frontend_links,
       'updated_at' => updated_at,
-      'base_path' => { 'type' => 'string' }
+      'base_path' => { '$ref' => '#/definitions/absolute_path' }
     )
   end
 

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   it "adds base_path as a required string property" do
     expect(generated.schema['properties']).to include(
       "base_path" => {
-        "type" => "string"
+        "$ref" => "#/definitions/absolute_path"
       }
     )
     expect(generated.schema["required"]).to include(


### PR DESCRIPTION
`base_path` should always contain an absolute path. At present the schema accepts any arbitrary string.

This definition was taken from this [gist](https://gist.github.com/dpk/4757681) which is based on [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.3).

I also use the same `absolute_path` definition to validate:

- the `base_path` in the frontend representation
- the `base_path` which occurs in the links section of the frontend representation

## Other possible follow ups

The `manual`, `manual_section`, `hmrc_manual` and `hmrc_manual_section` formats all contain "base_path" fields. We may want to use this to specify those as well.

