### PR TITLE
Add employment appeal tribunal decisions schema and examples

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -172,6 +172,9 @@
           "$ref": "#/definitions/drug_safety_update_metadata"
         },
         {
+          "$ref": "#/definitions/employment_appeal_tribunal_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/european_structural_investment_fund_metadata"
         },
         {
@@ -562,6 +565,62 @@
           }
         },
         "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_appeal_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_appeal_tribunal_decision"
+          ]
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_landmark": {
+          "type": "string",
+          "enum": [
+            "landmark",
+            "not-landmark"
+          ]
+        },
+        "tribunal_decision_landmark_name": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
         }

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -213,6 +213,9 @@
           "$ref": "#/definitions/drug_safety_update_metadata"
         },
         {
+          "$ref": "#/definitions/employment_appeal_tribunal_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/european_structural_investment_fund_metadata"
         },
         {
@@ -603,6 +606,62 @@
           }
         },
         "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_appeal_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_appeal_tribunal_decision"
+          ]
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_landmark": {
+          "type": "string",
+          "enum": [
+            "landmark",
+            "not-landmark"
+          ]
+        },
+        "tribunal_decision_landmark_name": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
         }

--- a/formats/finder/frontend/examples/employment-appeal-tribunal-decisions.json
+++ b/formats/finder/frontend/examples/employment-appeal-tribunal-decisions.json
@@ -1,0 +1,130 @@
+{
+  "content_id": "975cf540-6e64-40e3-b62a-df655a8c99ef",
+  "base_path": "/employment-appeal-tribunal-decisions",
+  "title": "Employment appeal tribunal decisions",
+  "description": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.",
+  "format": "finder",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-10-29T14:30:59.334Z",
+  "public_updated_at": "2015-10-29T12:18:39.000+00:00",
+  "details": {
+    "document_noun": "decision",
+    "filter": {
+      "document_type": "employment_appeal_tribunal_decision"
+    },
+    "format_name": "Employment appeal tribunal decision",
+    "show_summaries": true,
+    "summary": "<p>Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.</p><p>Includes decisions after [month year]. Find details of <a rel=\"external\" href=\"http://www.employmentappeals.gov.uk/Public/Search.aspx\">older cases.</a></p>",
+    "facets": [
+      {
+        "key": "tribunal_decision_categories",
+        "name": "Category",
+        "type": "text",
+        "preposition": "categorised as",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Age Discrimination",
+            "value": "age-discrimination"
+          },
+          {
+            "label": "Race Discrimination",
+            "value": "race-discrimination"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_categories_name",
+        "name": "Category name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_sub_categories",
+        "name": "Sub-category",
+        "type": "text",
+        "preposition": "sub-categorised as",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Race Discrimination - Detriment",
+            "value": "race-discrimination-detriment"
+          },
+          {
+            "label": "Race Discrimination - Direct",
+            "value": "race-discrimination-direct"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_sub_categories_name",
+        "name": "Sub-category name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_landmark",
+        "name": "Landmark",
+        "type": "text",
+        "display_as_result_metadata": false,
+        "filterable": false,
+        "allowed_values": [
+          {
+            "label": "Landmark",
+            "value": "landmark"
+          },
+          {
+            "label": "Not landmark",
+            "value": "not-landmark"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_landmark_name",
+        "name": "Landmark name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_decision_date",
+        "name": "Decision date",
+        "short_name": "Decided",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ]
+  },
+  "links": {
+    "organisations": [],
+    "related": [],
+    "email_alert_signup": [
+      {
+        "content_id": "1f5911f4-417a-4380-a5a0-674ebff332df",
+        "title": "Employment appeal tribunal decisions",
+        "base_path": "/employment-appeal-tribunal-decisions/email-signup",
+        "description": "You'll get an email each time a decision is updated or a new decision is published.",
+        "api_url": "http://content-store.dev.gov.uk/content/employment-appeal-tribunal-decisions/email-signup",
+        "web_url": "http://www.dev.gov.uk/employment-appeal-tribunal-decisions/email-signup",
+        "locale": "en"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "975cf540-6e64-40e3-b62a-df655a8c99ef",
+        "title": "Employment appeal tribunal decisions",
+        "base_path": "/employment-appeal-tribunal-decisions",
+        "description": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.",
+        "api_url": "http://content-store.dev.gov.uk/content/employment-appeal-tribunal-decisions",
+        "web_url": "http://www.dev.gov.uk/employment-appeal-tribunal-decisions",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
@@ -1,0 +1,47 @@
+{
+  "content_id": "3917cb0e-0928-45b7-bf63-20f9bc113a7a",
+  "base_path": "/employment-appeal-tribunal-decisions/ukeat-0144-15-la",
+  "title": "UKEAT/0144/15/LA",
+  "description": "Discrimination on grounds of race - Subjecting an employee to a detriment",
+  "format": "specialist_document",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-10-29T15:50:37.477Z",
+  "public_updated_at": "2015-10-29T15:50:37.000+00:00",
+  "details": {
+    "metadata": {
+      "bulk_published": false,
+      "document_type": "employment_appeal_tribunal_decision",
+      "hidden_indexable_content": "Appeal No. UKEAT/0144/15/LA\\n\tAt the Tribunal\n\tOn 7 October 2015\n\tJudgment handed down on 27 October 2015",
+      "tribunal_decision_categories": [
+        "race-discrimination"
+      ],
+      "tribunal_decision_decision_date": "2015-10-27",
+      "tribunal_decision_landmark": "not-landmark",
+      "tribunal_decision_sub_categories": [
+        "race-discrimination-detriment",
+        "race-discrimination-direct"
+      ]
+    },
+    "change_history": [
+      {
+        "public_timestamp": "2015-10-29T15:50:37+00:00",
+        "note": "First published."
+      }
+    ],
+    "body": "<p>Download PDF: <a rel=\"external\" href=\"http://assets-origin.dev.gov.uk/media/56324037759b742c00000001/15_0144rjfhMDLA.doc\">UKEAT/0144/15/LA</a></p>\n"
+  },
+  "links": {
+    "available_translations": [
+      {
+        "content_id": "3917cb0e-0928-45b7-bf63-20f9bc113a7a",
+        "title": "UKEAT/0144/15/LA",
+        "base_path": "/employment-appeal-tribunal-decisions/ukeat-0144-15-la",
+        "description": "Discrimination on grounds of race - Subjecting an employee to a detriment",
+        "api_url": "http://content-store.dev.gov.uk/content/employment-appeal-tribunal-decisions/ukeat-0144-15-la",
+        "web_url": "http://www.dev.gov.uk/employment-appeal-tribunal-decisions/ukeat-0144-15-la",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -49,6 +49,7 @@
         { "$ref": "#/definitions/cma_case_metadata" },
         { "$ref": "#/definitions/countryside_stewardship_grant_metadata" },
         { "$ref": "#/definitions/drug_safety_update_metadata" },
+        { "$ref": "#/definitions/employment_appeal_tribunal_decision_metadata" },
         { "$ref": "#/definitions/european_structural_investment_fund_metadata" },
         { "$ref": "#/definitions/international_development_fund_metadata" },
         { "$ref": "#/definitions/maib_report_metadata" },
@@ -424,6 +425,62 @@
           }
         },
         "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_appeal_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_appeal_tribunal_decision"
+          ]
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_landmark": {
+          "type": "string",
+          "enum": [
+            "landmark",
+            "not-landmark"
+          ]
+        },
+        "tribunal_decision_landmark_name": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
         }


### PR DESCRIPTION
The Employment Appeal Tribunal publishes decisions that describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.