### PR TITLE
Fix path error in the README section about frontend schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ a frontend schema from the backend schema.
 A script and make task is provided to do this:
 
 ```sh
-$ bundle exec ./bin/generate_frontend_schema formats/case_study/publisher/schema.json > formats/case_study/frontend/schema.json
+$ bundle exec ./bin/generate_frontend_schema dist/formats/case_study/publisher/schema.json > dist/formats/case_study/frontend/schema.json
 ```
 
 ### Validation of frontend examples


### PR DESCRIPTION
- The `bundle exec ./bin/generate_frontend_schema
  formats/case_study/publisher/schema.json >
  formats/case_study/frontend/schema.json` example, adapted for our
  use in contacts, line errored with
  "formats/contact/publisher/schema.json: no such file or directory"
  because `schema.json` is a built file and therefore is only in the
  `dist/` directory. Change the README example to refer to `dist/...`.