### PR TITLE
Change tribunal_decision_categories to match schema in examples

### DIFF
--- a/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
@@ -12,8 +12,8 @@
     "metadata": {
       "hidden_indexable_content": "The stay was extended pending the determination of proceedings commenced in 2000/2001 under the Part-time Workers (Prevention of Less Favourable Treatment) Regulations 2000, known as the Matthews -v- Kent & Medway Fire Authority litigation.",
       "tribunal_decision_categories": [
-        "contract-of-employment",
-        "part-time-workers"
+        "age-discrimination",
+        "agency-workers"
       ],
       "tribunal_decision_country": "england-and-wales",
       "tribunal_decision_decision_date": "2008-12-19",


### PR DESCRIPTION
Fixes error caused by non-matching `tribunal_decision_categories` values in employment tribunal decisions examples.