### PR TITLE
Remove change_note from specialist documents

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -43,8 +43,7 @@
       "required": [
         "body",
         "metadata",
-        "change_history",
-        "change_note"
+        "change_history"
       ],
       "properties": {
         "body": {
@@ -55,9 +54,6 @@
         },
         "headers": {
           "$ref": "#/definitions/nested_headers"
-        },
-        "change_note": {
-          "type": "string"
         },
         "change_history": {
           "type": "array",

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -89,8 +89,7 @@
       "required": [
         "body",
         "metadata",
-        "change_history",
-        "change_note"
+        "change_history"
       ],
       "properties": {
         "body": {
@@ -101,9 +100,6 @@
         },
         "headers": {
           "$ref": "#/definitions/nested_headers"
-        },
-        "change_note": {
-          "type": "string"
         },
         "change_history": {
           "type": "array",

--- a/formats/specialist_document/frontend/examples/aaib-reports.json
+++ b/formats/specialist_document/frontend/examples/aaib-reports.json
@@ -34,7 +34,6 @@
 				]
 			}
 		],
-		"change_note" : "",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/frontend/examples/cma-cases.json
+++ b/formats/specialist_document/frontend/examples/cma-cases.json
@@ -43,7 +43,6 @@
 				]
 			}
 		],
-		"change_note" : "First published.",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
@@ -119,7 +119,6 @@
 				"id" : "further-information"
 			}
 		],
-		"change_note" : "First published.",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -103,7 +103,6 @@
 				"id" : "download-documents"
 			}
 		],
-		"change_note" : "First published.",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/frontend/examples/drug-safety-update.json
+++ b/formats/specialist_document/frontend/examples/drug-safety-update.json
@@ -26,7 +26,6 @@
 				"id" : "further-information"
 			}
 		],
-		"change_note" : "",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
+++ b/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
@@ -76,7 +76,6 @@
 				"id" : "contact-details"
 			}
 		],
-		"change_note" : "Call closed for Tees Valley",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/frontend/examples/international-development-funding.json
+++ b/formats/specialist_document/frontend/examples/international-development-funding.json
@@ -67,7 +67,6 @@
 				"id" : "other-links"
 			}
 		],
-		"change_note" : "",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/frontend/examples/maib-reports.json
+++ b/formats/specialist_document/frontend/examples/maib-reports.json
@@ -31,7 +31,6 @@
 				]
 			}
 		],
-		"change_note" : "",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/frontend/examples/raib-reports.json
+++ b/formats/specialist_document/frontend/examples/raib-reports.json
@@ -14,7 +14,6 @@
 			"date_of_occurrence" : "2014-09-24",
 			"document_type" : "raib_report"
 		},
-		"change_note" : "First published.",
 		"change_history" : [
 			{
 				"note" : "First published.",

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -5,8 +5,7 @@
   "required": [
     "body",
     "metadata",
-    "change_history",
-    "change_note"
+    "change_history"
   ],
   "properties": {
     "body": {
@@ -18,9 +17,6 @@
 
     "headers" : {
       "$ref": "#/definitions/nested_headers"
-    },
-    "change_note" : {
-      "type" : "string"
     },
 
     "change_history": {


### PR DESCRIPTION
The `change_note` field contains the same content as the last entry in
the `change_history` (the last entry is the most recent one).

It's superfluous to duplicate that information in an additional
top-level field, and doing so introduces potential for confusion and
errors.

At present it's believed that the email alert api would use the
`change_note` field when listening on the message queue, however
specialist documents are not sent to the email-alert-api in that way and
we do not intend to do that in the future.