### PR TITLE
Remove warning from build log

### DIFF
--- a/bin/combine_publisher_schema
+++ b/bin/combine_publisher_schema
@@ -48,8 +48,6 @@ schemas = schema_files.reduce(Hash.new) do |schema_files, (name, filename)|
     end
 
     schema_files[name] = schema
-  else
-    $stderr.puts "Warning: #{path} not found"
   end
 
   schema_files


### PR DESCRIPTION
A format can have a `metadata.json` and a `links.json` file, but these are not required. This warning gives the impression something is wrong when one of them is missing, while everything is :ok_hand:.


## Before

```
bundle exec ./bin/combine_publisher_schema formats/case_study/publisher dist/formats/case_study/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/coming_soon/publisher dist/formats/coming_soon/publisher/schema.json
Warning: formats/coming_soon/publisher/links.json not found
bundle exec ./bin/combine_publisher_schema formats/email_alert_signup/publisher dist/formats/email_alert_signup/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/finder/publisher dist/formats/finder/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/hmrc_manual/publisher dist/formats/hmrc_manual/publisher/schema.json
Warning: formats/hmrc_manual/publisher/links.json not found
bundle exec ./bin/combine_publisher_schema formats/hmrc_manual_section/publisher dist/formats/hmrc_manual_section/publisher/schema.json
Warning: formats/hmrc_manual_section/publisher/links.json not found
bundle exec ./bin/combine_publisher_schema formats/mainstream_browse_page/publisher dist/formats/mainstream_browse_page/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/manual/publisher dist/formats/manual/publisher/schema.json
Warning: formats/manual/publisher/links.json not found
bundle exec ./bin/combine_publisher_schema formats/manual_section/publisher dist/formats/manual_section/publisher/schema.json
Warning: formats/manual_section/publisher/links.json not found
bundle exec ./bin/combine_publisher_schema formats/placeholder/publisher dist/formats/placeholder/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/policy/publisher dist/formats/policy/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/specialist_document/publisher dist/formats/specialist_document/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/topic/publisher dist/formats/topic/publisher/schema.json
...
```

## After

```
bundle exec ./bin/combine_publisher_schema formats/case_study/publisher dist/formats/case_study/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/coming_soon/publisher dist/formats/coming_soon/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/email_alert_signup/publisher dist/formats/email_alert_signup/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/finder/publisher dist/formats/finder/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/hmrc_manual/publisher dist/formats/hmrc_manual/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/hmrc_manual_section/publisher dist/formats/hmrc_manual_section/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/mainstream_browse_page/publisher dist/formats/mainstream_browse_page/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/manual/publisher dist/formats/manual/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/manual_section/publisher dist/formats/manual_section/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/placeholder/publisher dist/formats/placeholder/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/policy/publisher dist/formats/policy/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/specialist_document/publisher dist/formats/specialist_document/publisher/schema.json
bundle exec ./bin/combine_publisher_schema formats/topic/publisher dist/formats/topic/publisher/schema.json
...
```