### PR TITLE
Don't expected Dir.glob to return ordered filenames

### DIFF
--- a/spec/lib/finder_schema_converter_spec.rb
+++ b/spec/lib/finder_schema_converter_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
 
   context "converting multiple files" do
     let(:input_files) {
-      Dir[File.dirname(__FILE__) + "/../fixtures/finder_schemas/*.json"]
+      Dir[File.dirname(__FILE__) + "/../fixtures/finder_schemas/*.json"].sort
     }
 
     it "combines all of the facets from each file" do


### PR DESCRIPTION
Depending on the OS, the results of Dir.glob might not be in the order
you expect them. http://ruby-doc.org/core-2.1.2/Dir.html#method-c-glob

This causes this test to fail sometimes.