### PR TITLE
Add "internal_name" to topics and browse pages

### DIFF
--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -57,6 +57,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "internal_name": {
+          "type": "string",
+          "description": "An internal name for admin interfaces. Includes parent."
+        },
         "second_level_ordering": {
           "enum": [
             "alphabetical",

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -101,6 +101,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "internal_name": {
+          "type": "string",
+          "description": "An internal name for admin interfaces. Includes parent."
+        },
         "second_level_ordering": {
           "enum": [
             "alphabetical",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -57,6 +57,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "internal_name": {
+          "type": "string",
+          "description": "An internal name for admin interfaces. Includes parent."
+        },
         "beta": {
           "anyOf": [
             {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -101,6 +101,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "internal_name": {
+          "type": "string",
+          "description": "An internal name for admin interfaces. Includes parent."
+        },
         "beta": {
           "anyOf": [
             {

--- a/formats/mainstream_browse_page/publisher/details.json
+++ b/formats/mainstream_browse_page/publisher/details.json
@@ -3,6 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "internal_name": {
+      "type": "string",
+      "description": "An internal name for admin interfaces. Includes parent."
+    },
     "second_level_ordering": {
       "enum": [ "alphabetical", "curated" ]
     },

--- a/formats/topic/publisher/details.json
+++ b/formats/topic/publisher/details.json
@@ -3,6 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "internal_name": {
+      "type": "string",
+      "description": "An internal name for admin interfaces. Includes parent."
+    },
     "beta": {
       "anyOf": [
         { "type": "boolean" },


### PR DESCRIPTION
The `internal_name` field will be used in admin interfaces to provide context. 

In the case of topics and browse pages, it will contain "#{parent_title} / #{child_title)", so that we can populate the selectboxes without having to expand the link set (which the publishing-api doesn't do).

![screen shot 2015-11-23 at 12 24 42](https://cloud.githubusercontent.com/assets/233676/11336437/362bcf00-91dd-11e5-8055-39f89b3cd297.png)

I'm assuming that a generic `internal_name` field can also be used in other formats to disambiguate items for use in admin interfaces. For example, the `internal_name` of organisations could be used to contain the acronym or alternative spellings, which would make them more easily findable.

@rboulton 
