### PR TITLE
Tweak example datetime format...

### DIFF
--- a/formats/special_route/publisher/examples/robots.txt.json
+++ b/formats/special_route/publisher/examples/robots.txt.json
@@ -4,7 +4,7 @@
   "title": "Instructions for crawler robots",
   "description": "robots.txt provides rules for which parts of GOV.UK are permitted to be crawled by different bots.",
   "format": "special_route",
-  "public_updated_at": "2015-07-30T13:58:11+00:00",
+  "public_updated_at": "2015-07-30T13:58:11.000Z",
   "publishing_app": "static",
   "rendering_app": "static",
   "routes": [


### PR DESCRIPTION
We're using this example to generate the contract
tests in gds-api-adapters. By default, Rails formats
JSON with a particular datetime format. This didn't
match the one in the example.

Both of these formats are valid with the same RFC:
http://tools.ietf.org/html/rfc3339

This is a simple fix that resolves the problem.