### PR TITLE
Add ‘updated_at’ to travel advice details…

### DIFF
--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -59,6 +59,7 @@
       "required": [
         "summary",
         "country",
+        "updated_at",
         "reviewed_at",
         "change_description",
         "alert_status",
@@ -84,6 +85,10 @@
               "type": "string"
             }
           }
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
         },
         "reviewed_at": {
           "type": "string",

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -103,6 +103,7 @@
       "required": [
         "summary",
         "country",
+        "updated_at",
         "reviewed_at",
         "change_description",
         "alert_status",
@@ -128,6 +129,10 @@
               "type": "string"
             }
           }
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
         },
         "reviewed_at": {
           "type": "string",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -95,6 +95,7 @@
       "required": [
         "summary",
         "country",
+        "updated_at",
         "reviewed_at",
         "change_description",
         "alert_status",
@@ -120,6 +121,10 @@
               "type": "string"
             }
           }
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
         },
         "reviewed_at": {
           "type": "string",

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -9,6 +9,7 @@
       "name": "Albania",
       "slug": "albania"
     },
+    "updated_at": "2015-10-15T11:00:20+01:00",
     "reviewed_at": "2015-10-15T11:00:20+01:00",
     "change_description": "Latest Update - this advice has been reviewed and re-issued without amendment",
     "alert_status": [],

--- a/formats/travel_advice/frontend/examples/no-parts.json
+++ b/formats/travel_advice/frontend/examples/no-parts.json
@@ -8,6 +8,7 @@
       "name": "Antarctica",
       "slug": "antarctica"
     },
+    "updated_at": "2015-10-15T11:00:20+01:00",
     "reviewed_at": "2015-08-28T17:11:23+01:00",
     "change_description": "Latest update: Info about the cold.",
     "alert_status": [],

--- a/formats/travel_advice/publisher/details.json
+++ b/formats/travel_advice/publisher/details.json
@@ -5,6 +5,7 @@
   "required": [
      "summary",
      "country",
+     "updated_at",
      "reviewed_at",
      "change_description",
      "alert_status",
@@ -27,6 +28,10 @@
           "type": "string"
         }
       }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
     },
     "reviewed_at": {
       "type": "string",

--- a/formats/travel_advice/publisher_v2/examples/travel_advice.json
+++ b/formats/travel_advice/publisher_v2/examples/travel_advice.json
@@ -8,6 +8,7 @@
       "name": "Albania",
       "slug": "albania"
     },
+    "updated_at": "2015-10-15T11:00:20+01:00",
     "reviewed_at": "2015-10-15T11:00:20+01:00",
     "change_description": "Latest Update - this advice has been reviewed and re-issued without amendment",
     "alert_status": [],


### PR DESCRIPTION
The atom feed needs this field to render.

Application change: https://github.com/alphagov/travel-advice-publisher/pull/93