### PR TITLE
Remove guid_list definition from links template.

### DIFF
--- a/templates/links.json
+++ b/templates/links.json
@@ -9,13 +9,5 @@
     // "organisations": {
     //   "$ref": "#/definitions/guid_list"
     // }
-  },
-  "definitions": {
-    "guid_list": {
-      "type": "array",
-      "items": {
-        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-      }
-    }
   }
 }


### PR DESCRIPTION
The `links.json` files no longer need to include this definition because
it's now part of the base format (defined in `formats/metadata.json`).

These templates are used by the `new_format` rake task.