### PR TITLE
Add optional analytics_identifier to placeholder format

### DIFF
--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -40,6 +40,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "analytics_identifier": {
+          "type": "string",
+          "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+        },
         "change_note": {
           "type": [
             "string",

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -86,6 +86,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "analytics_identifier": {
+          "type": "string",
+          "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+        },
         "change_note": {
           "type": [
             "string",

--- a/formats/placeholder/publisher/details.json
+++ b/formats/placeholder/publisher/details.json
@@ -3,6 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "analytics_identifier": {
+      "type": "string",
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
     "change_note": {
       "type": ["string", "null"]
     },


### PR DESCRIPTION
We want to consistently tag pages across GOV.UK in Google Analytics with:
    * organisations
    * world_locations
    * world_organisations

Whitehall mints a short `analytics_identifier` for each of these things and sends it to Google Analytics in the frontend. This means content from content-store can't send the data to Google Analytics.

So, for content rendered from content-store, we will include these identifiers in the content item for each organisation/world_location/world_organisation, and then include it when expanding the `links` hash out for a content item so that it's available when the frontend is sending the data to Google Analytics.

The changes to include it in the frontend schema will come later, when we get to implementing the expansion.

/cc @danielroseman @rboulton 