### PR TITLE
Add asylum support decision schema and examples

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -132,6 +132,9 @@
           "$ref": "#/definitions/aaib_report_metadata"
         },
         {
+          "$ref": "#/definitions/asylum_support_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/cma_case_metadata"
         },
         {
@@ -233,6 +236,62 @@
           "type": "string"
         },
         "registration": {
+          "type": "string"
+        }
+      }
+    },
+    "asylum_support_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "asylum_support_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_judges_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_category": {
+          "type": "string"
+        },
+        "tribunal_decision_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_sub_category": {
+          "type": "string"
+        },
+        "tribunal_decision_sub_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_landmark": {
+          "type": "string",
+          "enum": [
+            "not-landmark",
+            "landmark"
+          ]
+        },
+        "tribunal_decision_landmark_name": {
+          "type": "string"
+        },
+        "tribunal_decision_reference_number": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
           "type": "string"
         }
       }

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -171,6 +171,9 @@
           "$ref": "#/definitions/aaib_report_metadata"
         },
         {
+          "$ref": "#/definitions/asylum_support_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/cma_case_metadata"
         },
         {
@@ -272,6 +275,62 @@
           "type": "string"
         },
         "registration": {
+          "type": "string"
+        }
+      }
+    },
+    "asylum_support_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "asylum_support_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_judges_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_category": {
+          "type": "string"
+        },
+        "tribunal_decision_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_sub_category": {
+          "type": "string"
+        },
+        "tribunal_decision_sub_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_landmark": {
+          "type": "string",
+          "enum": [
+            "not-landmark",
+            "landmark"
+          ]
+        },
+        "tribunal_decision_landmark_name": {
+          "type": "string"
+        },
+        "tribunal_decision_reference_number": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
           "type": "string"
         }
       }

