### PR TITLE
Make routes required

### DIFF
--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -57,6 +57,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -58,6 +58,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -8,6 +8,7 @@
     "rendering_app",
     "update_type",
     "locale",
+    "routes",
     "public_updated_at"
   ],
   "properties": {

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -51,6 +51,7 @@
     },
     "routes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/route"
       }


### PR DESCRIPTION
Routes are required by the content-store. We should make them mandatory here as well so that we can test that content we send to publishing-api is actually valid.

Inspired by https://github.com/alphagov/calendars/pull/93, where the contract tests passed, but publishing failed. 