### PR TITLE
Add contacts format

### DIFF
--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -1,0 +1,516 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "locale",
+    "public_updated_at",
+    "content_id"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "analytics_identifier": {
+      "type": "string"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "description"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "organisation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "contact_index_content_id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "abbreviation": {
+              "type": "string"
+            },
+            "govuk_status": {
+              "type": "string"
+            },
+            "created_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updated_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ancestry": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contact_index_content_id": {
+              "type": "string"
+            }
+          }
+        },
+        "quick_links": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "query_response_time": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "contact_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "organisation": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "contact_index_content_id"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "abbreviation": {
+                    "type": "string"
+                  },
+                  "govuk_status": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "ancestry": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contact_index_content_id": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": {
+                "type": "string"
+              },
+              "contacts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "contact_form_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_contact_form": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "email"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_email_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "phone_numbers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "number"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "number": {
+                "type": "string"
+              },
+              "textphone": {
+                "type": "string"
+              },
+              "international_phone": {
+                "type": "string"
+              },
+              "fax": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "open_hours": {
+                "type": "string"
+              },
+              "best_time_to_call": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_phone_number": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "post_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "street_address",
+              "postal_code",
+              "world_location"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "street_address": {
+                "type": "string"
+              },
+              "postal_code": {
+                "type": "string"
+              },
+              "world_location": {
+                "type": "string"
+              },
+              "locality": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_post_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "language": {
+          "type": "string"
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "related": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -1,0 +1,521 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "public_updated_at",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "type": "string"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "description"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "organisation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "contact_index_content_id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "abbreviation": {
+              "type": "string"
+            },
+            "govuk_status": {
+              "type": "string"
+            },
+            "created_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updated_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ancestry": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contact_index_content_id": {
+              "type": "string"
+            }
+          }
+        },
+        "quick_links": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "query_response_time": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "contact_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "organisation": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "contact_index_content_id"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "abbreviation": {
+                    "type": "string"
+                  },
+                  "govuk_status": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "ancestry": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contact_index_content_id": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": {
+                "type": "string"
+              },
+              "contacts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "contact_form_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_contact_form": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "email"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_email_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "phone_numbers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "number"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "number": {
+                "type": "string"
+              },
+              "textphone": {
+                "type": "string"
+              },
+              "international_phone": {
+                "type": "string"
+              },
+              "fax": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "open_hours": {
+                "type": "string"
+              },
+              "best_time_to_call": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_phone_number": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "post_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "street_address",
+              "postal_code",
+              "world_location"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "street_address": {
+                "type": "string"
+              },
+              "postal_code": {
+                "type": "string"
+              },
+              "world_location": {
+                "type": "string"
+              },
+              "locality": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_post_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "language": {
+          "type": "string"
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "These are for collecting content related to a particular government policy.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "previous_version": {
+      "type": "string"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "These are for collecting content related to a particular government policy.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -1,0 +1,480 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "public_updated_at",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "type": "string"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "description"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "organisation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "contact_index_content_id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "abbreviation": {
+              "type": "string"
+            },
+            "govuk_status": {
+              "type": "string"
+            },
+            "created_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updated_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "ancestry": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contact_index_content_id": {
+              "type": "string"
+            }
+          }
+        },
+        "quick_links": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "query_response_time": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "contact_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "organisation": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "contact_index_content_id"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "abbreviation": {
+                    "type": "string"
+                  },
+                  "govuk_status": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "ancestry": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contact_index_content_id": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": {
+                "type": "string"
+              },
+              "contacts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "contact_form_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_contact_form": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "email_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "email"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_email_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "phone_numbers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "number"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "number": {
+                "type": "string"
+              },
+              "textphone": {
+                "type": "string"
+              },
+              "international_phone": {
+                "type": "string"
+              },
+              "fax": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "open_hours": {
+                "type": "string"
+              },
+              "best_time_to_call": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_phone_number": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "post_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "street_address",
+              "postal_code",
+              "world_location"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "street_address": {
+                "type": "string"
+              },
+              "postal_code": {
+                "type": "string"
+              },
+              "world_location": {
+                "type": "string"
+              },
+              "locality": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "more_info_post_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "language": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    }
+  }
+}

