### PR TITLE
Add reject to Finders

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -101,6 +101,19 @@
             }
           }
         },
+        "reject": {
+          "description": "A fixed filter that rejects documents which match the conditions",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "facets": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -147,6 +147,19 @@
             }
           }
         },
+        "reject": {
+          "description": "A fixed filter that rejects documents which match the conditions",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "facets": {
           "type": "array",
           "items": {

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -55,6 +55,19 @@
         }
       }
     },
+    "reject": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "facets": {
       "type": "array",
       "items": {


### PR DESCRIPTION
In order to exclude certain values from a query built by a Finder we
need to add `reject` as an object, similar to the `filter`. This is then
used by Finder Frontend when constructing the query.