### PR TITLE
Enforce presence of signup_tags in details, remove tags in email_alert_signups

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -57,6 +57,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "signup_tags",
         "summary"
       ],
       "properties": {
@@ -79,9 +80,6 @@
               "type": "array"
             }
           }
-        },
-        "tags": {
-          "type": "object"
         },
         "summary": {
           "type": "string"

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -101,6 +101,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "signup_tags",
         "summary"
       ],
       "properties": {
@@ -123,9 +124,6 @@
               "type": "array"
             }
           }
-        },
-        "tags": {
-          "type": "object"
         },
         "summary": {
           "type": "string"

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "signup_tags",
     "summary"
   ],
   "properties": {
@@ -18,9 +19,6 @@
         "policies": { "type": "array" },
         "topics": { "type": "array" }
       }
-    },
-    "tags": {
-      "type": "object"
     },
     "summary": {
       "type": "string"


### PR DESCRIPTION
The contents of an email-alert-signup has changed: there is no longer a 'tags' key in the details hash - it is replaced by a new 'signup-tags' key (see https://github.com/alphagov/govuk-content-schemas/commit/1bc4952cfb021698340dbb6c29df2d25570c517e for reason why).

This change amends the JSON schema to enforce those changes.

Trello: https://trello.com/c/t42ZUP2j/434-make-signup-tags-required-in-govuk-content-schemas-email-alert-signup-and-remove-tags