### PR TITLE
Gitignore *.json.publisher_v2.valid files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.json.valid
 *.json.frontend.valid
 *.json.publisher.valid
+*.json.publisher_v2.valid
+*.json.publisher_v2_links.valid


### PR DESCRIPTION
- These seem to be a new addition. We couldn't work out why they were
  polluting our `git status` when we were generating new schemas and why
  we'd never seen anything like them before, then we found this file and
  determined they'd been missed when they were added.