### PR TITLE
Make update_type optional for redirects.

### DIFF
--- a/dist/formats/redirect/publisher/schema.json
+++ b/dist/formats/redirect/publisher/schema.json
@@ -5,7 +5,6 @@
   "required": [
     "format",
     "publishing_app",
-    "update_type",
     "redirects",
     "base_path"
   ],

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -5,7 +5,6 @@
   "required": [
     "format",
     "publishing_app",
-    "update_type",
     "redirects",
     "base_path"
   ],


### PR DESCRIPTION
The v1 endpoints require this but the v2 endpoints
don't.