### PR TITLE
Add organisations to hmrc manual examples

### DIFF
--- a/formats/hmrc_manual/frontend/examples/vat-government-public-bodies.json
+++ b/formats/hmrc_manual/frontend/examples/vat-government-public-bodies.json
@@ -128,6 +128,16 @@
         "web_url": "https://www.preview.alphagov.co.uk/hmrc-internal-manuals/vat-government-and-public-bodies",
         "locale": "en"
       }
+    ],
+    "organisations": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue & Customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
+        "locale": "en"
+      }
     ]
   }
 }

--- a/formats/hmrc_manual/publisher_v2/examples/hmrc_manual_links.json
+++ b/formats/hmrc_manual/publisher_v2/examples/hmrc_manual_links.json
@@ -1,0 +1,7 @@
+{
+  "links": {
+    "organisations": [
+      "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
+    ]
+  }
+}

--- a/formats/hmrc_manual_section/publisher_v2/examples/hmrc_manual_section_links.json
+++ b/formats/hmrc_manual_section/publisher_v2/examples/hmrc_manual_section_links.json
@@ -1,0 +1,7 @@
+{
+  "links": {
+    "organisations": [
+      "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
+    ]
+  }
+}


### PR DESCRIPTION
We're currently migrating hmrc-manuals-api to a new tagging
architecture. As part of this, we want to ensure that organisations
data is published in the links hash. Updating the hmrc manual frontend
example to support testing of this change.