### PR TITLE
Add ‘actions’ to ‘travel_advice’ details hash

### DIFF
--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -63,7 +63,8 @@
         "change_description",
         "alert_status",
         "email_signup_link",
-        "parts"
+        "parts",
+        "actions"
       ],
       "properties": {
         "summary": {
@@ -126,6 +127,27 @@
                 "type": "string"
               },
               "body": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "request_type"
+            ],
+            "properties": {
+              "request_type": {
+                "type": "string"
+              },
+              "requester": {
+                "type": "string"
+              },
+              "comment": {
                 "type": "string"
               }
             }

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -107,7 +107,8 @@
         "change_description",
         "alert_status",
         "email_signup_link",
-        "parts"
+        "parts",
+        "actions"
       ],
       "properties": {
         "summary": {
@@ -170,6 +171,27 @@
                 "type": "string"
               },
               "body": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "request_type"
+            ],
+            "properties": {
+              "request_type": {
+                "type": "string"
+              },
+              "requester": {
+                "type": "string"
+              },
+              "comment": {
                 "type": "string"
               }
             }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -99,7 +99,8 @@
         "change_description",
         "alert_status",
         "email_signup_link",
-        "parts"
+        "parts",
+        "actions"
       ],
       "properties": {
         "summary": {
@@ -162,6 +163,27 @@
                 "type": "string"
               },
               "body": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "request_type"
+            ],
+            "properties": {
+              "request_type": {
+                "type": "string"
+              },
+              "requester": {
+                "type": "string"
+              },
+              "comment": {
                 "type": "string"
               }
             }

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -62,6 +62,13 @@
         "title": "Contact FCO Travel Advice Team",
         "body": "<p>This email service only offers information and advice for British nationals planning to travel abroad. </p> <p>If you need urgent help because something has happened to a friend or relative abroad, contact the consular assistance team on 020 7008 1500 (24 hours).</p> <p>If you’re abroad and need emergency help, please contact the nearest <a href=\"https://www.gov.uk/government/world/organisations\">British embassy, consulate or high commission</a>.</p> <p>If you have a question about this travel advice, you can email us at <a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;</a></p> <p>Before you send an email, make sure you have read the travel advice for the country you’re travelling to, and the guidance on <a href=\"https://www.gov.uk/how-the-foreign-commonwealth-office-puts-together-travel-advice\">how the FCO puts travel advice together</a>.</p> "
       }
+    ],
+    "actions": [
+      {
+        "request_type": "new_version",
+        "requester": "user@example.com",
+        "comment": "Created version 20"
+      }
     ]
   },
   "format": "travel_advice",

--- a/formats/travel_advice/frontend/examples/no-parts.json
+++ b/formats/travel_advice/frontend/examples/no-parts.json
@@ -12,7 +12,14 @@
     "change_description": "Latest update: Info about the cold.",
     "alert_status": [],
     "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
-    "parts": []
+    "parts": [],
+    "actions": [
+      {
+        "request_type": "new_version",
+        "requester": "user@example.com",
+        "comment": "Created version 20"
+      }
+    ]
   },
   "format": "travel_advice",
   "links": {

--- a/formats/travel_advice/publisher/details.json
+++ b/formats/travel_advice/publisher/details.json
@@ -9,7 +9,8 @@
      "change_description",
      "alert_status",
      "email_signup_link",
-     "parts"
+     "parts",
+     "actions"
   ],
   "properties": {
     "summary": {
@@ -65,6 +66,25 @@
             "type": "string"
           },
           "body": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["request_type"],
+        "properties": {
+          "request_type": {
+            "type": "string"
+          },
+          "requester": {
+            "type": "string"
+          },
+          "comment": {
             "type": "string"
           }
         }

--- a/formats/travel_advice/publisher_v2/examples/travel_advice.json
+++ b/formats/travel_advice/publisher_v2/examples/travel_advice.json
@@ -61,6 +61,13 @@
         "title": "Contact FCO Travel Advice Team",
         "body": "<p>This email service only offers information and advice for British nationals planning to travel abroad. </p> <p>If you need urgent help because something has happened to a friend or relative abroad, contact the consular assistance team on 020 7008 1500 (24 hours).</p> <p>If you’re abroad and need emergency help, please contact the nearest <a href=\"https://www.gov.uk/government/world/organisations\">British embassy, consulate or high commission</a>.</p> <p>If you have a question about this travel advice, you can email us at <a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;</a></p> <p>Before you send an email, make sure you have read the travel advice for the country you’re travelling to, and the guidance on <a href=\"https://www.gov.uk/how-the-foreign-commonwealth-office-puts-together-travel-advice\">how the FCO puts travel advice together</a>.</p> "
       }
+    ],
+    "actions": [
+      {
+        "request_type": "new_version",
+        "requester": "user@example.com",
+        "comment": "Created version 20"
+      }
     ]
   },
   "format": "travel_advice",


### PR DESCRIPTION
Closing this pull request.

It will be required for phase 2, so we should try to keep this branch around if possible. For now, we're migrating travel advice publisher to phase 1.