### PR TITLE
Update email_signup_alert example

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -57,8 +57,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "summary",
-        "tags"
+        "summary"
       ],
       "properties": {
         "email_alert_type": {
@@ -68,11 +67,24 @@
             "policies"
           ]
         },
-        "summary": {
-          "type": "string"
+        "signup_tags": {
+          "type": "object",
+          "description": "The content item for which this is handling email signups",
+          "additionalProperties": false,
+          "properties": {
+            "policies": {
+              "type": "array"
+            },
+            "topics": {
+              "type": "array"
+            }
+          }
         },
         "tags": {
           "type": "object"
+        },
+        "summary": {
+          "type": "string"
         },
         "breadcrumbs": {
           "type": "array",

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -101,8 +101,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "summary",
-        "tags"
+        "summary"
       ],
       "properties": {
         "email_alert_type": {
@@ -112,11 +111,24 @@
             "policies"
           ]
         },
-        "summary": {
-          "type": "string"
+        "signup_tags": {
+          "type": "object",
+          "description": "The content item for which this is handling email signups",
+          "additionalProperties": false,
+          "properties": {
+            "policies": {
+              "type": "array"
+            },
+            "topics": {
+              "type": "array"
+            }
+          }
         },
         "tags": {
           "type": "object"
+        },
+        "summary": {
+          "type": "string"
         },
         "breadcrumbs": {
           "type": "array",

--- a/formats/email_alert_signup/frontend/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/email_alert_signup.json
@@ -10,6 +10,11 @@
   "public_updated_at": "2015-04-14T10:56:00.000+00:00",
   "details": {
     "email_alert_type": "policies",
+    "signup_tags": {
+      "policies": [
+        "employment"
+      ]
+    },
     "breadcrumbs": [
       {
         "title": "Employment",
@@ -17,11 +22,6 @@
       }
     ],
     "summary": "You'll get an email each time any information on this policy is published or updated.",
-    "tags": {
-      "policy": [
-        "employment"
-      ]
-    },
     "govdelivery_title": "Employment policy"
   },
   "links": {

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -3,19 +3,27 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "summary",
-    "tags"
+    "summary"
   ],
   "properties": {
     "email_alert_type": {
       "type": "string",
       "enum": ["topics", "policies"]
     },
-    "summary": {
-      "type": "string"
+    "signup_tags": {
+      "type": "object",
+      "description": "The content item for which this is handling email signups",
+      "additionalProperties": false,
+      "properties": {
+        "policies": { "type": "array" },
+        "topics": { "type": "array" }
+      }
     },
     "tags": {
-       "type": "object"
+      "type": "object"
+    },
+    "summary": {
+      "type": "string"
     },
     "breadcrumbs": {
       "type": "array",


### PR DESCRIPTION
Change the tag in the example to 'policies' as this is what is required
from the email alert attributes exported by the policy-publisher. The
goal of this change is to ultimately ensure that the
email-alert-frontend correctly subscribes users using tags named
'policies'.