### PR TITLE
Running rake now runs make clean && make

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ rescue LoadError
 end
 
 task :make do
-  sh "make"
+  sh "make clean && make"
 end
 
 desc "creates the folders and files for adding a new format"


### PR DESCRIPTION
When running `bundle exec rake` previously it only ran `make`, which
doesn't rebuild the schemas each time which sometimes passes when it
shouldn't.

This commit changes `rake` to run `make clean` which deletes all the
derived files and regenerates them.