### PR TITLE
Add #/links/topics to HMRC Manuals

### DIFF
--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -147,9 +147,12 @@
       }
     },
     "links": {
-      "additionalProperties": false,
       "type": "object",
+      "additionalProperties": false,
       "properties": {
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
         }
@@ -182,6 +185,12 @@
             "exact"
           ]
         }
+      }
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
       }
     },
     "frontend_links": {

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -191,6 +191,15 @@
           }
         }
       }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "topics": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
     }
   },
   "definitions": {
@@ -215,6 +224,12 @@
             "exact"
           ]
         }
+      }
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
       }
     }
   }

--- a/formats/hmrc_manual/publisher/links.json
+++ b/formats/hmrc_manual/publisher/links.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "topics": {
+      "$ref": "#/definitions/guid_list"
+    }
+  },
+  "definitions": {
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      }
+    }
+  }
+}


### PR DESCRIPTION
HMRC Manuals're in the process of becoming 'linkable' to topics.

It was decided that we should publish a manual's list of topics as part of its
`links` data, as an array of topic content_ids.