### PR TITLE
Add employment tribunal decisions schema and examples

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -217,6 +217,9 @@
           "$ref": "#/definitions/employment_appeal_tribunal_decision_metadata"
         },
         {
+          "$ref": "#/definitions/employment_tribunal_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/european_structural_investment_fund_metadata"
         },
         {
@@ -665,6 +668,50 @@
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_country": {
+          "type": "string",
+          "enum": [
+            "england-and-wales",
+            "scotland"
+          ]
+        },
+        "tribunal_decision_country_name": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -260,6 +260,9 @@
           "$ref": "#/definitions/employment_appeal_tribunal_decision_metadata"
         },
         {
+          "$ref": "#/definitions/employment_tribunal_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/european_structural_investment_fund_metadata"
         },
         {
@@ -708,6 +711,50 @@
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_country": {
+          "type": "string",
+          "enum": [
+            "england-and-wales",
+            "scotland"
+          ]
+        },
+        "tribunal_decision_country_name": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -222,6 +222,9 @@
           "$ref": "#/definitions/employment_appeal_tribunal_decision_metadata"
         },
         {
+          "$ref": "#/definitions/employment_tribunal_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/european_structural_investment_fund_metadata"
         },
         {
@@ -670,6 +673,50 @@
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_country": {
+          "type": "string",
+          "enum": [
+            "england-and-wales",
+            "scotland"
+          ]
+        },
+        "tribunal_decision_country_name": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         }
       }
     },

--- a/formats/finder/frontend/examples/employment-tribunal-decisions.json
+++ b/formats/finder/frontend/examples/employment-tribunal-decisions.json
@@ -1,0 +1,106 @@
+{
+  "content_id": "1b5e08c8-ddde-4637-9375-f79e085ba6d5",
+  "base_path": "/employment-tribunal-decisions",
+  "title": "Employment tribunal decisions",
+  "description": "Find decisions on Employment Tribunal cases in England, Wales and Scotland.",
+  "format": "finder",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-10-15T14:25:29.741Z",
+  "public_updated_at": "2015-10-15T11:45:22.000+00:00",
+  "details": {
+    "document_noun": "decision",
+    "filter": {
+      "document_type": "employment_tribunal_decision"
+    },
+    "format_name": "Employment tribunal decision",
+    "show_summaries": true,
+    "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland.</p>",
+    "facets": [
+      {
+        "key": "tribunal_decision_country",
+        "name": "Country",
+        "type": "text",
+        "preposition": "by country",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "England and Wales",
+            "value": "england-and-wales"
+          },
+          {
+            "label": "Scotland",
+            "value": "scotland"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_country_name",
+        "name": "Country name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_categories",
+        "name": "Jurisdiction code",
+        "type": "text",
+        "preposition": "by jurisdiction",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Age Discrimination",
+            "value": "age-discrimination"
+          },
+          {
+            "label": "Agency Workers",
+            "value": "agency-workers"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_categories_name",
+        "name": "Jurisdiction code name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_decision_date",
+        "name": "Decision date",
+        "short_name": "Decided",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ]
+  },
+  "links": {
+    "organisations": [],
+    "related": [],
+    "email_alert_signup": [
+      {
+        "content_id": "6d7ace06-f437-4fb3-b948-8534ff34540f",
+        "title": "Employment tribunal decisions",
+        "base_path": "/employment-tribunal-decisions/email-signup",
+        "description": "You'll get an email each time a decision is updated or a new decision is published.",
+        "api_url": "http://content-store.dev.gov.uk/content/employment-tribunal-decisions/email-signup",
+        "web_url": "http://www.dev.gov.uk/employment-tribunal-decisions/email-signup",
+        "locale": "en"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "1b5e08c8-ddde-4637-9375-f79e085ba6d5",
+        "title": "Employment tribunal decisions",
+        "base_path": "/employment-tribunal-decisions",
+        "description": "Find decisions on Employment Tribunal cases in England, Wales and Scotland.",
+        "api_url": "http://content-store.dev.gov.uk/content/employment-tribunal-decisions",
+        "web_url": "http://www.dev.gov.uk/employment-tribunal-decisions",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
@@ -1,0 +1,44 @@
+{
+  "content_id": "a66a167f-081b-4b0c-bd8e-3bb1242507df",
+  "base_path": "/employment-tribunal-decisions/retained-firefighters-case-management-order-of-employment-tribunal-of-19-december-2008",
+  "title": "Retained Firefighters:Case Management Order of Employment Tribunal of 19 December 2008",
+  "description": "This Case Management Discussion concerns the large number of claims brought by retained fire-fighters, principally in 1994 and 1995, complaining that their exclusion from the pension scheme.",
+  "format": "specialist_document",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-10-15T14:26:18.717Z",
+  "public_updated_at": "2015-10-15T14:26:18.000+00:00",
+  "details": {
+    "metadata": {
+      "hidden_indexable_content": "The stay was extended pending the determination of proceedings commenced in 2000/2001 under the Part-time Workers (Prevention of Less Favourable Treatment) Regulations 2000, known as the Matthews -v- Kent & Medway Fire Authority litigation.",
+      "tribunal_decision_categories": [
+        "contract-of-employment",
+        "part-time-workers"
+      ],
+      "tribunal_decision_country": "england-and-wales",
+      "tribunal_decision_decision_date": "2008-12-19",
+      "bulk_published": false,
+      "document_type": "employment_tribunal_decision"
+    },
+    "change_history": [
+      {
+        "public_timestamp": "2015-10-15T12:00:37+00:00",
+        "note": "First published."
+      }
+    ],
+    "body": "<p>Download PDF: </p>\n"
+  },
+  "links": {
+    "available_translations": [
+      {
+        "content_id": "a66a167f-081b-4b0c-bd8e-3bb1242507df",
+        "title": "Retained Firefighters:Case Management Order of Employment Tribunal of 19 December 2008",
+        "base_path": "/employment-tribunal-decisions/retained-firefighters-case-management-order-of-employment-tribunal-of-19-december-2008",
+        "description": "This Case Management Discussion concerns the large number of claims brought by retained fire-fighters, principally in 1994 and 1995, complaining that their exclusion from the pension scheme.",
+        "api_url": "http://content-store.dev.gov.uk/content/employment-tribunal-decisions/retained-firefighters-case-management-order-of-employment-tribunal-of-19-december-2008",
+        "web_url": "http://www.dev.gov.uk/employment-tribunal-decisions/retained-firefighters-case-management-order-of-employment-tribunal-of-19-december-2008",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -50,6 +50,7 @@
         { "$ref": "#/definitions/countryside_stewardship_grant_metadata" },
         { "$ref": "#/definitions/drug_safety_update_metadata" },
         { "$ref": "#/definitions/employment_appeal_tribunal_decision_metadata" },
+        { "$ref": "#/definitions/employment_tribunal_decision_metadata" },
         { "$ref": "#/definitions/european_structural_investment_fund_metadata" },
         { "$ref": "#/definitions/international_development_fund_metadata" },
         { "$ref": "#/definitions/maib_report_metadata" },
@@ -483,6 +484,50 @@
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_country": {
+          "type": "string",
+          "enum": [
+            "england-and-wales",
+            "scotland"
+          ]
+        },
+        "tribunal_decision_country_name": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
The Employment Tribunal publishes decisions that describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.