--- a/formats/finder/frontend/examples/asylum-support-decisions.json
+++ b/formats/finder/frontend/examples/asylum-support-decisions.json
@@ -1,0 +1,151 @@
+{
+  "base_path": "/asylum-support-decisions",
+  "title": "First-tier Tribunal (Asylum Support) decisions",
+  "description": "Find decisions by the First-tier Tribunal (Asylum Support)",
+  "format": "finder",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-09-02T15:56:15.163Z",
+  "public_updated_at": "2015-09-02T10:06:06.000+00:00",
+  "details": {
+    "beta": true,
+    "document_noun": "decision",
+    "filter": {
+      "document_type": "asylum_support_decision"
+    },
+    "format_name": "First-tier Tribunal (Asylum Support) decision",
+    "show_summaries": true,
+    "facets": [
+      {
+        "key": "tribunal_decision_judges",
+        "name": "Judges",
+        "type": "text",
+        "preposition": "by judge",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Alan Ponting",
+            "value": "alan-ponting"
+          },
+          {
+            "label": "Sally Verity Smith",
+            "value": "sally-verity-smith"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_judges_name",
+        "name": "Judges name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_category",
+        "name": "Category",
+        "type": "text",
+        "preposition": "categorised as",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Section 95 (asylum-seekers)",
+            "value": "section-95-asylum-seekers"
+          },
+          {
+            "label": "Section 4(2) (failed asylum seekers)",
+            "value": "section-4-2-failed-asylum-seekers"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_category_name",
+        "name": "Category name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_sub_category",
+        "name": "Sub-category",
+        "type": "text",
+        "preposition": "sub-categorised as",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Section 95 - jurisdiction",
+            "value": "section-95-jurisdiction"
+          },
+          {
+            "label": "Section 4(2) - jurisdiction",
+            "value": "section-4-2-jurisdiction"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_sub_category_name",
+        "name": "Sub-category name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_landmark",
+        "name": "Landmark",
+        "type": "text",
+        "display_as_result_metadata": false,
+        "filterable": false,
+        "allowed_values": [
+          {
+            "label": "Not Landmark",
+            "value": "not-landmark"
+          },
+          {
+            "label": "Landmark",
+            "value": "landmark"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_landmark_name",
+        "name": "Landmark name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_reference_number",
+        "name": "Reference number",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_decision_date",
+        "name": "Decision date",
+        "short_name": "Decided",
+        "type": "date",
+        "preposition": "was decided",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ]
+  },
+  "links": {
+    "organisations": [],
+    "related": [],
+    "email_alert_signup": [],
+    "available_translations": [
+      {
+        "title": "First-tier Tribunal (Asylum Support) decisions",
+        "base_path": "/asylum-support-decisions",
+        "description": "Find decisions by the First-tier Tribunal (Asylum Support)",
+        "api_url": "http://content-store.dev.gov.uk/content/asylum-support-decisions",
+        "web_url": "http://www.dev.gov.uk/asylum-support-decisions",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/specialist_document/frontend/examples/asylum-support-decision.json
+++ b/formats/specialist_document/frontend/examples/asylum-support-decision.json
@@ -1,0 +1,47 @@
+{
+  "base_path": "/asylum-support-decisions/ast-06-04-13140",
+  "title": "AST / 06 / 04 / 13140",
+  "description": "The House of Lords guidance in Limbuela did not include failed asylum seekers - paragraphs 13, 81 and 100 of their Lordships' judgement refers - the solution to a failed asylum seeker's destitution lies in his own hands by way of a voluntary return home - an option not expected of an asylum seeker",
+  "format": "specialist_document",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-09-04T09:04:39.828Z",
+  "public_updated_at": "2015-09-04T09:04:39.000+00:00",
+  "details": {
+    "metadata": {
+      "tribunal_decision_judges": [
+        "sally-verity-smith"
+      ],
+      "tribunal_decision_category": "section-4-2-failed-asylum-seekers",
+      "tribunal_decision_sub_category": "section-4-2-jurisdiction",
+      "tribunal_decision_landmark": "landmark",
+      "tribunal_decision_reference_number": "AST / 06 / 04 / 13140",
+      "tribunal_decision_decision_date": "2006-04-27",
+      "hidden_indexable_content": "The appellant, an Iranian Kurd born on 20 February 1979, appeals against the decision of the Secretary of State who refused support under Section 4 of the Immigration and Asylum Act 1999 (“the Act”) on 8 April 2006 on the grounds that the appellant did not satisfy one or more of the conditions set out in Regulation 3 of the Immigration and Asylum (Provision of Accommodation to Failed Asylum Seekers) Regulations 2005 (“the 2005 Regulations”). \r\n...\r\n",
+      "document_type": "asylum_support_decision"
+    },
+    "change_history": [
+      {
+        "public_timestamp": "2015-09-04T09:03:56+00:00",
+        "note": "First published."
+      },
+      {
+        "public_timestamp": "2015-09-04T09:04:39+00:00",
+        "note": "date format"
+      }
+    ],
+    "body": "<p>Download decision: </p>\n"
+  },
+  "links": {
+    "available_translations": [
+      {
+        "title": "AST / 06 / 04 / 13140",
+        "base_path": "/asylum-support-decisions/ast-06-04-13140",
+        "description": "The House of Lords guidance in Limbuela did not include failed asylum seekers - paragraphs 13, 81 and 100 of their Lordships' judgement refers - the solution to a failed asylum seeker's destitution lies in his own hands by way of a voluntary return home - an option not expected of an asylum seeker",
+        "api_url": "http://content-store.dev.gov.uk/content/asylum-support-decisions/ast-06-04-13140",
+        "web_url": "http://www.dev.gov.uk/asylum-support-decisions/ast-06-04-13140",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -45,6 +45,7 @@
       "type": "object",
       "oneOf": [
         { "$ref": "#/definitions/aaib_report_metadata" },
+        { "$ref": "#/definitions/asylum_support_decision_metadata" },
         { "$ref": "#/definitions/cma_case_metadata" },
         { "$ref": "#/definitions/countryside_stewardship_grant_metadata" },
         { "$ref": "#/definitions/drug_safety_update_metadata" },
@@ -127,6 +128,62 @@
           "type": "string"
         },
         "registration": {
+          "type": "string"
+        }
+      }
+    },
+    "asylum_support_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "asylum_support_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_judges_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_category": {
+          "type": "string"
+        },
+        "tribunal_decision_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_sub_category": {
+          "type": "string"
+        },
+        "tribunal_decision_sub_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_landmark": {
+          "type": "string",
+          "enum": [
+            "not-landmark",
+            "landmark"
+          ]
+        },
+        "tribunal_decision_landmark_name": {
+          "type": "string"
+        },
+        "tribunal_decision_reference_number": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
           "type": "string"
         }
       }


### PR DESCRIPTION
Add schema and examples for asylum support decisions - a new specialist document type.