### PR TITLE
Add analytics identifier to root metadata

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -36,6 +36,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -82,6 +82,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -37,6 +37,9 @@
         "type": "string"
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -83,6 +83,9 @@
         }
       }
     },
+    "analytics_identifier": {
+      "type": "string"
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -73,6 +73,9 @@
           }
         }
       }
+    },
+    "analytics_identifier": {
+      "type": "string"
     }
   },
   "definitions": {


### PR DESCRIPTION
So that we can easily expand the analytics identifiers in the links hash
add it to the root metadata.

The use case for this is that we have many things in the content store
that have short codes we use in analytics (to get around character
limits in dimensions). Any page which gets linked to any of these
objects should have those short codes exposed on the frontend. Adding
these codes to the links hash means that frontends won't need to make a
query to the content store for every object in the links hash. Having
the identifiers in the root object rather than in the details hash means
that we don't need to load the entire details hash to generate the links
hash objects.