### PR TITLE
Make content_id not required temporarily

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "content_id",
     "format",
     "locale",
     "public_updated_at"

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "content_id",
     "format",
     "publishing_app",
     "rendering_app",


### PR DESCRIPTION
hmrc-manuals-api doesn't send the content_id yet, so making the `content_id` required makes all tests on this repo fail.

This can be reverted after hmrc-manuals-api is updated.

The test failure wasn't picked up in https://github.com/alphagov/govuk-content-schemas/pull/141, because hmrc-manuals-api schema tests weren't being run in.