### PR TITLE
Add "Gone" format

### DIFF
--- a/dist/formats/gone/publisher/schema.json
+++ b/dist/formats/gone/publisher/schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "update_type",
+    "routes"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "format": {
+      "enum": [ "gone" ]
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [ "major", "minor", "republish" ]
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "path",
+          "type"
+        ],
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [ "exact", "prefix" ]
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    }
+  }
+}

--- a/formats/gone/publisher/examples/gone.json
+++ b/formats/gone/publisher/examples/gone.json
@@ -1,0 +1,12 @@
+{
+  "format": "gone",
+  "publishing_app": "collections-publisher",
+  "content_id": "4c5eed70-2fbb-4d39-94f2-de83bc2879a5",
+  "update_type": "major",
+  "routes": [
+    {
+      "path": "/some-gone-route",
+      "type": "exact"
+    }
+  ]
+}

--- a/formats/gone/publisher/schema.json
+++ b/formats/gone/publisher/schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "update_type",
+    "routes"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "format": {
+      "enum": [ "gone" ]
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [ "major", "minor", "republish" ]
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "path",
+          "type"
+        ],
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [ "exact", "prefix" ]
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    }
+  }
+}


### PR DESCRIPTION
From the [content-store docs](https://github.com/alphagov/content-store/blob/0e96e934206abd54e057e63a7eb6beaf71d21f60/doc/gone_item.md
):

> To represent content that is no longer available, the content store supports items with a format of "gone". These will cause a gone route to be setup in the router so that the item returns a 410 HTTP status.

This item is based on [the redirect format](https://github.com/alphagov/govuk-content-schemas/tree/master/formats/redirect).

This format will be used for testing the creation of gone routes for draft content-items in https://github.com/alphagov/collections-publisher/pull/138.

Related Trello: https://trello.com/c/ybdnGMhl

