### PR TITLE
Allow Finders to be Alpha

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -46,6 +46,26 @@
         "facets"
       ],
       "properties": {
+        "alpha": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "alpha_message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "beta": {
           "anyOf": [
             {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -92,6 +92,26 @@
         "facets"
       ],
       "properties": {
+        "alpha": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "alpha_message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "beta": {
           "anyOf": [
             {

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -8,6 +8,18 @@
     "facets"
   ],
   "properties": {
+    "alpha": {
+      "anyOf": [
+        { "type": "boolean" },
+        { "type": "null" }
+      ]
+    },
+    "alpha_message": {
+      "anyOf": [
+        { "type": "string" },
+        { "type": "null" }
+      ]
+    },
     "beta": {
       "anyOf": [
         { "type": "boolean" },


### PR DESCRIPTION
Same as the Beta, this commit adds an `alpha` boolean and an option
`alpha_message` on the details of the Finder. In Finder Frontend this is
then used to render the Alpha Banner.