### PR TITLE
Add `replaced_content_item` for redirects

### DIFF
--- a/dist/formats/redirect/publisher/schema.json
+++ b/dist/formats/redirect/publisher/schema.json
@@ -47,6 +47,17 @@
           }
         }
       }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replaced_content_item": {
+          "description": "The optional content_item that this redirect has replaced.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        }
+      }
     }
   },
   "definitions": {
@@ -59,6 +70,16 @@
       "type": "string",
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
       "description": "A path with optional query string and/or fragment."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
     }
   }
 }

--- a/dist/formats/redirect/publisher/schema.json
+++ b/dist/formats/redirect/publisher/schema.json
@@ -13,8 +13,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "format": {
       "enum": [ "redirect" ]

--- a/formats/redirect/publisher/examples/redirect-with-replacement.json
+++ b/formats/redirect/publisher/examples/redirect-with-replacement.json
@@ -1,0 +1,16 @@
+{
+  "content_id": "f779f980-403d-473b-80aa-f038a58c3107",
+  "format": "redirect",
+  "publishing_app": "short-url-manager",
+  "update_type": "minor",
+  "redirects": [
+    {
+      "path": "/406beacon",
+      "type": "exact",
+      "destination": "/maritime-safety-weather-and-navigation/register-406-mhz-beacons?query=answer#fragment"
+    }
+  ],
+  "links": {
+    "replaced_content_item": ["2054b5e5-8d58-456b-8832-66c0d2b72565"]
+  }
+}

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -47,6 +47,17 @@
           }
         }
       }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replaced_content_item": {
+          "description": "The optional content_item that this redirect has replaced.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        }
+      }
     }
   },
   "definitions": {
@@ -59,6 +70,16 @@
       "type": "string",
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
       "description": "A path with optional query string and/or fragment."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
     }
   }
 }

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -13,8 +13,7 @@
       "$ref": "#/definitions/absolute_path"
     },
     "content_id": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+      "$ref": "#/definitions/guid"
     },
     "format": {
       "enum": [ "redirect" ]


### PR DESCRIPTION
`replaced_content_item` is the optional content_id of the item this redirect is replacing.

It allows publishing-api to add special behaviour for putting back redirects.

It will also be added to the coming_soon format (https://github.com/alphagov/govuk-content-schemas/pull/141).

/cc @elliotcm 