### PR TITLE
Allow additional properties in ‘placeholder’ formats…

### DIFF
--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -54,7 +54,7 @@
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "analytics_identifier": {
           "type": "string",

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -98,7 +98,7 @@
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "analytics_identifier": {
           "type": "string",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -90,7 +90,7 @@
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "analytics_identifier": {
           "type": "string",

--- a/formats/placeholder/publisher/details.json
+++ b/formats/placeholder/publisher/details.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "analytics_identifier": {
       "type": "string",


### PR DESCRIPTION
This eases the migration by allowing publishing
apps to send all required data to the publishing
api, without actually making the switch to the
new format.