### PR TITLE
Add bulk published to specialist documents

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -84,6 +84,9 @@
               "note"
             ]
           }
+        },
+        "bulk_published": {
+          "type": "boolean"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -130,6 +130,9 @@
               "note"
             ]
           }
+        },
+        "bulk_published": {
+          "type": "boolean"
         }
       }
     },

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -38,6 +38,10 @@
           "note"
         ]
       }
+    },
+
+    "bulk_published": {
+      "type": "boolean"
     }
   },
   "definitions": {


### PR DESCRIPTION
The `bulk_published` attribute is used by Specialist Frontend to decide
if it show the Published date for documents. When it's true, the
Published date is hidden.