### PR TITLE
Add topic tags to HMRC Manuals

### DIFF
--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -146,6 +146,19 @@
               }
             }
           }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "topics": {
+              "description": "Slugs of the Manual's topics. An example of a topic slug is 'business-tax/vat'.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -192,6 +192,19 @@
               }
             }
           }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "topics": {
+              "description": "Slugs of the Manual's topics. An example of a topic slug is 'business-tax/vat'.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/formats/hmrc_manual/publisher/details.json
+++ b/formats/hmrc_manual/publisher/details.json
@@ -105,6 +105,19 @@
           }
         }
       }
+    },
+    "tags": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "topics": {
+          "description": "Slugs of the Manual's topics. An example of a topic slug is 'business-tax/vat'.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This change adds 'tags' under 'details', and 'topics' under those 'tags'.

This is the format expected by Email Alert Service in the Current World, as
demonstrated in the Case Study schema.