### PR TITLE
Add Phase for alpha or beta

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -39,6 +39,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -85,6 +85,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -40,6 +40,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -86,6 +86,13 @@
     "analytics_identifier": {
       "type": "string"
     },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/finder/frontend/examples/all_policies.json
+++ b/formats/finder/frontend/examples/all_policies.json
@@ -1,0 +1,37 @@
+{
+  "base_path": "/government/policies/all",
+  "title": "All policy content",
+  "description": "",
+  "format": "finder",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-07-28T13:31:24.082Z",
+  "public_updated_at": "2015-07-28T13:29:02.000+00:00",
+  "phase": "alpha",
+  "details": {
+    "document_noun": "documents",
+    "facets": [],
+    "filter": {},
+    "reject": {
+      "policies": [
+        "_MISSING"
+      ]
+    },
+    "show_summaries": false
+  },
+  "links": {
+    "email_alert_signup": [],
+    "organisations": [],
+    "related": [],
+    "available_translations": [
+      {
+        "title": "All policy content",
+        "base_path": "/government/policies/all",
+        "description": "",
+        "api_url": "https://www.gov.uk/api/content/government/policies/all",
+        "web_url": "https://www.gov.uk/government/policies/all",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -76,6 +76,10 @@
     },
     "analytics_identifier": {
       "type": "string"
+    },
+    "phase": {
+      "type": "string",
+      "enum": [ "alpha", "beta" ]
     }
   },
   "definitions": {


### PR DESCRIPTION
This PR adds a phase attribute for a Content Item. It can only be present with
`alpha` or `beta` as the attributes. This can then be used by the Rendering
Application to switch functionality or visual features based on the phase.