### PR TITLE
Add email_alert_type to email_alert_signup details hash

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -60,6 +60,13 @@
         "tags"
       ],
       "properties": {
+        "email_alert_type": {
+          "type": "string",
+          "enum": [
+            "topics",
+            "policies"
+          ]
+        },
         "summary": {
           "type": "string"
         },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -104,6 +104,13 @@
         "tags"
       ],
       "properties": {
+        "email_alert_type": {
+          "type": "string",
+          "enum": [
+            "topics",
+            "policies"
+          ]
+        },
         "summary": {
           "type": "string"
         },

--- a/formats/email_alert_signup/frontend/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/email_alert_signup.json
@@ -9,6 +9,7 @@
   "updated_at": "2015-04-14T13:11:45.809Z",
   "public_updated_at": "2015-04-14T10:56:00.000+00:00",
   "details": {
+    "email_alert_type": "policies",
     "breadcrumbs": [
       {
         "title": "Employment",

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -7,6 +7,10 @@
     "tags"
   ],
   "properties": {
+    "email_alert_type": {
+      "type": "string",
+      "enum": ["topics", "policies"]
+    },
     "summary": {
       "type": "string"
     },


### PR DESCRIPTION
This states explicitly the kind of page a given email signup is handling.
This improves clarity when viewing an email-signup content item retrieved
from the content store, and also helps the email-alert-frontend (for example)
resolve how to format its subscription payload for the email-alert-api.

The goal of all this is to handle email subscription/alerting via content
IDs in the links hash and eventually move away from the use of slugs.