### PR TITLE
Rename publisher to content_owner within Service Manual Guide

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -58,16 +58,16 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "publisher"
+        "content_owner"
       ],
       "properties": {
         "body": {
           "type": "string"
         },
-        "publisher": {
+        "content_owner": {
           "type": "object",
           "properties": {
-            "name": {
+            "title": {
               "type": "string"
             },
             "href": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -102,16 +102,16 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "publisher"
+        "content_owner"
       ],
       "properties": {
         "body": {
           "type": "string"
         },
-        "publisher": {
+        "content_owner": {
           "type": "object",
           "properties": {
-            "name": {
+            "title": {
               "type": "string"
             },
             "href": {

--- a/formats/service_manual_guide/frontend/examples/basic_with_related_discussions.json
+++ b/formats/service_manual_guide/frontend/examples/basic_with_related_discussions.json
@@ -5,8 +5,8 @@
   "locale": "en",
   "details" : {
     "body" : "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "publisher" : {
-      "name" : "Agile community",
+    "content_owner" : {
+      "title" : "Agile community",
       "href" : "http://sm-11.herokuapp.com/communities/design-community/"
     },
     "related_discussion" : {

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -4,16 +4,16 @@
   "additionalProperties": false,
   "required": [
     "body",
-    "publisher"
+    "content_owner"
   ],
   "properties": {
     "body": {
       "type": "string"
     },
-    "publisher": {
+    "content_owner": {
       "type": "object",
       "properties": {
-        "name": {
+        "title": {
           "type": "string"
         },
         "href": {


### PR DESCRIPTION
We have realised that using publisher to indicate the group responsible for a
piece of content can be ambiguous because within GOV.UK we use the term
"publisher" to name applications that publish content.

I've used this opportunity to rename publisher.name to content_owner.title too
to make it consistent with code in other related repos and bring it in line
with "related_discussion" fields' naming conventions.

Other repos that need this renaming:
      service-manual-publisher (branch rename_publisher)
      government-frontend (branch service-manual-frontent-real-data)

We will not need to sync deploys or migrate data because none of those are used
in production.

Related: https://github.com/alphagov/government-frontend/pull/63

/cc @KushalP 