### PR TITLE
[Discuss] Run `make clean` before running tests 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ rescue LoadError
 end
 
 task :make do
-  sh "make"
+  sh "make clean && make"
 end
 
 desc "creates the folders and files for adding a new format"


### PR DESCRIPTION
If `make clean` isn't run, `make` will not regenerate all files. This sometimes causes tests to pass in development, but not on CI, where we `make clean` before every test run.

This has tripped up @tommyp and me today, as https://github.com/alphagov/govuk-content-schemas/pull/126 was passing on our machines but failing on CI (https://ci-new.alphagov.co.uk/job/govuk_content_schemas/126/console).

@rboulton @alext @heathd thoughts?