### PR TITLE
Add two new HMRA alert types

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -810,7 +810,9 @@
           "type": "string",
           "enum": [
             "drugs",
-            "devices"
+            "devices",
+            "field-safety",
+            "company-led-drug"
           ]
         },
         "medical_specialism": {

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -851,7 +851,9 @@
           "type": "string",
           "enum": [
             "drugs",
-            "devices"
+            "devices",
+            "field-safety",
+            "company-led-drug"
           ]
         },
         "medical_specialism": {

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -672,7 +672,9 @@
           "type": "string",
           "enum": [
             "drugs",
-            "devices"
+            "devices",
+            "field-safety",
+            "company-led-drug"
           ]
         },
         "medical_specialism": {


### PR DESCRIPTION
https://trello.com/c/tiCatwpE/117-add-two-new-alert-types-to-mhra-drug-device-alerts-finder-small

MHRA are removing these remaining alerts away from publications to a
finder.

Related: 
https://github.com/alphagov/rummager/pull/530
https://github.com/alphagov/specialist-publisher/pull/581