### PR TITLE
Allow organisations-links for all formats

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -211,6 +211,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -257,6 +257,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -82,6 +82,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -128,6 +128,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -112,6 +112,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -160,6 +160,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -215,9 +215,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -231,6 +228,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -259,9 +259,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "organisations": {
-          "$ref": "#/definitions/guid_list"
-        },
         "related": {
           "$ref": "#/definitions/guid_list"
         },
@@ -277,6 +274,9 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
           "$ref": "#/definitions/guid_list"
         },
         "policies": {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -185,6 +185,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -231,6 +231,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -176,6 +176,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -222,6 +222,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -109,6 +109,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -159,6 +159,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -165,6 +165,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -211,6 +211,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -112,6 +112,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -158,6 +158,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -107,6 +107,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -153,6 +153,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -181,9 +181,6 @@
         "related"
       ],
       "properties": {
-        "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "people": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -203,6 +200,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -225,9 +225,6 @@
         "related"
       ],
       "properties": {
-        "organisations": {
-          "$ref": "#/definitions/guid_list"
-        },
         "people": {
           "$ref": "#/definitions/guid_list"
         },
@@ -249,6 +246,9 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
           "$ref": "#/definitions/guid_list"
         },
         "policies": {

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -118,6 +118,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -164,6 +164,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -103,6 +103,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -149,6 +149,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -107,6 +107,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -156,6 +156,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -95,6 +95,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -141,6 +141,9 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
           "$ref": "#/definitions/guid_list"

--- a/formats/base_links.json
+++ b/formats/base_links.json
@@ -11,6 +11,9 @@
       "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
       "$ref": "#/definitions/guid_list"
     },
+    "organisations": {
+      "$ref": "#/definitions/guid_list"
+    },
     "policies": {
       "description": "These are for collecting content related to a particular government policy.",
       "$ref": "#/definitions/guid_list"

--- a/formats/finder/publisher/links.json
+++ b/formats/finder/publisher/links.json
@@ -3,9 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "organisations": {
-      "$ref": "#/definitions/guid_list"
-    },
     "related": {
       "$ref": "#/definitions/guid_list"
     },

--- a/formats/policy/publisher/links.json
+++ b/formats/policy/publisher/links.json
@@ -7,9 +7,6 @@
     "related"
   ],
   "properties": {
-    "organisations": {
-      "$ref": "#/definitions/guid_list"
-    },
     "people": {
       "$ref": "#/definitions/guid_list"
     },


### PR DESCRIPTION
All content can be tagged with organisations in the future.

Relevant for https://github.com/alphagov/panopticon/pull/313, which will copy any `organisation` tags in panopticon to the publishing-api.

/cc @rboulton 