### PR TITLE
Expose content_id in frontend representations.

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -227,10 +230,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -258,11 +265,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -270,10 +269,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -92,10 +95,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -123,11 +130,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -135,10 +134,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -118,10 +121,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -149,11 +156,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -161,10 +160,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -247,10 +250,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -278,11 +285,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -293,10 +292,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -201,10 +204,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -232,11 +239,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -244,10 +243,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -192,10 +195,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -223,11 +230,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -235,10 +234,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -125,10 +128,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -156,11 +163,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -172,10 +171,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -181,10 +184,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -212,11 +219,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -224,10 +223,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -128,10 +131,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -159,11 +166,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -171,10 +170,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -123,10 +126,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -154,11 +161,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -166,10 +165,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -219,10 +222,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -250,11 +257,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -265,10 +264,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -119,10 +122,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -953,11 +960,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -162,10 +161,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -123,10 +126,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -154,11 +161,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -169,10 +168,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -12,6 +12,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "title": {
       "type": "string"
     },
@@ -105,10 +108,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {
@@ -136,11 +143,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "content_id",
           "title",
           "base_path",
           "locale"
         ],
         "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
           "title": {
             "type": "string"
           },

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -15,8 +15,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -148,10 +147,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -1,5 +1,6 @@
 {
   "base_path": "/government/case-studies/terence-age-33-stoke-on-trent",
+  "content_id": "3933c3df-9fdd-4a56-99cd-9a9351cbbf99",
   "title": "Terence, age 33, Stoke-on-Trent",
   "description": "'My experience with Shaw Trust was very positive and I received all the support I needed to get back into work.'",
   "format": "case_study",
@@ -36,6 +37,7 @@
   "links": {
     "lead_organisations": [
       {
+        "content_id": "dbeaa22b-fb0c-49b0-b44e-0ca6cb52b381",
         "title": "Department for Work and Pensions",
         "base_path": "/government/organisations/department-for-work-pensions",
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-pensions",
@@ -45,6 +47,7 @@
     ],
     "related_policies": [
       {
+        "content_id": "155c22d4-c1f9-40fc-bbe4-4a19df82b164",
         "title": "Helping people to find and stay in work",
         "base_path": "/government/policies/helping-people-to-find-and-stay-in-work",
         "api_url": "https://www.gov.uk/api/content/government/policies/helping-people-to-find-and-stay-in-work",
@@ -58,6 +61,7 @@
     "worldwide_priorities": [],
     "available_translations": [
       {
+        "content_id": "3933c3df-9fdd-4a56-99cd-9a9351cbbf99",
         "title": "Terence, age 33, Stoke-on-Trent",
         "base_path": "/government/case-studies/terence-age-33-stoke-on-trent",
         "api_url": "https://www.gov.uk/api/content/government/case-studies/terence-age-33-stoke-on-trent",
@@ -67,6 +71,7 @@
     ],
     "document_collections": [
       {
+        "content_id": "19ed8498-37ed-4c8e-b0bf-accbb2cf5477",
         "title": "Work Programme real life stories",
         "base_path": "/government/collections/work-programme-real-life-stories",
         "api_url": "https://www.gov.uk/api/content/government/collections/work-programme-real-life-stories",

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "cc717565-1290-4a22-b8d4-4b25facb3c8f",
     "base_path": "/government/case-studies/get-britain-building-carlisle-park",
     "description": "Nearly 400 homes are set to be built on the site of a former tar distillery thanks to Gleeson Homes and HCA investment.",
     "details": {
@@ -21,6 +22,7 @@
     "links": {
       "lead_organisations": [
         {
+          "content_id": "8b19c238-54e3-4e27-b0d7-60f8e2a677c9",
           "title": "Department for International Development",
           "base_path": "/government/organisations/department-for-international-development",
           "api_url": "https://www.gov.uk/api/organisations/department-for-international-development",
@@ -32,6 +34,7 @@
       "supporting_organisations": [],
       "world_locations": [
         {
+          "content_id": "456af51f-5fd3-4855-8a33-52cb32ff9985",
           "title": "Pakistan",
           "base_path": "/government/world/pakistan",
           "api_url": "https://www.gov.uk/api/content/government/world/pakistan",
@@ -41,6 +44,7 @@
       ],
       "worldwide_organisations": [
         {
+          "content_id": "f1ec569a-3471-4de0-947c-a4f3bcccb983",
           "title": "DFID Pakistan",
           "base_path": "/government/world/organisations/dfid-pakistan",
           "api_url": "https://www.gov.uk/api/content/government/world/organisations/dfid-pakistan",
@@ -51,6 +55,7 @@
       "worldwide_priorities": [],
       "available_translations": [
         {
+          "content_id": "cc717565-1290-4a22-b8d4-4b25facb3c8f",
           "title": "Pakistan: In school for the first time",
           "base_path": "/government/case-studies/pakistan-in-school-for-the-first-time",
           "api_url": "https://www.gov.uk/api/content/government/case-studies/pakistan-in-school-for-the-first-time",
@@ -58,6 +63,7 @@
           "locale": "en"
         },
         {
+          "content_id": "cc717565-1290-4a22-b8d4-4b25facb3c8f",
           "title": "پاکستان: اسکول میں پہلی بارداخلہ",
           "base_path": "/government/case-studies/pakistan-in-school-for-the-first-time.ur",
           "api_url": "https://www.gov.uk/api/content/government/case-studies/pakistan-in-school-for-the-first-time.ur",
@@ -67,6 +73,7 @@
       ],
       "document_collections": [
         {
+          "content_id": "def40c5f-52d0-4dca-80ea-b0da5caeebcd",
           "title": "Work Programme real life stories",
           "base_path": "/government/collections/work-programme-real-life-stories",
           "api_url": "https://www.gov.uk/api/content/government/collections/work-programme-real-life-stories",

--- a/formats/case_study/frontend/examples/translated.json
+++ b/formats/case_study/frontend/examples/translated.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "394f8be4-175b-4fb8-8470-35049451b1c7",
     "base_path": "/government/case-studies/doing-business-in-spain.es",
     "description": "Los negocios y las inversiones de las empresas espa\u00f1olas en el exterior tienen \u00e9xito y, al mismo tiempo, empresas extranjeras siguen identificando atractivas oportunidades de negocio que ofrece Espa\u00f1a.",
     "details": {
@@ -27,6 +28,7 @@
     "links": {
         "available_translations": [
             {
+                "content_id": "394f8be4-175b-4fb8-8470-35049451b1c7",
                 "api_url": "https://www.gov.uk/api/content/government/case-studies/doing-business-in-spain",
                 "base_path": "/government/case-studies/doing-business-in-spain",
                 "locale": "en",
@@ -34,6 +36,7 @@
                 "web_url": "https://www.gov.uk/government/case-studies/doing-business-in-spain"
             },
             {
+                "content_id": "394f8be4-175b-4fb8-8470-35049451b1c7",
                 "api_url": "https://www.gov.uk/api/content/government/case-studies/doing-business-in-spain.es",
                 "base_path": "/government/case-studies/doing-business-in-spain.es",
                 "locale": "es",
@@ -41,6 +44,7 @@
                 "web_url": "https://www.gov.uk/government/case-studies/doing-business-in-spain.es"
             },
             {
+                "content_id": "394f8be4-175b-4fb8-8470-35049451b1c7",
                 "api_url": "https://www.gov.uk/api/content/government/case-studies/doing-business-in-spain.ar",
                 "base_path": "/government/case-studies/doing-business-in-spain.ar",
                 "locale": "ar",
@@ -50,6 +54,7 @@
         ],
         "lead_organisations": [
             {
+                "content_id": "8449fbe1-bffe-46cf-a141-07df52c530b7",
                 "api_url": "https://www.gov.uk/api/content/government/organisations/uk-trade-investment",
                 "base_path": "/government/organisations/uk-trade-investment",
                 "locale": "en",
@@ -59,6 +64,7 @@
         ],
         "supporting_organisations": [
             {
+                "content_id": "4e5d0f10-65cb-4036-8a18-123240e3698a",
                 "api_url": "https://www.gov.uk/api/content/government/organisations/foreign-commonwealth-office",
                 "base_path": "/government/organisations/foreign-commonwealth-office",
                 "locale": "en",
@@ -68,6 +74,7 @@
         ],
         "world_locations": [
             {
+                "content_id": "1a47d8eb-36e8-4a9e-8a05-ca33184c2f86",
                 "api_url": "https://www.gov.uk/api/content/government/world/spain.es",
                 "base_path": "/government/world/spain.es",
                 "locale": "es",

--- a/formats/coming_soon/frontend/examples/coming_soon.json
+++ b/formats/coming_soon/frontend/examples/coming_soon.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "3e0467ef-640b-4a9f-8f9c-2b174d9274e6",
     "base_path": "/government/case-studies/a-random-title-for-a-random-document",
     "details": {
         "publish_time": "2014-12-17T09:30:00+00:00"

--- a/formats/email_alert_signup/frontend/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/email_alert_signup.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "2ac1ff8b-2869-445d-9268-d90c96f3f67c",
   "base_path": "/government/policies/employment/email-signup",
   "title": "Employment",
   "description": "",

--- a/formats/finder/frontend/examples/aaib-reports.json
+++ b/formats/finder/frontend/examples/aaib-reports.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "68518b2a-bb48-4807-99d6-de31d39b3810",
   "base_path": "/aaib-reports",
   "title": "Air Accidents Investigation Branch reports",
   "description": "",
@@ -120,6 +121,7 @@
     "email_alert_signup": [],
     "organisations": [
       {
+        "content_id": "28b9541f-0414-405c-8eb0-16a6fbaa800f",
         "title": "Air Accidents Investigation Branch",
         "base_path": "/government/organisations/air-accidents-investigation-branch",
         "api_url": "https://www.gov.uk/api/content/government/organisations/air-accidents-investigation-branch",
@@ -130,6 +132,7 @@
     "related": [],
     "available_translations": [
       {
+        "content_id": "68518b2a-bb48-4807-99d6-de31d39b3810",
         "title": "Air Accidents Investigation Branch reports",
         "base_path": "/aaib-reports",
         "description": "",

--- a/formats/finder/frontend/examples/all_policies.json
+++ b/formats/finder/frontend/examples/all_policies.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "3f68ef63-252c-4982-8569-a01a911e7397",
   "base_path": "/government/policies/all",
   "title": "All policy content",
   "description": "",
@@ -25,6 +26,7 @@
     "related": [],
     "available_translations": [
       {
+        "content_id": "3f68ef63-252c-4982-8569-a01a911e7397",
         "title": "All policy content",
         "base_path": "/government/policies/all",
         "description": "",

--- a/formats/finder/frontend/examples/asylum-support-decisions.json
+++ b/formats/finder/frontend/examples/asylum-support-decisions.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "6a0da4c9-1969-4c2f-972c-88b5497c2b65",
   "base_path": "/asylum-support-decisions",
   "title": "First-tier Tribunal (Asylum Support) decisions",
   "description": "Find decisions by the First-tier Tribunal (Asylum Support)",
@@ -139,6 +140,7 @@
     "email_alert_signup": [],
     "available_translations": [
       {
+        "content_id": "6a0da4c9-1969-4c2f-972c-88b5497c2b65",
         "title": "First-tier Tribunal (Asylum Support) decisions",
         "base_path": "/asylum-support-decisions",
         "description": "Find decisions by the First-tier Tribunal (Asylum Support)",

--- a/formats/finder/frontend/examples/cma-cases.json
+++ b/formats/finder/frontend/examples/cma-cases.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "3631309f-b9c0-4942-afe6-3ae3819fc6a1",
   "base_path": "/cma-cases",
   "title": "Competition and Markets Authority cases",
   "description": "",
@@ -334,6 +335,7 @@
   "links": {
     "email_alert_signup": [
       {
+        "content_id": "b269c38b-6e5a-4258-9735-66389749e341",
         "title": "Competition and Markets Authority cases",
         "base_path": "/cma-cases/email-signup",
         "description": "You'll get an email each time a case is updated or a new case is published.",
@@ -344,6 +346,7 @@
     ],
     "organisations": [
       {
+        "content_id": "271e858a-6b44-4c9c-9282-6f599d268895",
         "title": "Competition and Markets Authority",
         "base_path": "/government/organisations/competition-and-markets-authority",
         "api_url": "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
@@ -354,6 +357,7 @@
     "related": [],
     "available_translations": [
       {
+        "content_id": "3631309f-b9c0-4942-afe6-3ae3819fc6a1",
         "title": "Competition and Markets Authority cases",
         "base_path": "/cma-cases",
         "description": "",

--- a/formats/finder/frontend/examples/contacts.json
+++ b/formats/finder/frontend/examples/contacts.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "07ab2c1d-1a89-46a8-b96a-4a0f8065bec1",
   "base_path": "/government/organisations/hm-cheese-biscuits/contact",
   "format": "finder",
   "title": "HM Cheese & Biscuits Contacts",
@@ -40,6 +41,7 @@
   "links": {
     "organisations": [
       {
+        "content_id": "378d0b6a-36e5-4a74-8495-215187ab8316",
         "title": "HM Cheese & Biscuits",
         "base_path": "/government/organisations/hm-cheese-biscuits",
         "api_url": "https://www.gov.uk/api/content/government/organisations/government/organisations/hm-cheese-biscuits",

--- a/formats/finder/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/finder/frontend/examples/countryside-stewardship-grants.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "49e05ad1-8c76-49a1-b017-6b113a6bb7d5",
   "base_path": "/countryside-stewardship-grants",
   "title": "Countryside Stewardship grants",
   "description": "",
@@ -182,6 +183,7 @@
     "email_alert_signup": [],
     "organisations": [
       {
+        "content_id": "fc483d53-551a-4bc0-952b-6bc0d900b31b",
         "title": "Natural England",
         "base_path": "/government/organisations/natural-england",
         "api_url": "https://www.gov.uk/api/content/government/organisations/natural-england",
@@ -189,6 +191,7 @@
         "locale": "en"
       },
       {
+        "content_id": "cb135a46-9a2b-4cf4-8c60-7448ae7de751",
         "title": "Department for Environment, Food & Rural Affairs",
         "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-environment-food-rural-affairs",
@@ -196,6 +199,7 @@
         "locale": "en"
       },
       {
+        "content_id": "a20c4a89-8133-4cb9-a93f-049115865524",
         "title": "Forestry Commission",
         "base_path": "/government/organisations/forestry-commission",
         "api_url": "https://www.gov.uk/api/content/government/organisations/forestry-commission",
@@ -205,6 +209,7 @@
     ],
     "related": [
       {
+        "content_id": "e3bd0d0b-5c06-4678-91d6-a0d18f16ae2c",
         "title": "Countryside Stewardship manual",
         "base_path": "/guidance/countryside-stewardship-manual",
         "description": "This manual provides the information needed to apply for the new Countryside Stewardship scheme.",
@@ -213,6 +218,7 @@
         "locale": "en"
       },
       {
+        "content_id": "2d704772-e145-4d21-a165-d5d102732411",
         "title": "Countryside Stewardship manual and grants: print versions",
         "base_path": "/government/publications/countryside-stewardship-manual-print-version",
         "description": "Find out about the Countryside Stewardship options and capital items requirements, and how to apply.",
@@ -223,6 +229,7 @@
     ],
     "available_translations": [
       {
+        "content_id": "49e05ad1-8c76-49a1-b017-6b113a6bb7d5",
         "title": "Countryside Stewardship grants",
         "base_path": "/countryside-stewardship-grants",
         "description": "",

--- a/formats/finder/frontend/examples/drug-device-alerts.json
+++ b/formats/finder/frontend/examples/drug-device-alerts.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "429bd6e5-fbdf-4e3d-b6ed-1ef6471bf749",
   "base_path": "/drug-device-alerts",
   "title": "Alerts and recalls for drugs and medical devices",
   "description": "",
@@ -147,6 +148,7 @@
   "links": {
     "email_alert_signup": [
       {
+        "content_id": "ea3bee2c-dbc6-4b55-a1bc-866e5e110f99",
         "title": "Drug alerts and medical device alerts",
         "base_path": "/drug-device-alerts/email-signup",
         "description": "You'll get an email each time an alert is updated or a new alert is published.",
@@ -157,6 +159,7 @@
     ],
     "organisations": [
       {
+        "content_id": "399503ac-569f-40c3-8b0b-8aa5fb52da20",
         "title": "Medicines and Healthcare products Regulatory Agency",
         "base_path": "/government/organisations/medicines-and-healthcare-products-regulatory-agency",
         "api_url": "https://www.gov.uk/api/content/government/organisations/medicines-and-healthcare-products-regulatory-agency",
@@ -166,6 +169,7 @@
     ],
     "related": [
       {
+        "content_id": "97397fb6-d189-4878-9091-0e4610c3202f",
         "title": "Drug Safety Update",
         "base_path": "/drug-safety-update",
         "description": "",
@@ -176,6 +180,7 @@
     ],
     "available_translations": [
       {
+        "content_id": "429bd6e5-fbdf-4e3d-b6ed-1ef6471bf749",
         "title": "Alerts and recalls for drugs and medical devices",
         "base_path": "/drug-device-alerts",
         "description": "",

--- a/formats/finder/frontend/examples/drug-safety-update.json
+++ b/formats/finder/frontend/examples/drug-safety-update.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "34a376eb-5a60-4a05-8d37-450660b67410",
   "base_path": "/drug-safety-update",
   "title": "Drug Safety Update",
   "description": "",
@@ -133,6 +134,7 @@
   "links": {
     "email_alert_signup": [
       {
+        "content_id": "c7371680-8205-4f18-a533-fa987d4225cf",
         "title": "Drug Safety Update",
         "base_path": "/drug-safety-update/email-signup",
         "description": "The drug safety update is a monthly newsletter for healthcare professionals, bringing you information and clinical advice on the safe use of medicines.",
@@ -143,6 +145,7 @@
     ],
     "organisations": [
       {
+        "content_id": "e68b064d-dfb6-46e6-91db-48df629f0162",
         "title": "Medicines and Healthcare products Regulatory Agency",
         "base_path": "/government/organisations/medicines-and-healthcare-products-regulatory-agency",
         "api_url": "https://www.gov.uk/api/content/government/organisations/medicines-and-healthcare-products-regulatory-agency",
@@ -152,6 +155,7 @@
     ],
     "related": [
       {
+        "content_id": "79f4668f-8672-4769-9323-ee00ae0dadda",
         "title": "Alerts and recalls for drugs and medical devices",
         "base_path": "/drug-device-alerts",
         "description": "",
@@ -160,6 +164,7 @@
         "locale": "en"
       },
       {
+        "content_id": "20c598af-8d10-4a18-8c3a-9cc52e8b7bfd",
         "title": "Drug Safety Update: monthly PDF newsletter",
         "base_path": "/government/publications/drug-safety-update-monthly-newsletter",
         "description": "Monthly PDF editions of the Drug Safety Update newsletter from MHRA and its independent advisor the Commission on Human Medicines. ",
@@ -170,6 +175,7 @@
     ],
     "available_translations": [
       {
+        "content_id": "34a376eb-5a60-4a05-8d37-450660b67410",
         "title": "Drug Safety Update",
         "base_path": "/drug-safety-update",
         "description": "",

--- a/formats/finder/frontend/examples/european-structural-investment-funds.json
+++ b/formats/finder/frontend/examples/european-structural-investment-funds.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "5057413b-82ea-4172-af10-18c307f98012",
   "base_path": "/european-structural-investment-funds",
   "title": "European Structural and Investment Funds (ESIF)",
   "description": "",
@@ -178,6 +179,7 @@
   "links": {
     "email_alert_signup": [
       {
+        "content_id": "af366ed4-2ff5-45e2-b694-cc13c5a4e887",
         "title": "European Structural and Investment Funds (ESIF)",
         "base_path": "/european-structural-investment-funds/email-signup",
         "description": "You'll get an email each time a fund is updated or a new fund is published.",
@@ -188,6 +190,7 @@
     ],
     "organisations": [
       {
+        "content_id": "b1e4e105-c157-43ae-899c-4bccca45b336",
         "title": "Department for Communities and Local Government",
         "base_path": "/government/organisations/department-for-communities-and-local-government",
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-communities-and-local-government",
@@ -195,6 +198,7 @@
         "locale": "en"
       },
       {
+        "content_id": "b2f980f7-eca3-4bc8-aaa3-a40788a72e52",
         "title": "Department for Environment, Food & Rural Affairs",
         "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-environment-food-rural-affairs",
@@ -202,6 +206,7 @@
         "locale": "en"
       },
       {
+        "content_id": "3d7941fc-e5d6-4309-b5f9-eeee0e9f1109",
         "title": "Department for Business, Innovation & Skills",
         "base_path": "/government/organisations/department-for-business-innovation-skills",
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-business-innovation-skills",
@@ -212,6 +217,7 @@
     "related": [],
     "available_translations": [
       {
+        "content_id": "5057413b-82ea-4172-af10-18c307f98012",
         "title": "European Structural and Investment Funds (ESIF)",
         "base_path": "/european-structural-investment-funds",
         "description": "",

--- a/formats/finder/frontend/examples/finder.json
+++ b/formats/finder/frontend/examples/finder.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "23ec51f6-b1a1-41a7-97bc-59e18041e2e7",
   "base_path": "/mosw-reports",
   "title": "Ministry of Silly Walks reports",
   "description": "",
@@ -84,6 +85,7 @@
   "links": {
     "organisations": [
       {
+        "content_id": "3338f283-64a1-4062-842e-677f520c1f15",
         "title": "Ministry of Silly Walks",
         "base_path": "/government/organisations/ministry-of-silly-walks",
         "api_url": "https://www.gov.uk/api/content/government/organisations/government/organisations/ministry-of-silly-walks",
@@ -94,6 +96,7 @@
     "related": [],
     "email_alert_signup": [
       {
+        "content_id": "5c35b119-aebc-4ec8-9413-370bd01c24b3",
         "title": "Ministry of Silly Walks reports",
         "base_path": "/mosw-reports/email-signup",
         "api_url": "https://www.gov.uk/api/content/mosw-reports/email-signup",
@@ -103,6 +106,7 @@
     ],
     "available_translations": [
       {
+        "content_id": "23ec51f6-b1a1-41a7-97bc-59e18041e2e7",
         "title": "Ministry of Silly Walks reports",
         "base_path": "/mosw-reports",
         "api_url": "https://www.gov.uk/api/content/mosw-reports",

--- a/formats/finder/frontend/examples/international-development-funding.json
+++ b/formats/finder/frontend/examples/international-development-funding.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "1e0784fb-0a81-442e-82a0-efa678d76b4d",
   "base_path": "/international-development-funding",
   "title": "International development funding",
   "description": "",
@@ -299,6 +300,7 @@
   "links": {
     "email_alert_signup": [
       {
+        "content_id": "420b6a4a-7399-4763-b82d-2e54f6583ef9",
         "title": "International development funding",
         "base_path": "/international-development-funding/email-signup",
         "description": "You'll get an email each time a fund is updated or a new fund is published.",
@@ -309,6 +311,7 @@
     ],
     "organisations": [
       {
+        "content_id": "ee825e42-e3a4-4168-919c-56c8fbc313c9",
         "title": "Department for International Development",
         "base_path": "/government/organisations/department-for-international-development",
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-international-development",
@@ -319,6 +322,7 @@
     "related": [],
     "available_translations": [
       {
+        "content_id": "1e0784fb-0a81-442e-82a0-efa678d76b4d",
         "title": "International development funding",
         "base_path": "/international-development-funding",
         "description": "",

--- a/formats/finder/frontend/examples/maib-reports.json
+++ b/formats/finder/frontend/examples/maib-reports.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "3df5a305-2819-4125-882b-65c2f3edf6cf",
   "base_path": "/maib-reports",
   "title": "Marine Accident Investigation Branch reports",
   "description": "",
@@ -90,6 +91,7 @@
   "links": {
     "email_alert_signup": [
       {
+        "content_id": "21c88fa0-79f0-4ec2-8936-4b086f2ce5ed",
         "title": "Marine Accident Investigation Branch reports",
         "base_path": "/maib-reports/email-signup",
         "description": "You'll get an email each time a report is updated or a new report is published.",
@@ -100,6 +102,7 @@
     ],
     "organisations": [
       {
+        "content_id": "5415d422-e3ab-4cb7-bd84-d54640be0b1c",
         "title": "Marine Accident Investigation Branch",
         "base_path": "/government/organisations/marine-accident-investigation-branch",
         "api_url": "https://www.gov.uk/api/content/government/organisations/marine-accident-investigation-branch",
@@ -110,6 +113,7 @@
     "related": [],
     "available_translations": [
       {
+        "content_id": "3df5a305-2819-4125-882b-65c2f3edf6cf",
         "title": "Marine Accident Investigation Branch reports",
         "base_path": "/maib-reports",
         "description": "",

--- a/formats/finder/frontend/examples/policies_finder.json
+++ b/formats/finder/frontend/examples/policies_finder.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "854c7a4a-e8bf-44df-a08a-edbb2a56a58e",
   "base_path": "/government/policies",
   "title": "Policies",
   "description": "",
@@ -31,6 +32,7 @@
     "related": [],
     "available_translations": [
       {
+        "content_id": "854c7a4a-e8bf-44df-a08a-edbb2a56a58e",
         "title": "Policies",
         "base_path": "/government/policies",
         "api_url": "http://content-store.dev.gov.uk/content/government/policies",

--- a/formats/finder/frontend/examples/raib-reports.json
+++ b/formats/finder/frontend/examples/raib-reports.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "bec582be-a95c-41f2-8a56-53dc19f45b76",
   "base_path": "/raib-reports",
   "title": "Rail Accident Investigation Branch reports",
   "description": "",
@@ -82,6 +83,7 @@
   "links": {
     "email_alert_signup": [
       {
+        "content_id": "81e62338-4644-4520-bbfc-6378855e9e43",
         "title": "Rail Accident Investigation Branch reports",
         "base_path": "/raib-reports/email-signup",
         "description": "You'll get an email each time a report is updated or a new report is published.",
@@ -92,6 +94,7 @@
     ],
     "organisations": [
       {
+        "content_id": "7c87edb4-1b32-4da2-bce8-f67fd9bb50db",
         "title": "Rail Accident Investigation Branch",
         "base_path": "/government/organisations/rail-accident-investigation-branch",
         "api_url": "https://www.gov.uk/api/content/government/organisations/rail-accident-investigation-branch",
@@ -102,6 +105,7 @@
     "related": [],
     "available_translations": [
       {
+        "content_id": "bec582be-a95c-41f2-8a56-53dc19f45b76",
         "title": "Rail Accident Investigation Branch reports",
         "base_path": "/raib-reports",
         "description": "",

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -5,11 +5,15 @@
     "type": "object",
     "additionalProperties": false,
     "required": [
+      "content_id",
       "title",
       "base_path",
       "locale"
     ],
     "properties": {
+      "content_id": {
+        "$ref": "#/definitions/guid"
+      },
       "title": {
         "type": "string"
       },

--- a/formats/hmrc_manual/frontend/examples/vat-government-public-bodies.json
+++ b/formats/hmrc_manual/frontend/examples/vat-government-public-bodies.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "e5c19314-6746-4141-9d11-5fbd449a9b2e",
   "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies",
   "title": "VAT Government and Public Bodies",
   "description": "Guidance on VAT as it applies to local authorities and other government and public bodies.",
@@ -120,6 +121,7 @@
   "links": {
     "available_translations": [
       {
+        "content_id": "e5c19314-6746-4141-9d11-5fbd449a9b2e",
         "title": "VAT Government and Public Bodies",
         "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies",
         "api_url": "https://content-store.preview.alphagov.co.uk/content/hmrc-internal-manuals/vat-government-and-public-bodies",

--- a/formats/hmrc_manual_section/frontend/examples/vatgpb1000.json
+++ b/formats/hmrc_manual_section/frontend/examples/vatgpb1000.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "2189bae1-a94e-4f90-917b-ffe25ec9ac4d",
   "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
   "title": "Introduction: contents",
   "description": "",
@@ -67,6 +68,7 @@
   "links": {
     "available_translations": [
       {
+        "content_id": "2189bae1-a94e-4f90-917b-ffe25ec9ac4d",
         "title": "Introduction: contents",
         "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
         "api_url": "https://content-store.preview.alphagov.co.uk/content/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",

--- a/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/curated_level_2_page.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "1a0ec400-632d-4af5-ad96-f18dc028d9ba",
     "base_path": "/browse/benefits/entitlement-with-list",
     "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
     "details": {},
@@ -25,6 +26,7 @@
     "links": {
       "active_top_level_browse_page": [
         {
+          "content_id": "778bb9da-db42-4855-b0a2-1470246a5568",
           "title": "Benefits",
           "base_path": "/browse/benefits",
           "description": "Includes tax credits, eligibility and appeals",
@@ -35,6 +37,7 @@
       ],
       "top_level_browse_pages": [
         {
+          "content_id": "778bb9da-db42-4855-b0a2-1470246a5568",
           "title": "Benefits",
           "base_path": "/browse/benefits",
           "description": "Includes tax credits, eligibility and appeals",
@@ -43,6 +46,7 @@
           "locale": "en"
         },
         {
+          "content_id": "05cd9691-ed36-4cb2-9576-ce7cb81e1936",
           "title": "Births, deaths, marriages and care",
           "base_path": "/browse/births-deaths-marriages",
           "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
@@ -51,6 +55,7 @@
           "locale": "en"
         },
         {
+          "content_id": "426debef-4aad-423e-8597-4851f9015b5f",
           "title": "Business and self-employed",
           "base_path": "/browse/business",
           "description": "Information about starting up and running a business in the UK, including help if you're self employed or a sole trader.",
@@ -61,14 +66,16 @@
       ],
       "second_level_browse_pages": [
         {
+          "content_id": "1a0ec400-632d-4af5-ad96-f18dc028d9ba",
           "title": "Benefits entitlement",
-          "base_path": "/browse/benefits/entitlement",
+          "base_path": "/browse/benefits/entitlement-with-list",
           "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
           "api_url": "https://www.gov.uk/api/content/browse/benefits/entitlement",
           "web_url": "https://www.gov.uk/browse/benefits/entitlement",
           "locale": "en"
         },
         {
+          "content_id": "7fd9bd20-f18c-495b-aac4-e05489be2b87",
           "title": "Benefits for families",
           "base_path": "/browse/benefits/families",
           "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
@@ -77,6 +84,7 @@
           "locale": "en"
         },
         {
+          "content_id": "f6a1202c-8491-49eb-94ce-cdddb55806da",
           "title": "Carers and disability benefits",
           "base_path": "/browse/benefits/disability",
           "description": "Includes Disability Living Allowance, Carer's Allowance and Employment and Support Allowance",

--- a/formats/mainstream_browse_page/frontend/examples/level_2_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "d086e95b-0e5e-46a3-97bc-d0672b111b7c",
     "base_path": "/browse/benefits/entitlement",
     "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
     "details": {},
@@ -6,6 +7,7 @@
     "links": {
       "active_top_level_browse_page": [
         {
+          "content_id": "fde24a9c-f304-4b8b-af67-39faabb3c821",
           "title": "Benefits",
           "base_path": "/browse/benefits",
           "description": "Includes tax credits, eligibility and appeals",
@@ -16,6 +18,7 @@
       ],
       "top_level_browse_pages": [
         {
+          "content_id": "fde24a9c-f304-4b8b-af67-39faabb3c821",
           "title": "Benefits",
           "base_path": "/browse/benefits",
           "description": "Includes tax credits, eligibility and appeals",
@@ -24,6 +27,7 @@
           "locale": "en"
         },
         {
+          "content_id": "2695b93d-aa9f-418a-847d-eaf63a474d75",
           "title": "Births, deaths, marriages and care",
           "base_path": "/browse/births-deaths-marriages",
           "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
@@ -32,6 +36,7 @@
           "locale": "en"
         },
         {
+          "content_id": "14a1e0fd-2ee3-4816-b700-e3640f9c4533",
           "title": "Business and self-employed",
           "base_path": "/browse/business",
           "description": "Information about starting up and running a business in the UK, including help if you're self employed or a sole trader.",
@@ -42,6 +47,7 @@
       ],
       "second_level_browse_pages": [
         {
+          "content_id": "d086e95b-0e5e-46a3-97bc-d0672b111b7c",
           "title": "Benefits entitlement",
           "base_path": "/browse/benefits/entitlement",
           "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
@@ -50,6 +56,7 @@
           "locale": "en"
         },
         {
+          "content_id": "c48318ab-26cf-4049-9c0f-3bc693cf41b7",
           "title": "Benefits for families",
           "base_path": "/browse/benefits/families",
           "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
@@ -58,6 +65,7 @@
           "locale": "en"
         },
         {
+          "content_id": "b8ecf6a5-ea0e-43d1-aa25-fb68bbe62554",
           "title": "Carers and disability benefits",
           "base_path": "/browse/benefits/disability",
           "description": "Includes Disability Living Allowance, Carer's Allowance and Employment and Support Allowance",

--- a/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
+++ b/formats/mainstream_browse_page/frontend/examples/level_2_page_with_related_topics.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "05aadfe6-50d4-4932-bb76-5dfe315a1eb1",
     "base_path": "/browse/benefits/families",
     "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
     "details": {},
@@ -6,6 +7,7 @@
     "links": {
       "related_topics": [
         {
+          "content_id": "4f67c02c-c9c5-4119-baa7-68b910516c08",
           "title": "Universal credit",
           "base_path": "/benefits/universal-credit",
           "api_url": "https://www.gov.uk/api/content/benefits/universal-credit",
@@ -15,6 +17,7 @@
       ],
       "active_top_level_browse_page": [
         {
+          "content_id": "3ed5d5a0-4224-4cc7-a9b1-0c471150f69b",
           "title": "Benefits",
           "base_path": "/browse/benefits",
           "description": "Includes tax credits, eligibility and appeals",
@@ -25,6 +28,7 @@
       ],
       "top_level_browse_pages": [
         {
+          "content_id": "3ed5d5a0-4224-4cc7-a9b1-0c471150f69b",
           "title": "Benefits",
           "base_path": "/browse/benefits",
           "description": "Includes tax credits, eligibility and appeals",
@@ -33,6 +37,7 @@
           "locale": "en"
         },
         {
+          "content_id": "4fd8cfb6-95ea-4998-92e2-7f332254a89b",
           "title": "Births, deaths, marriages and care",
           "base_path": "/browse/births-deaths-marriages",
           "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
@@ -41,6 +46,7 @@
           "locale": "en"
         },
         {
+          "content_id": "15cb6f9b-2c05-487c-b716-c3a0ade38165",
           "title": "Business and self-employed",
           "base_path": "/browse/business",
           "description": "Information about starting up and running a business in the UK, including help if you're self employed or a sole trader.",
@@ -51,6 +57,7 @@
       ],
       "second_level_browse_pages": [
         {
+          "content_id": "eaddac26-5db9-4b1b-9e88-5291b1577ed4",
           "title": "Benefits entitlement",
           "base_path": "/browse/benefits/entitlement",
           "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
@@ -59,6 +66,7 @@
           "locale": "en"
         },
         {
+          "content_id": "05aadfe6-50d4-4932-bb76-5dfe315a1eb1",
           "title": "Benefits for families",
           "base_path": "/browse/benefits/families",
           "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
@@ -67,6 +75,7 @@
           "locale": "en"
         },
         {
+          "content_id": "c1e05eb9-98dc-4cc0-985c-0ec3ec66a4e0",
           "title": "Carers and disability benefits",
           "base_path": "/browse/benefits/disability",
           "description": "Includes Disability Living Allowance, Carer's Allowance and Employment and Support Allowance",

--- a/formats/mainstream_browse_page/frontend/examples/root_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/root_page.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "19ed8498-37ed-4c8e-b0bf-accbb2cf5477",
     "base_path": "/browse",
     "description": "Almost everything on GOV.UK.",
     "details": {},
@@ -6,6 +7,7 @@
     "links": {
       "top_level_browse_pages": [
         {
+          "content_id": "3c0557d1-518e-4a9b-8920-78524944a28c",
           "title": "Benefits",
           "base_path": "/browse/benefits",
           "description": "Includes tax credits, eligibility and appeals",
@@ -14,6 +16,7 @@
           "locale": "en"
         },
         {
+          "content_id": "94ecd143-c60f-4981-a914-242d0c3b0bd1",
           "title": "Births, deaths, marriages and care",
           "base_path": "/browse/births-deaths-marriages",
           "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
@@ -22,6 +25,7 @@
           "locale": "en"
         },
         {
+          "content_id": "88c8dabd-ff05-4530-99ff-ecf3294a9949",
           "title": "Business and self-employed",
           "base_path": "/browse/business",
           "description": "Information about starting up and running a business in the UK, including help if you're self employed or a sole trader.",

--- a/formats/mainstream_browse_page/frontend/examples/top_level_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/top_level_page.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "bfe85c75-0526-4551-b362-8e9f06a8b36c",
     "base_path": "/browse/benefits",
     "description": "Includes tax credits, eligibility and appeals",
     "details": {
@@ -8,6 +9,7 @@
     "links": {
       "top_level_browse_pages": [
         {
+          "content_id": "bfe85c75-0526-4551-b362-8e9f06a8b36c",
           "title": "Benefits",
           "base_path": "/browse/benefits",
           "description": "Includes tax credits, eligibility and appeals",
@@ -16,6 +18,7 @@
           "locale": "en"
         },
         {
+          "content_id": "d0caf80e-f666-41fa-b1ef-5f898014449d",
           "title": "Births, deaths, marriages and care",
           "base_path": "/browse/births-deaths-marriages",
           "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
@@ -24,6 +27,7 @@
           "locale": "en"
         },
         {
+          "content_id": "047f41dd-1ebd-4370-8878-1a851b6538db",
           "title": "Business and self-employed",
           "base_path": "/browse/business",
           "description": "Information about starting up and running a business in the UK, including help if you're self employed or a sole trader.",
@@ -34,6 +38,7 @@
       ],
       "second_level_browse_pages": [
         {
+          "content_id": "f91583d0-be95-4dc8-8268-c2551ff8628a",
           "title": "Benefits entitlement",
           "base_path": "/browse/benefits/entitlement",
           "description": "When and how benefit payments are made, benefits adviser and benefit fraud",
@@ -42,6 +47,7 @@
           "locale": "en"
         },
         {
+          "content_id": "c7d40a39-bda7-42c3-9287-2c080d10a2a9",
           "title": "Benefits for families",
           "base_path": "/browse/benefits/families",
           "description": "Includes Child Trust Funds, childcare and the Sure Start Maternity Grant",
@@ -50,6 +56,7 @@
           "locale": "en"
         },
         {
+          "content_id": "9592c019-1792-430d-88df-df9f560a2d08",
           "title": "Carers and disability benefits",
           "base_path": "/browse/benefits/disability",
           "description": "Includes Disability Living Allowance, Carer's Allowance and Employment and Support Allowance",

--- a/formats/mainstream_browse_page/frontend/examples/top_level_page_with_child_pages_in_curated_order.json
+++ b/formats/mainstream_browse_page/frontend/examples/top_level_page_with_child_pages_in_curated_order.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "e995bd80-cb9b-48dd-bb2c-8e9b2bbefce5",
     "base_path": "/browse/visas-immigration",
     "description": "Visas, settlement, asylum and sponsorship",
     "details": {
@@ -8,6 +9,7 @@
     "links": {
       "top_level_browse_pages": [
         {
+          "content_id": "c4997014-d9d7-4ef8-95b3-87049db8efce",
           "title": "Money and tax",
           "base_path": "/browse/tax",
           "description": "Includes VAT, debt and inheritance tax",
@@ -16,6 +18,7 @@
           "locale": "en"
         },
         {
+          "content_id": "3b6b5aa1-7fbe-4d86-af77-5412698175fc",
           "title": "Passports, travel and living abroad",
           "base_path": "/browse/abroad",
           "description": "Includes renewing passports and travel advice by country",
@@ -24,6 +27,7 @@
           "locale": "en"
         },
         {
+          "content_id": "e995bd80-cb9b-48dd-bb2c-8e9b2bbefce5",
           "title": "Visas and immigration",
           "base_path": "/browse/visas-immigration",
           "description": "Visas, settlement, asylum and sponsorship",
@@ -34,6 +38,7 @@
       ],
       "second_level_browse_pages": [
         {
+          "content_id": "0529f318-e05a-4798-9e77-a901eedfdb37",
           "title": "Work visas",
           "base_path": "/browse/visas-immigration/work-visas",
           "description": "Paid and voluntary work visas (eg Tier 1, Tier 2, Tier 5)",
@@ -42,6 +47,7 @@
           "locale": "en"
         },
         {
+          "content_id": "ce9f6198-f7d1-4625-9ae7-9611ffc9caa7",
           "title": "Asylum",
           "base_path": "/browse/visas-immigration/asylum",
           "description": "Claiming asylum as a refugee, the asylum process and support",
@@ -50,6 +56,7 @@
           "locale": "en"
         },
         {
+          "content_id": "8e9576ca-8bbe-450f-9eb9-14bea6f93534",
           "title": "Transit visas",
           "base_path": "/browse/visas-immigration/transit-visas",
           "description": "In transit through the UK: airside, landside or the common travel area",

--- a/formats/manual/frontend/examples/content-design.json
+++ b/formats/manual/frontend/examples/content-design.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "9b2e22e1-a222-4cda-9799-de7ce56088b0",
   "base_path": "/guidance/content-design",
   "title": "Content design: planning, writing and managing content",
   "description": "Planning and managing digital content to meet the needs the public has of government.",
@@ -68,6 +69,7 @@
   "links": {
     "available_translations": [
       {
+        "content_id": "9b2e22e1-a222-4cda-9799-de7ce56088b0",
         "title": "Content design: planning, writing and managing content",
         "base_path": "/guidance/content-design",
         "api_url": "https://content-store.preview.alphagov.co.uk/content/guidance/content-design",

--- a/formats/manual_section/frontend/examples/what-is-content-design.json
+++ b/formats/manual_section/frontend/examples/what-is-content-design.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "66d565ea-1544-4410-85ff-2e411cdf78e6",
   "base_path": "/guidance/content-design/what-is-content-design",
   "title": "What is content design?",
   "description": "Introduction to content design.",
@@ -23,6 +24,7 @@
   "links": {
     "available_translations": [
       {
+        "content_id": "66d565ea-1544-4410-85ff-2e411cdf78e6",
         "title": "What is content design?",
         "base_path": "/guidance/content-design/what-is-content-design",
         "api_url": "https://content-store.preview.alphagov.co.uk/content/guidance/content-design/what-is-content-design",

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -15,8 +15,7 @@
       "$ref" : "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "title": {
       "type": "string"
@@ -88,10 +87,14 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
       "description": "A path only. Query string and/or fragment are not allowed."
     },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "guid_list": {
       "type": "array",
       "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        "$ref": "#/definitions/guid"
       }
     },
     "route": {

--- a/formats/policy/frontend/examples/minimal_policy_area.json
+++ b/formats/policy/frontend/examples/minimal_policy_area.json
@@ -1,4 +1,5 @@
 {
+   "content_id": "2f675206-25cc-482f-9eb9-7c25a555ce7f",
    "base_path": "/government/policies/minimal-benefits-reform",
    "title": "Minimal benefits reform",
    "description": "",
@@ -23,6 +24,7 @@
       "related":[],
       "email_alert_signup":[
         {
+          "content_id": "2054b5e5-8d58-456b-8832-66c0d2b72565",
           "title": "Minimal Benefits Reform",
           "base_path": "/government/policies/minimal-benefits-reform/email-signup",
           "api_url": "https://www.gov.uk/api/content/government/policies/minimal-benefits-reform/email-signup",

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -1,4 +1,5 @@
 {
+   "content_id": "f8c3682c-3a88-4f35-afba-3607384e39e6",
    "base_path": "/government/policies/benefits-reform",
    "title": "Benefits Reform",
    "description": "",
@@ -58,6 +59,7 @@
    "links": {
       "organisations":[
         {
+          "content_id": "a4759607-4fd8-4cf0-9d56-af9d14a71162",
           "title": "Department for Work and Pensions",
           "base_path": "/government/organisations/department-for-work-and-pensions",
           "api_url": "https://www.gov.uk/api/organisations/department-for-work-and-pensions",
@@ -70,6 +72,7 @@
       "related":[],
       "email_alert_signup":[
         {
+          "content_id": "69938c64-4bb3-4b4f-814b-e73cb71831ef",
           "title": "Benefits Reform",
           "base_path": "/government/policies/benefits-reform/email-signup",
           "api_url": "https://www.gov.uk/api/content/government/policies/benefits-reform/email-signup",
@@ -79,6 +82,7 @@
       ],
       "available_translations":[
          {
+            "content_id": "f8c3682c-3a88-4f35-afba-3607384e39e6",
             "title": "Benefits Reform",
             "base_path": "/government/policies/benefits-reform",
             "api_url": "https://www.gov.uk/api/content/government/policies/benefits-reform",

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -1,4 +1,5 @@
 {
+   "content_id": "6c767453-c328-4cb4-8812-fae88a250bb3",
    "base_path": "/government/policies/universal-credit",
    "title": "Universal Credit",
    "description": "",
@@ -57,6 +58,7 @@
    "links": {
       "organisations":[
         {
+          "content_id": "9417d532-a080-4856-9a0f-08b1d9d78c98",
           "title": "Department for Work and Pensions",
           "base_path": "/government/organisations/department-for-work-and-pensions",
           "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-and-pensions",
@@ -66,6 +68,7 @@
       ],
       "people": [
         {
+          "content_id": "295ce3e3-a68b-4952-8f13-72ea62f5c16b",
           "title": "George Dough",
           "base_path": "/government/people/george-dough",
           "api_url": "https://www.gov.uk/api/content/government/people/george-dough",
@@ -75,6 +78,7 @@
       ],
       "working_groups": [
         {
+          "content_id": "248de49c-da2a-4142-9310-bcea244c6dce",
           "title": "Medical Advisory Group",
           "base_path": "/government/groups/medical-advisory-group",
           "api_url": "https://www.gov.uk/api/content/government/groups/medical-advisory-group",
@@ -85,6 +89,7 @@
       "related":[],
       "email_alert_signup":[
         {
+          "content_id": "a0f12caf-2555-4bfc-9c85-0c8ad4c1e766",
           "title": "Universal Credit",
           "base_path": "/government/policies/universal-credit/email-signup",
           "api_url": "https://www.gov.uk/api/content/government/policies/universal-credit/email-signup",
@@ -94,6 +99,7 @@
       ],
       "policy_areas":[
         {
+          "content_id": "848b8564-328c-4787-bebb-9e1b60ccf0d7",
           "title": "Benefits Reform",
           "base_path": "/government/policies/benefits-reform",
           "api_url": "https://www.gov.uk/api/content/government/policies/benefits-reform",
@@ -103,6 +109,7 @@
       ],
       "available_translations":[
          {
+            "content_id": "6c767453-c328-4cb4-8812-fae88a250bb3",
             "title": "Unveirsal Credit",
             "base_path": "/government/policies/universal-credit",
             "api_url": "https://www.gov.uk/api/content/government/policies/universal-credit",

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -1,4 +1,5 @@
 {
+   "content_id": "c3fee553-1891-411b-8d00-4aefbe86e40a",
    "base_path": "/government/policies/keeping-northern-ireland-safe",
    "title": "Keeping Northern Ireland safe",
    "description": "",
@@ -51,6 +52,7 @@
    "links": {
       "organisations":[
         {
+          "content_id": "8927158f-e4b2-4361-b55d-02de7599b220",
           "title": "Northern Ireland Office",
           "base_path": "/government/organisations/northern-ireland-office",
           "api_url": "https://www.gov.uk/api/organisations/northern-ireland-office",
@@ -60,6 +62,7 @@
       ],
       "people": [
         {
+          "content_id": "70dc1901-2d36-4c3d-98ee-e1d5587a5ba9",
           "title": "George Dough",
           "base_path": "/government/people/george-dough",
           "api_url": "https://www.gov.uk/api/government/people/george-dough",
@@ -70,6 +73,7 @@
       "related":[],
       "available_translations":[
          {
+            "content_id": "c3fee553-1891-411b-8d00-4aefbe86e40a",
             "title": "Keeping Northern Ireland safe",
             "base_path": "/government/policies/keeping-northern-ireland-safe",
             "api_url": "https://www.gov.uk/api/content/government/policies/keeping-northern-ireland-safe",

--- a/formats/specialist_document/frontend/examples/aaib-reports.json
+++ b/formats/specialist_document/frontend/examples/aaib-reports.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "fb81a47b-7c8f-4280-b6c7-b6fa258b19b3",
 	"public_updated_at" : "2015-07-09T08:17:10+00:00",
 	"format": "specialist_document",
 	"locale": "en",

--- a/formats/specialist_document/frontend/examples/asylum-support-decision.json
+++ b/formats/specialist_document/frontend/examples/asylum-support-decision.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "3917cb0e-0928-45b7-bf63-20f9bc113a7a",
   "base_path": "/asylum-support-decisions/ast-06-04-13140",
   "title": "AST / 06 / 04 / 13140",
   "description": "The House of Lords guidance in Limbuela did not include failed asylum seekers - paragraphs 13, 81 and 100 of their Lordships' judgement refers - the solution to a failed asylum seeker's destitution lies in his own hands by way of a voluntary return home - an option not expected of an asylum seeker",
@@ -36,6 +37,7 @@
   "links": {
     "available_translations": [
       {
+        "content_id": "3917cb0e-0928-45b7-bf63-20f9bc113a7a",
         "title": "AST / 06 / 04 / 13140",
         "base_path": "/asylum-support-decisions/ast-06-04-13140",
         "description": "The House of Lords guidance in Limbuela did not include failed asylum seekers - paragraphs 13, 81 and 100 of their Lordships' judgement refers - the solution to a failed asylum seeker's destitution lies in his own hands by way of a voluntary return home - an option not expected of an asylum seeker",

--- a/formats/specialist_document/frontend/examples/cma-cases.json
+++ b/formats/specialist_document/frontend/examples/cma-cases.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "574585b6-bf99-4cb1-be8b-628695f358d9",
 	"format": "specialist_document",
 	"locale": "en",
 	"base_path" : "/cma-cases/richemont-yoox-net-a-porter-merger-inquiry",

--- a/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "6f86e13a-04f5-4b69-98f3-4ab374c764e0",
 	"format": "specialist_document",
 	"locale": "en",
 	"base_path" : "/countryside-stewardship-grants/nectar-flower-mix-ab1",

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "23714fce-cd0f-45cf-abae-65eec4756981",
 	"format": "specialist_document",
 	"locale": "en",
 	"base_path" : "/drug-device-alerts/transwarmer-infant-transport-mattress-novaplus-transwarmer-infant-heat-therapy-mattress-with-warmgel-infant-heel-warmer-risk-of-serious-burn",

--- a/formats/specialist_document/frontend/examples/drug-safety-update.json
+++ b/formats/specialist_document/frontend/examples/drug-safety-update.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "7a06f974-ffbd-467f-ba0b-7ade2a15f0e4",
 	"format": "specialist_document",
 	"locale": "en",
 	"details" : {

--- a/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
+++ b/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "2f1560bf-8b24-48c5-a9b4-3e29d27d3e48",
 	"format": "specialist_document",
 	"locale": "en",
 	"details" : {

--- a/formats/specialist_document/frontend/examples/international-development-funding.json
+++ b/formats/specialist_document/frontend/examples/international-development-funding.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "7cf2bfcb-8711-4cf4-951e-a27efb04a231",
 	"format": "specialist_document",
 	"locale": "en",
 	"details" : {

--- a/formats/specialist_document/frontend/examples/maib-reports.json
+++ b/formats/specialist_document/frontend/examples/maib-reports.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "10089df0-4c3d-4779-b6e3-174daa6e1cbc",
 	"format": "specialist_document",
 	"locale": "en",
 	"details" : {

--- a/formats/specialist_document/frontend/examples/raib-reports.json
+++ b/formats/specialist_document/frontend/examples/raib-reports.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "8b75627d-7c41-40fb-8c74-978e12dc920f",
 	"format": "specialist_document",
 	"locale": "en",
 	"base_path" : "/raib-reports/train-driver-receiving-a-severe-electric-shock-at-sutton-weaver",

--- a/formats/topic/frontend/examples/curated_subtopic.json
+++ b/formats/topic/frontend/examples/curated_subtopic.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "e8238ae7-39a7-47c4-bc3a-501da0b55afe",
     "base_path": "/topic/oil-and-gas/offshore",
     "description": "A page about offshore oil and gas",
     "details": {
@@ -22,6 +23,7 @@
     "links": {
       "parent": [
         {
+          "content_id": "9d7a445f-7451-4ef8-815e-ae66676a240b",
           "base_path": "/topic/oil-and-gas",
           "title": "Oil and gas",
           "api_url": "https://www.gov.uk/api/content/topic/oil-and-gas",

--- a/formats/topic/frontend/examples/topic-in-beta.json
+++ b/formats/topic/frontend/examples/topic-in-beta.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "88df090f-8d1c-4629-b2f5-1f573b72b44e",
     "base_path": "/topic/oil-and-gas-beta",
     "description": "",
     "details": {

--- a/formats/topic/frontend/examples/topic.json
+++ b/formats/topic/frontend/examples/topic.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "63d98739-fc60-4e28-a65f-edb56000fd39",
     "base_path": "/topic/oil-and-gas",
     "description": "",
     "details": {},
@@ -6,6 +7,7 @@
     "links": {
       "children": [
         {
+          "content_id": "f6eef5ca-be55-41b2-98be-f72b3e649b84",
           "base_path": "/topic/oil-and-gas/fields-and-wells",
           "title": "Fields and wells",
           "api_url": "https://www.gov.uk/api/content/topic/oil-and-gas/fields-and-wells",
@@ -13,6 +15,7 @@
           "locale": "en"
         },
         {
+          "content_id": "0a6116da-fbf6-4d5c-baa9-2a74ae8a8fb9",
           "base_path": "/topic/oil-and-gas/licensing",
           "title": "Licensing",
           "api_url": "https://www.gov.uk/api/content/topic/oil-and-gas/licensing",

--- a/formats/topic/frontend/examples/uncurated_subtopic.json
+++ b/formats/topic/frontend/examples/uncurated_subtopic.json
@@ -1,4 +1,5 @@
 {
+    "content_id": "ee990f3e-5aee-4a09-a247-70177ea23690",
     "base_path": "/topic/oil-and-gas/licensing",
     "description": "A page about oil and gas licensing",
     "details": {
@@ -7,6 +8,7 @@
     "links": {
       "parent": [
         {
+          "content_id": "a6510b11-75c8-4df3-be2d-17d0e2c081be",
           "base_path": "/topic/oil-and-gas",
           "title": "Oil and gas",
           "api_url": "https://www.gov.uk/api/content/topic/oil-and-gas",

--- a/formats/unpublishing/frontend/examples/unpublishing.json
+++ b/formats/unpublishing/frontend/examples/unpublishing.json
@@ -1,4 +1,5 @@
 {
+  "content_id": "19ed8498-37ed-4c8e-b0bf-accbb2cf5477",
   "base_path":"/government/case-studies/bubble-trouble",
   "title":"Bubble and trouble",
   "description":"A case study about bubble and trouble.",
@@ -17,6 +18,7 @@
   "links":{
     "available_translations":[
       {
+        "content_id": "19ed8498-37ed-4c8e-b0bf-accbb2cf5477",
         "title":"Bubble and trouble",
         "base_path":"/government/case-studies/bubble-trouble",
         "api_url": "https://www.gov.uk/api/content/government/case-studies/bubble-trouble",

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -9,7 +9,6 @@ class GovukContentSchemas::FrontendSchemaGenerator
 
   INTERNAL_PROPERTIES = %w{
     access_limited
-    content_id
     publishing_app
     redirects
     rendering_app

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   }
 
   let(:internal_properties) {
-    %w{content_id publishing_app redirects rendering_app routes update_type}
+    %w{publishing_app redirects rendering_app routes update_type}
   }
 
   it "does not modify its input" do


### PR DESCRIPTION
This includes the content_id in the frontend representation of content
items - both in the main item, and in the expanded links.

It is becoming necessary for some of the frontend applications to know
about content_ids (eg email_alert_frontend needs the topic content_ids
in order to send them to email-slert-api to create the link to
govdelivery topics).

Trello: https://trello.com/c/7K6FySvv