### PR TITLE
Allow service design phase to be 'live'

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -40,10 +40,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -86,10 +86,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -41,10 +41,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -87,10 +87,12 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
       "enum": [
         "alpha",
-        "beta"
+        "beta",
+        "live"
       ]
     },
     "details": {

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -78,8 +78,9 @@
       "type": "string"
     },
     "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
-      "enum": [ "alpha", "beta" ]
+      "enum": [ "alpha", "beta", "live" ]
     }
   },
   "definitions": {


### PR DESCRIPTION
Given live is one of the [service design phases](https://www.gov.uk/service-manual/phases) it makes sense for it to be one of the allowed options. This will allow publishing apps to be simpler, avoiding examples like https://github.com/alphagov/collections-publisher/blob/master/app/presenters/tag_presenter.rb#L60-L63

Before this is merged, the [content-store validations](https://github.com/alphagov/content-store/blob/master/app/models/content_item.rb#L61-L64) will need to be updated to allow this value. I'd also suggest that the field should be defaulted to 'live' when not explicitly set in an incoming request.