--- a/formats/contact/frontend/examples/contact.json
+++ b/formats/contact/frontend/examples/contact.json
@@ -1,0 +1,317 @@
+{
+  "base_path": "/government/organisations/hm-revenue-customs/contact/customs-excise-and-vat-fraud-reporting",
+  "content_id": "6c50a476-5681-4808-974d-c8e80bcca90d",
+  "title": "Customs, Excise and VAT fraud reporting",
+  "format": "contact",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2015-12-02T10:42:56.350Z",
+  "public_updated_at": "2015-09-30T09:11:00.300+00:00",
+  "phase": "live",
+  "analytics_identifier": "",
+  "links": {
+    "related": [
+      {
+        "content_id": "4e661905-fd41-453a-b953-6877bfa88b45",
+        "title": "Fraud: report a benefit thief online ",
+        "base_path": "/government/organisations/hm-revenue-customs/contact/report-a-benefit-thief-online",
+        "description": "If you suspect someone of benefit fraud report them online here",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs/contact/report-a-benefit-thief-online",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/report-a-benefit-thief-online",
+        "locale": "en"
+      },
+      {
+        "content_id": "e90e2f58-670d-4871-a5c8-71fd9c0b2a7b",
+        "title": "Fraudulent emails",
+        "base_path": "/government/organisations/hm-revenue-customs/contact/reporting-fraudulent-emails",
+        "description": "Email address to use to report a fraudulent or phishing email that mentions HMRC",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs/contact/reporting-fraudulent-emails",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/reporting-fraudulent-emails",
+        "locale": "en"
+      },
+      {
+        "content_id": "5a21285a-f386-4820-af81-e6d2a847b223",
+        "title": "Tax evasion",
+        "base_path": "/government/organisations/hm-revenue-customs/contact/reporting-tax-evasion",
+        "description": "Use the online form, or call or write to HMRC to report someone not paying their fair share of tax",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs/contact/reporting-tax-evasion",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/reporting-tax-evasion",
+        "locale": "en"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "6c50a476-5681-4808-974d-c8e80bcca90d",
+        "title": "Customs, Excise and VAT fraud reporting",
+        "base_path": "/government/organisations/hm-revenue-customs/contact/customs-excise-and-vat-fraud-reporting",
+        "description": "Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs/contact/customs-excise-and-vat-fraud-reporting",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-excise-and-vat-fraud-reporting",
+        "locale": "en"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue & Customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
+        "locale": "en"
+      }
+    ]
+  },
+  "description": "Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud",
+  "details": {
+    "slug": "customs-excise-and-vat-fraud-reporting",
+    "title": "Customs, Excise and VAT fraud reporting",
+    "description": "Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud",
+    "organisation": {
+      "id": 1,
+      "title": "HM Revenue & Customs",
+      "format": "Non-ministerial department",
+      "slug": "hm-revenue-customs",
+      "abbreviation": "HMRC",
+      "govuk_status": "live",
+      "created_at": "2014-04-09T13:06:30.000Z",
+      "updated_at": "2015-01-23T12:32:09.000Z",
+      "ancestry": null,
+      "contact_index_content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
+    },
+    "quick_links": [
+      {
+        "title": "Report smuggling ",
+        "url": "https://www.gov.uk/report-smuggling"
+      },
+      {
+        "title": "Report VAT fraud",
+        "url": "https://www.gov.uk/report-vat-fraud"
+      }
+    ],
+    "query_response_time": false,
+    "contact_groups": [
+      {
+        "title": "VAT",
+        "organisation": {
+          "id": 1,
+          "title": "HM Revenue & Customs",
+          "format": "Non-ministerial department",
+          "slug": "hm-revenue-customs",
+          "abbreviation": "HMRC",
+          "govuk_status": "live",
+          "created_at": "2014-04-09T13:06:30.000Z",
+          "updated_at": "2015-01-23T12:32:09.000Z",
+          "ancestry": null,
+          "contact_index_content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
+        },
+        "description": "<p>VAT enquiries</p>\n",
+        "contacts": [
+          {
+            "description": "<p>Email, call or write to HMRC for help on opting to tax land or buildings for VAT purposes</p>\n"
+          },
+          {
+            "description": "<p>Use the online form or call HMRC for help with all VAT online services</p>\n"
+          },
+          {
+            "description": "<p>Contact HMRC with questions about VAT and to report changes to your business</p>\n"
+          },
+          {
+            "description": "<p>Contact HMRC for information about VAT reliefs available for disabled and older people</p>\n"
+          },
+          {
+            "description": "<p>Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud</p>\n"
+          },
+          {
+            "description": "<p>Write to HMRC to join or leave the Annual Accounting and Flat Rate schemes or to change your details</p>\n"
+          },
+          {
+            "description": "<p>Call or write to HMRC for help with reporting errors on your VAT Return</p>\n"
+          },
+          {
+            "description": "<p>Send your VAT Return to HMRC if you or your business becomes bankrupt or insolvent</p>\n"
+          },
+          {
+            "description": "<p>Use the online form or call HMRC to order VAT paying-in slips</p>\n"
+          },
+          {
+            "description": "<p>Use online forms or write to HMRC to register for VAT and keep your VAT registration details up to date</p>\n"
+          },
+          {
+            "description": "<p>Call HMRC if you’re having problems making a payment before the deadline, including if you can’t pay due to banking restrictions in Greece</p>\n"
+          },
+          {
+            "description": "<p>Contact HMRC about reclaiming VAT paid in the UK if your business is based overseas</p>\n"
+          }
+        ]
+      },
+      {
+        "title": "Fraud and tax evasion   ",
+        "organisation": {
+          "id": 1,
+          "title": "HM Revenue & Customs",
+          "format": "Non-ministerial department",
+          "slug": "hm-revenue-customs",
+          "abbreviation": "HMRC",
+          "govuk_status": "live",
+          "created_at": "2014-04-09T13:06:30.000Z",
+          "updated_at": "2015-01-23T12:32:09.000Z",
+          "ancestry": null,
+          "contact_index_content_id": "6f74bf97-11f3-4bf2-a114-459e5062c0be"
+        },
+        "description": "<p>Telling HMRC about fraud and tax evasion </p>\n",
+        "contacts": [
+          {
+            "description": "<p>If you suspect someone of benefit fraud report them online here</p>\n"
+          },
+          {
+            "description": "<p>Email address to use to report a fraudulent or phishing email that mentions HMRC</p>\n"
+          },
+          {
+            "description": "<p>Use the online form, or call or write to HMRC to report someone not paying their fair share of tax</p>\n"
+          },
+          {
+            "description": "<p>Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud</p>\n"
+          }
+        ]
+      },
+      {
+        "title": "Customs and Excise",
+        "organisation": {
+          "id": 1,
+          "title": "HM Revenue & Customs",
+          "format": "Non-ministerial department",
+          "slug": "hm-revenue-customs",
+          "abbreviation": "HMRC",
+          "govuk_status": "live",
+          "created_at": "2014-04-09T13:06:30.000Z",
+          "updated_at": "2015-01-23T12:32:09.000Z",
+          "ancestry": null,
+          "contact_index_content_id": "6f74bf97-11f3-4bf2-a114-459e5062c0be"
+        },
+        "description": "<p>Customs and Excise enquiries</p>\n",
+        "contacts": [
+          {
+            "description": "<p>Contact HMRC for help with questions about importing, exporting and customs reliefs</p>\n"
+          },
+          {
+            "description": "<p>Email, call or write to HMRC for advice about money laundering and how to report suspicious transactions</p>\n"
+          },
+          {
+            "description": "<p>Email HMRC for help with tariff classification issues </p>\n"
+          },
+          {
+            "description": "<p>Email or call HMRC for information about the Excise Movement and Control System (EMCS)</p>\n"
+          },
+          {
+            "description": "<p>Call HMRC for help with registration and enrolment on the Excise Movement and Control System (EMCS) online service</p>\n"
+          },
+          {
+            "description": "<p>Use the online form or call HMRC for help to register, enrol and submit using the ATWD online service</p>\n"
+          },
+          {
+            "description": "<p>Email, call or write to HMRC for help with the Duty Deferment Scheme</p>\n"
+          },
+          {
+            "description": "<p>Call the National Yachtline if you’re sailing your yacht or pleasurecraft to the UK</p>\n"
+          },
+          {
+            "description": "<p>Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud</p>\n"
+          },
+          {
+            "description": "<p>Email or call HMRC for help with the New Computerised Transit System, Import Control System, Export Control System and using the online services</p>\n"
+          },
+          {
+            "description": "<p>Call or write to HMRC for help with paying Beer, Wine and Cider Duty</p>\n"
+          },
+          {
+            "description": "<p>Call or write to HMRC for advice about paying gambling duty or if you have a problem using the online Gambling Tax Service</p>\n"
+          },
+          {
+            "description": "<p>Write to HMRC for help with registering for alcohol, tobacco and fuel duties</p>\n"
+          },
+          {
+            "description": "<p>Contact HMRC with your questions about alcohol, tobacco, fuel and gambling duties, warehousing and moving excise goods</p>\n"
+          },
+          {
+            "description": "<p>Email addresses for software developers to use when testing the New Computerised Transit System</p>\n"
+          },
+          {
+            "description": "<p>Call or write to HMRC for help with Air Passenger Duty, including registering and making payments and returns</p>\n"
+          }
+        ]
+      }
+    ],
+    "contact_form_links": [
+      {
+        "title": "Customs Hotline online form",
+        "link": "https://online.hmrc.gov.uk/shortforms/form/CusConf_InformB?dept-name=Customs&sub-dept-name=Hotline&location=48&origin=http://www.hmrc.gov.uk",
+        "description": "<p>Contact HMRC to report suspicious activity in relation to smuggling, customs, excise and VAT fraud.</p>\n"
+      }
+    ],
+    "more_info_contact_form": "<p>If HMRC needs to contact you about anything confidential they’ll reply by phone or post.</p>\n",
+    "email_addresses": [
+      {
+        "title": "Customs Hotline",
+        "email": "customs.hotline@hmrc.gsi.gov.uk ",
+        "description": "\n"
+      }
+    ],
+    "more_info_email_address": "<p>If HMRC needs to contact you about anything confidential they’ll reply by phone or post.</p>\n",
+    "phone_numbers": [
+      {
+        "title": "Customs Hotline",
+        "number": "0800 595 000",
+        "textphone": "",
+        "international_phone": "",
+        "fax": "0800 528 0506",
+        "description": "<p>Call or fax HMRC to report suspicious activity in relation to smuggling, customs, excise and VAT fraud.</p>\n\n<p>This number does not deal with questions about taxes, duty, benefits or tax credits.</p>\n",
+        "open_hours": "<p>24 hours a day, 7 days a week</p>\n",
+        "best_time_to_call": "\n"
+      },
+      {
+        "title": "Belgium, Denmark, France, Germany, Republic of Ireland, Netherlands",
+        "number": "+800 555 95000",
+        "textphone": "",
+        "international_phone": "",
+        "fax": "",
+        "description": "\n",
+        "open_hours": "\n",
+        "best_time_to_call": "\n"
+      },
+      {
+        "title": "Mainland Spain",
+        "number": "900 988 922",
+        "textphone": "",
+        "international_phone": "",
+        "fax": "",
+        "description": "\n",
+        "open_hours": "\n",
+        "best_time_to_call": "\n"
+      },
+      {
+        "title": "Any other country",
+        "number": "+44 208 929 0153",
+        "textphone": "",
+        "international_phone": "",
+        "fax": "",
+        "description": "\n",
+        "open_hours": "\n",
+        "best_time_to_call": "\n"
+      }
+    ],
+    "more_info_phone_number": "\n",
+    "post_addresses": [
+      {
+        "title": "HM Revenue and Customs - Customs, Excise and VAT fraud reporting",
+        "street_address": "Freepost NAT22785\r\n",
+        "postal_code": "CF14 5GX",
+        "world_location": "United Kingdom",
+        "locality": "",
+        "region": "CARDIFF",
+        "description": "<p>Write to this address to report suspicious activity in relation to smuggling, customs, excise and VAT fraud.</p>\n"
+      }
+    ],
+    "more_info_post_address": "\n",
+    "language": "en"
+  }
+}

