### PR TITLE
Add parent link to email_alert_signup schema

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -95,6 +95,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "mainstream_browse_pages": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -139,6 +139,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "parent": {
+          "description": "The parent content item",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"

--- a/formats/email_alert_signup/frontend/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/email_alert_signup.json
@@ -23,5 +23,14 @@
     },
     "govdelivery_title": "Employment policy"
   },
-  "links": {}
+  "links": {
+    "parent": [
+      {
+        "content_id": "f8c3682c-3a88-4f35-afba-3607384e39e6",
+        "title": "Benefits Reform",
+        "base_path": "/government/policies/benefits-reform",
+        "locale": "en"
+      }
+    ]
+  }
 }

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -10,7 +10,7 @@
     "summary": {
       "type": "string"
     },
-     "tags": {
+    "tags": {
        "type": "object"
     },
     "breadcrumbs": {

--- a/formats/email_alert_signup/publisher/links.json
+++ b/formats/email_alert_signup/publisher/links.json
@@ -2,5 +2,11 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "properties": {}
+  "properties": {
+    "parent": {
+      "description": "The parent content item",
+      "$ref": "#/definitions/guid_list",
+      "maxItems": 1
+    }
+  }
 }


### PR DESCRIPTION
As part of the effort to convert email alerting to rely on content IDs
rather than slugs, this change adds a field to email alert signup pages
that provides a reference to the parent piece of content. This makes it
easier for the email-alert-frontend to obtain the correct content ID to
send on to the email-alert-api.