### PR TITLE
More rigorous `clean` step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ default: $(dist_publisher_schemas) $(frontend_schemas) validate_unique_base_path
 
 # A task to remove all intermediary files and force a complete rebuild
 clean:
-	rm -f $(frontend_schemas)
-	rm -f $(dist_publisher_schemas)
+	rm -rf dist/formats
 
 validate_unique_base_path: $(frontend_schemas)
 	$(ensure_example_base_paths_unique_bin) $(frontend_examples)

--- a/lib/tasks/combine_publisher_schemas.rake
+++ b/lib/tasks/combine_publisher_schemas.rake
@@ -7,6 +7,7 @@ schema_reader = JSON::Schema::Reader.new(accept_file: true, accept_uri: false)
 hand_made_publisher_schemas = FileList.new("formats/*/publisher/schema.json")
 
 rule %r{^dist/formats/.*/publisher(_v2)?/schema.json} => ->(f) { f.sub(%r{^dist/}, '').sub(%r{_v2}, "") } do |t|
+  FileUtils.mkdir_p t.name.pathmap("%d")
   FileUtils.cp t.source, t.name
 end
 


### PR DESCRIPTION
The idea is that everything in `dist/formats` should be generated.
To make sure that this is indeed the case, the `clean` step should
delete everything in that folder and the build should successfully
regenerate it.

/cc @boffbowsh 
