### PR TITLE
topic and mainstream_browse_page now use paths

### DIFF
--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -63,7 +63,7 @@
               "contents": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/definitions/absolute_path"
                 }
               }
             }

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -109,7 +109,7 @@
               "contents": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/definitions/absolute_path"
                 }
               }
             }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -67,7 +67,7 @@
               "contents": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/definitions/absolute_path"
                 }
               }
             }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -113,7 +113,7 @@
               "contents": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/definitions/absolute_path"
                 }
               }
             }

--- a/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
@@ -8,16 +8,16 @@
         {
           "name": "Fraud",
           "contents": [
-            "https://www.gov.uk/benefit-fraud",
-            "https://www.gov.uk/national-benefit-fraud-hotline",
-            "https://www.gov.uk/benefit-integrity-centres"
+            "/benefit-fraud",
+            "/national-benefit-fraud-hotline",
+            "/benefit-integrity-centres"
           ]
         },
         {
           "name": "Complaints",
           "contents": [
-            "https://www.gov.uk/complain-debt-management",
-            "https://www.gov.uk/complain-independent-case-examiner"
+            "/complain-debt-management",
+            "/complain-independent-case-examiner"
           ]
         }
       ]

--- a/formats/mainstream_browse_page/publisher/details.json
+++ b/formats/mainstream_browse_page/publisher/details.json
@@ -22,7 +22,7 @@
           "contents": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref" : "#/definitions/absolute_path"
             }
           }
         }

--- a/formats/topic/frontend/examples/curated_subtopic.json
+++ b/formats/topic/frontend/examples/curated_subtopic.json
@@ -6,14 +6,14 @@
         {
           "name": "Oil rigs",
           "contents": [
-            "https://www.gov.uk/oil-rig-safety-requirements",
-            "https://www.gov.uk/oil-rig-staffing"
+            "/oil-rig-safety-requirements",
+            "/oil-rig-staffing"
           ]
         },
         {
           "name": "Piping",
           "contents": [
-            "https://www.gov.uk/undersea-piping-restrictions"
+            "/undersea-piping-restrictions"
           ]
         }
       ]

--- a/formats/topic/publisher/details.json
+++ b/formats/topic/publisher/details.json
@@ -25,7 +25,7 @@
           "contents": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref" : "#/definitions/absolute_path"
             }
           }
         }


### PR DESCRIPTION
collections-publisher now sends details of curated list contents as
an array of base_paths as opposed to api_urls. Update the schema and
examples accordingly. This also validates that the values given are all
valid absolute URL paths.