### PR TITLE
Add tax tribunal decisions schema and examples

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -187,6 +187,9 @@
           "$ref": "#/definitions/raib_report_metadata"
         },
         {
+          "$ref": "#/definitions/tax_tribunal_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata"
         }
       ]
@@ -883,6 +886,42 @@
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "tax_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "tax_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_category": {
+          "type": "string",
+          "enum": [
+            "banking",
+            "charity",
+            "financial-services",
+            "land-registration",
+            "pensions",
+            "tax"
+          ]
+        },
+        "tribunal_decision_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -228,6 +228,9 @@
           "$ref": "#/definitions/raib_report_metadata"
         },
         {
+          "$ref": "#/definitions/tax_tribunal_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata"
         }
       ]
@@ -924,6 +927,39 @@
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "tax_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "tax_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_category": {
+          "type": "string",
+          "enum": [
+            "banking",
+            "charity",
+            "financial-services",
+            "land-registration",
+            "pensions",
+            "tax"
+          ]
+        },
+        "tribunal_decision_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         }
       }
     },

--- a/formats/finder/frontend/examples/tax-tribunal-decisions.json
+++ b/formats/finder/frontend/examples/tax-tribunal-decisions.json
@@ -1,0 +1,98 @@
+{
+  "content_id": "632290ae-aad8-4895-b135-1e0a72a6bdeb",
+  "base_path": "/tax-and-chancery-tribunal-decisions",
+  "title": "Tax and Chancery tribunal decisions",
+  "description": "Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).",
+  "format": "finder",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-10-07T13:15:28.108Z",
+  "public_updated_at": "2015-10-07T10:14:26.000+00:00",
+  "details": {
+    "document_noun": "decision",
+    "filter": {
+      "document_type": "tax_tribunal_decision"
+    },
+    "format_name": "Tax and Chancery tribunal decision",
+    "show_summaries": true,
+    "summary": "<p>Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).</p>",
+    "facets": [
+      {
+        "key": "tribunal_decision_category",
+        "name": "Category",
+        "short_name": "category",
+        "type": "text",
+        "preposition": "categorised as",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Banking",
+            "value": "banking"
+          },
+          {
+            "label": "Charity",
+            "value": "charity"
+          },
+          {
+            "label": "Financial Services",
+            "value": "financial-services"
+          },
+          {
+            "label": "Land Registration",
+            "value": "land-registration"
+          },
+          {
+            "label": "Pensions",
+            "value": "pensions"
+          },
+          {
+            "label": "Tax",
+            "value": "tax"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_category_name",
+        "name": "Category name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_decision_date",
+        "name": "Release date",
+        "short_name": "Released",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ]
+  },
+  "links": {
+    "organisations": [],
+    "related": [],
+    "email_alert_signup": [
+      {
+        "content_id": "ae5afec1-30d6-4997-bdf8-7de94d2dd910",
+        "title": "Tax and Chancery tribunal decisions",
+        "base_path": "/tax-and-chancery-tribunal-decisions/email-signup",
+        "description": "You'll get an email each time a decision is updated or a new decision is published.",
+        "api_url": "http://content-store.dev.gov.uk/content/tax-and-chancery-tribunal-decisions/email-signup",
+        "web_url": "http://www.dev.gov.uk/tax-and-chancery-tribunal-decisions/email-signup",
+        "locale": "en"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "632290ae-aad8-4895-b135-1e0a72a6bdeb",
+        "title": "Tax and Chancery tribunal decisions",
+        "base_path": "/tax-and-chancery-tribunal-decisions",
+        "description": "Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).",
+        "api_url": "http://content-store.dev.gov.uk/content/tax-and-chancery-tribunal-decisions",
+        "web_url": "http://www.dev.gov.uk/tax-and-chancery-tribunal-decisions",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
@@ -1,0 +1,40 @@
+{
+  "content_id": "5ea90783-1a5b-4c0b-9c48-ce7ba478ee7b",
+  "base_path": "/tax-and-chancery-tribunal-decisions/why-pay-more-for-cars-limited-v-the-commissioners-for-her-majesty-s-revenue-and-customs",
+  "title": "Why Pay More For Cars Limited v The Commissioners For Her Majesty's Revenue And Customs",
+  "description": "VALUE ADDED TAX - Edwards v Bairstow - jurisdiction of Upper Tribunal - appeal against refusal of claim for repayment of overpaid VAT",
+  "format": "specialist_document",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-10-08T09:48:30.337Z",
+  "public_updated_at": "2015-10-07T10:56:47.000+00:00",
+  "details": {
+    "metadata": {
+      "bulk_published": false,
+      "document_type": "tax_tribunal_decision",
+      "tribunal_decision_category": "tax",
+      "tribunal_decision_decision_date": "2015-09-08",
+      "hidden_indexable_content": "whether FTT entitled not to find or infer that car dealer had accounted for VAT on bonuses paid by manufacturers to dealer on purchase of demonstrator and courtesy cars in claim periods - appeal dismissed"
+    },
+    "change_history": [
+      {
+        "public_timestamp": "2015-10-07T10:54:48+00:00",
+        "note": "Add attachment."
+      }
+    ],
+    "body": "<p>Download decision as a PDF document: <a rel=\"external\" href=\"http://assets-origin.dev.gov.uk/media/5614f9f7759b74281e000001/Why-Pay-More-for-Cars-v-HMRC.pdf\">Why Pay More For Cars Limited v The Commissioners For Her Majesty&rsquo;s Revenue And Customs</a></p>\n"
+  },
+  "links": {
+    "available_translations": [
+      {
+        "content_id": "5ea90783-1a5b-4c0b-9c48-ce7ba478ee7b",
+        "title": "Why Pay More For Cars Limited v The Commissioners For Her Majesty's Revenue And Customs",
+        "base_path": "/tax-and-chancery-tribunal-decisions/why-pay-more-for-cars-limited-v-the-commissioners-for-her-majesty-s-revenue-and-customs",
+        "description": "VALUE ADDED TAX - Edwards v Bairstow - jurisdiction of Upper Tribunal - appeal against refusal of claim for repayment of overpaid VAT",
+        "api_url": "http://content-store.dev.gov.uk/content/tax-and-chancery-tribunal-decisions/why-pay-more-for-cars-limited-v-the-commissioners-for-her-majesty-s-revenue-and-customs",
+        "web_url": "http://www.dev.gov.uk/tax-and-chancery-tribunal-decisions/why-pay-more-for-cars-limited-v-the-commissioners-for-her-majesty-s-revenue-and-customs",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -54,6 +54,7 @@
         { "$ref": "#/definitions/maib_report_metadata" },
         { "$ref": "#/definitions/medical_safety_alert_metadata" },
         { "$ref": "#/definitions/raib_report_metadata" },
+        { "$ref": "#/definitions/tax_tribunal_decision_metadata" },
         { "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata" }
       ]
     },
@@ -747,6 +748,39 @@
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "tax_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "tax_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_category": {
+          "type": "string",
+          "enum": [
+            "banking",
+            "charity",
+            "financial-services",
+            "land-registration",
+            "pensions",
+            "tax"
+          ]
+        },
+        "tribunal_decision_category_name": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION


The Upper Tribunal (Tax and Chancery Chamber) publishes decisions that describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.