### PR TITLE
Topic enhancements to support Service Manual Topics

### DIFF
--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -115,10 +115,10 @@
         "children": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "linked_items": {
           "$ref": "#/definitions/frontend_links"
         },
-        "linked_items": {
+        "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -118,6 +118,9 @@
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
+        "linked_items": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "mainstream_browse_pages": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -91,11 +91,17 @@
               "name": {
                 "type": "string"
               },
+              "description": {
+                "type": "string"
+              },
               "contents": {
                 "type": "array",
                 "items": {
                   "$ref": "#/definitions/absolute_path"
                 }
+              },
+              "content_ids": {
+                "$ref": "#/definitions/guid_list"
               }
             }
           }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -135,11 +135,17 @@
               "name": {
                 "type": "string"
               },
+              "description": {
+                "type": "string"
+              },
               "contents": {
                 "type": "array",
                 "items": {
                   "$ref": "#/definitions/absolute_path"
                 }
+              },
+              "content_ids": {
+                "$ref": "#/definitions/guid_list"
               }
             }
           }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -164,6 +164,10 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
+        "linked_items": {
+          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
+          "$ref": "#/definitions/guid_list"
+        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -160,12 +160,12 @@
           "description": "Any child topics",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
         "linked_items": {
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "alpha_taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -14,6 +14,10 @@
           "description": "Any child topics",
           "$ref": "#/definitions/guid_list"
         },
+        "linked_items": {
+          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -127,11 +127,17 @@
               "name": {
                 "type": "string"
               },
+              "description": {
+                "type": "string"
+              },
               "contents": {
                 "type": "array",
                 "items": {
                   "$ref": "#/definitions/absolute_path"
                 }
+              },
+              "content_ids": {
+                "$ref": "#/definitions/guid_list"
               }
             }
           }

--- a/formats/topic/frontend/examples/service_manual_topic.json
+++ b/formats/topic/frontend/examples/service_manual_topic.json
@@ -1,0 +1,86 @@
+{
+  "base_path":"/service-manual/test-topic",
+  "content_id":"cd02b82d-c706-435c-a2fc-2dcabd168ef4",
+  "title":"Service Manual Test Topic",
+  "format":"topic",
+  "need_ids":[],
+  "locale":"en",
+  "updated_at":"2016-01-15T16:53:47.645Z",
+  "public_updated_at":"2016-01-15T15:31:21.000+00:00",
+  "phase":"alpha",
+  "analytics_identifier":null,
+  "links":{
+    "linked_items":[
+      {
+        "content_id":"60b91f03-9dfe-4cb1-a01b-d0391b261cd8",
+        "title":"Helpdesk",
+        "base_path":"/service-manual/operations/helpdesk",
+        "description":"Description",
+        "api_url":"http://content-store.dev.gov.uk/content/service-manual/operations/helpdesk",
+        "web_url":"http://www.dev.gov.uk/service-manual/operations/helpdesk",
+        "locale":"en",
+        "analytics_identifier":null
+      },
+      {
+        "content_id":"0c23c42e-d1ae-433a-834b-ebc5e4c3785f",
+        "title":"Accessibility",
+        "base_path":"/service-manual/user-centred-design/accessibility",
+        "description":"Description",
+        "api_url":"http://content-store.dev.gov.uk/content/service-manual/user-centred-design/accessibility",
+        "web_url":"http://www.dev.gov.uk/service-manual/user-centred-design/accessibility",
+        "locale":"en",
+        "analytics_identifier":null
+      },
+      {
+        "content_id":"56b79735-fd9b-4119-a9f4-682098087953",
+        "title":"Addresses",
+        "base_path":"/service-manual/user-centred-design/resources/patterns/addresses",
+        "description":"Description",
+        "api_url":"http://content-store.dev.gov.uk/content/service-manual/user-centred-design/resources/patterns/addresses",
+        "web_url":"http://www.dev.gov.uk/service-manual/user-centred-design/resources/patterns/addresses",
+        "locale":"en",
+        "analytics_identifier":null
+      }
+    ],
+    "available_translations":[
+      {
+        "content_id":"cd02b82d-c706-435c-a2fc-2dcabd168ef4",
+        "title":"This should be looking goooooood",
+        "base_path":"/service-manual/test-topic",
+        "description":"A good lookin topic",
+        "api_url":"http://content-store.dev.gov.uk/content/service-manual/test-topic",
+        "web_url":"http://www.dev.gov.uk/service-manual/test-topic",
+        "locale":"en"
+      }
+    ]
+  },
+  "description":"Service Manual Topic description",
+  "details":{
+    "groups":[
+      {
+        "name":"Group 1",
+        "description":"The first group",
+        "contents":[
+          "/service-manual/user-centred-design/accessibility",
+          "/service-manual/user-centred-design/resources/patterns/addresses"
+        ],
+        "content_ids":[
+          "0c23c42e-d1ae-433a-834b-ebc5e4c3785f",
+          "56b79735-fd9b-4119-a9f4-682098087953"
+        ]
+      },
+      {
+        "name":"Group 2",
+        "description":"The second group",
+        "contents":[
+          "/service-manual/operations/helpdesk",
+          "/service-manual/user-centred-design/resources/creating-accessible-PDFs"
+        ],
+        "content_ids":[
+          "60b91f03-9dfe-4cb1-a01b-d0391b261cd8",
+          "65744959-71cc-495c-922e-da4709a5f89b"
+        ]
+      }
+    ]
+  }
+}

--- a/formats/topic/publisher/details.json
+++ b/formats/topic/publisher/details.json
@@ -26,11 +26,17 @@
           "name": {
             "type": "string"
           },
+          "description": {
+            "type": "string"
+          },
           "contents": {
             "type": "array",
             "items": {
               "$ref" : "#/definitions/absolute_path"
             }
+          },
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
           }
         }
       }

--- a/formats/topic/publisher/links.json
+++ b/formats/topic/publisher/links.json
@@ -6,6 +6,10 @@
     "children": {
       "description": "Any child topics",
       "$ref": "#/definitions/guid_list"
+    },
+    "linked_items": {
+      "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
+      "$ref": "#/definitions/guid_list"
     }
   }
 }


### PR DESCRIPTION
After several discussions with the Finding Things team we've decided to use the existing Topics format for Service Manual Topics ([see example](http://service-manual-staging.herokuapp.com/agile-delivery/)). To make it work we need the following:

1. topic groups need an optional `description` field to describe each group ("sub-section"?)
2. reference linked items within groups using `content_id`s
3. be able to "expand" `content_id`s so that a URL and a title for the referenced content items could be displayed on a frontend page.

To implement 3 we have decided to *temporarily* use the `links -> linked_items` hash. Content ids in the links hash are automatically expanded by the content-store. This can later be used to match the expanded content items to match with their references in `groups -> content_ids`. This is expected to be replaced by a dependency resolution service that is currently being spiked.

@rboulton could you please have a look and let me know if you have any questions?

There are related WIP branches: 
1) on service-manual-publisher: to generate payload in this format, [see here](https://github.com/alphagov/service-manual-publisher/pull/130)
2) on government-frontend: to display Service Manual Topics that is using this format: [see here](https://github.com/alphagov/government-frontend/compare/service_manual_topics?expand=1).