### PR TITLE
Require base_path in redirect

### DIFF
--- a/dist/formats/redirect/publisher/schema.json
+++ b/dist/formats/redirect/publisher/schema.json
@@ -6,7 +6,8 @@
     "format",
     "publishing_app",
     "update_type",
-    "redirects"
+    "redirects",
+    "base_path"
   ],
   "properties": {
     "base_path": {

--- a/formats/redirect/publisher/examples/redirect-with-replacement.json
+++ b/formats/redirect/publisher/examples/redirect-with-replacement.json
@@ -1,6 +1,7 @@
 {
   "content_id": "f779f980-403d-473b-80aa-f038a58c3107",
   "format": "redirect",
+  "base_path": "/406beacon",
   "publishing_app": "short-url-manager",
   "update_type": "minor",
   "redirects": [

--- a/formats/redirect/publisher/examples/redirect.json
+++ b/formats/redirect/publisher/examples/redirect.json
@@ -1,6 +1,7 @@
 {
   "content_id": "f779f980-403d-473b-80aa-f038a58c3107",
   "format": "redirect",
+  "base_path": "/406beacon",
   "publishing_app": "short-url-manager",
   "update_type": "minor",
   "redirects": [

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -6,7 +6,8 @@
     "format",
     "publishing_app",
     "update_type",
-    "redirects"
+    "redirects",
+    "base_path"
   ],
   "properties": {
     "base_path": {


### PR DESCRIPTION
After
https://github.com/alphagov/publishing-api/commit/5e5397f4c3e8bf680977ebc5417e0947d563cc18
made base_path mandatory, we need to update content schemas to reflect
this.