### PR TITLE
Finders don't require a Filter

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -57,7 +57,6 @@
       "additionalProperties": false,
       "required": [
         "document_noun",
-        "filter",
         "facets"
       ],
       "properties": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -101,7 +101,6 @@
       "additionalProperties": false,
       "required": [
         "document_noun",
-        "filter",
         "facets"
       ],
       "properties": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -57,7 +57,6 @@
       "additionalProperties": false,
       "required": [
         "document_noun",
-        "filter",
         "facets"
       ],
       "properties": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -101,7 +101,6 @@
       "additionalProperties": false,
       "required": [
         "document_noun",
-        "filter",
         "facets"
       ],
       "properties": {

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "document_noun",
-    "filter",
     "facets"
   ],
   "properties": {

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "document_noun",
-    "filter",
     "facets"
   ],
   "properties": {


### PR DESCRIPTION
Now that Finders/Policies can use a `reject` hash to build the base query, we no
longer require a `filter` hash to be present.