### PR TITLE
Remove update_type from redirects schema

### DIFF
--- a/dist/formats/redirect/publisher/schema.json
+++ b/dist/formats/redirect/publisher/schema.json
@@ -5,7 +5,6 @@
   "required": [
     "format",
     "publishing_app",
-    "update_type",
     "redirects",
     "base_path"
   ],
@@ -21,9 +20,6 @@
     },
     "publishing_app": {
       "type": "string"
-    },
-    "update_type": {
-      "enum": [ "major", "minor", "republish" ]
     },
     "redirects": {
       "type": "array",

--- a/formats/redirect/publisher/examples/redirect-with-replacement.json
+++ b/formats/redirect/publisher/examples/redirect-with-replacement.json
@@ -3,7 +3,6 @@
   "format": "redirect",
   "base_path": "/406beacon",
   "publishing_app": "short-url-manager",
-  "update_type": "minor",
   "redirects": [
     {
       "path": "/406beacon",

--- a/formats/redirect/publisher/examples/redirect.json
+++ b/formats/redirect/publisher/examples/redirect.json
@@ -3,7 +3,6 @@
   "format": "redirect",
   "base_path": "/406beacon",
   "publishing_app": "short-url-manager",
-  "update_type": "minor",
   "redirects": [
     {
       "path": "/406beacon",

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -5,7 +5,6 @@
   "required": [
     "format",
     "publishing_app",
-    "update_type",
     "redirects",
     "base_path"
   ],
@@ -21,9 +20,6 @@
     },
     "publishing_app": {
       "type": "string"
-    },
-    "update_type": {
-      "enum": [ "major", "minor", "republish" ]
     },
     "redirects": {
       "type": "array",


### PR DESCRIPTION
update_type is no longer passed through in the initial payload. It is
now the second parameter of the #publish method.

_I'm not 100% sure this is the correct thing to do, so I've opened a PR to discuss._