--- a/formats/contact/publisher/details.json
+++ b/formats/contact/publisher/details.json
@@ -1,0 +1,308 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "description"
+  ],
+  "properties": {
+    "slug": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "organisation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contact_index_content_id"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "abbreviation": {
+          "type": "string"
+        },
+        "govuk_status": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ancestry": {
+          "type": ["string", "null"]
+        },
+        "contact_index_content_id": {
+          "type": "string"
+        }
+      }
+    },
+    "quick_links": {
+      "type": "array",
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "url"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "query_response_time": {
+      "type": ["string", "boolean"]
+    },
+    "contact_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "organisation": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "contact_index_content_id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "title": {
+                "type": "string"
+              },
+              "format": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              },
+              "abbreviation": {
+                "type": "string"
+              },
+              "govuk_status": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "ancestry": {
+                "type": ["string", "null"]
+              },
+              "contact_index_content_id": {
+                "type": "string"
+              }
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "contacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "contact_form_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "link": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "more_info_contact_form": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "email_addresses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "email"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "more_info_email_address": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "phone_numbers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "number"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "number": {
+            "type": "string"
+          },
+          "textphone": {
+            "type": "string"
+          },
+          "international_phone": {
+            "type": "string"
+          },
+          "fax": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "open_hours": {
+            "type": "string"
+          },
+          "best_time_to_call": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "more_info_phone_number": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "post_addresses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "street_address",
+          "postal_code",
+          "world_location"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "street_address": {
+            "type": "string"
+          },
+          "postal_code": {
+            "type": "string"
+          },
+          "world_location": {
+            "type": "string"
+          },
+          "locality": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "more_info_post_address": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "language": {
+      "type": "string"
+    }
+  }
+}

--- a/formats/contact/publisher/links.json
+++ b/formats/contact/publisher/links.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "related": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}


### PR DESCRIPTION
We create the content schema for `contacts` (for how they are currently represented in the `content-store`), so that we can implement contract testing in `contacts-frontend` and `contacts-admin`. We make the change to add `organisations` to the links JSON, so that in future we can reference organisations from the content-store (currently we are passing `organisation` data in the details hash as well). 

The reason why we cannot not just switch to using the `organisations` from the `content-store` right now is that in `contacts-frontend` we require the `organisation.abbreviation` attribute, which is currently not stored for `content-store` organisations.

Improvements can be made in future PR's, removing `organisation` data from the details hash.