### PR TITLE
Add breadcrumbs to travel advice details

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -281,6 +281,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -325,6 +325,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -123,6 +123,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -266,6 +266,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -166,6 +166,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -210,6 +210,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -175,6 +175,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -472,6 +472,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -516,6 +516,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -102,6 +102,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -478,6 +478,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -209,6 +209,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -253,6 +253,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -218,6 +218,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -178,6 +178,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -222,6 +222,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -187,6 +187,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -185,6 +185,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -229,6 +229,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -194,6 +194,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -168,6 +168,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -212,6 +212,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -177,6 +177,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -171,6 +171,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -215,6 +215,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -105,6 +105,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -174,6 +174,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -317,6 +317,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -364,6 +364,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -108,6 +108,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -320,6 +320,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -275,6 +275,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -319,6 +319,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -284,6 +284,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -266,6 +266,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -310,6 +310,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -275,6 +275,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -203,6 +203,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -251,6 +251,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -115,6 +115,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -200,6 +200,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -255,6 +255,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -299,6 +299,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -264,6 +264,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -202,6 +202,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -246,6 +246,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -211,6 +211,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -196,6 +196,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -240,6 +240,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -205,6 +205,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -289,6 +289,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -336,6 +336,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -118,6 +118,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -282,6 +282,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -208,6 +208,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -252,6 +252,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -217,6 +217,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -193,6 +193,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -237,6 +237,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -202,6 +202,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -169,6 +169,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -213,6 +213,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -178,6 +178,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -163,6 +163,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -207,6 +207,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -172,6 +172,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -207,6 +207,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -253,6 +253,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -107,6 +107,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -210,6 +210,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -263,6 +263,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -345,34 +373,6 @@
         },
         "content_type": {
           "type": "string"
-        }
-      }
-    },
-    "parent": {
-      "type": "object",
-      "additionalPropeties": false,
-      "required": [
-        "title",
-        "web_url",
-        "parent"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "web_url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "parent": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "#/definitions/parent"
-            }
-          ]
         }
       }
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -71,7 +71,8 @@
         "change_description",
         "alert_status",
         "email_signup_link",
-        "parts"
+        "parts",
+        "primary_parent"
       ],
       "properties": {
         "summary": {
@@ -140,6 +141,27 @@
               "body": {
                 "type": "string"
               }
+            }
+          }
+        },
+        "primary_parent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "web_url",
+            "parent"
+          ],
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "web_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "parent": {
+              "$ref": "#/definitions/parent"
             }
           }
         }
@@ -323,6 +345,34 @@
         },
         "content_type": {
           "type": "string"
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
         }
       }
     },

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -307,6 +307,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -389,34 +417,6 @@
         },
         "content_type": {
           "type": "string"
-        }
-      }
-    },
-    "parent": {
-      "type": "object",
-      "additionalPropeties": false,
-      "required": [
-        "title",
-        "web_url",
-        "parent"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "web_url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "parent": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "#/definitions/parent"
-            }
-          ]
         }
       }
     }

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -115,7 +115,8 @@
         "change_description",
         "alert_status",
         "email_signup_link",
-        "parts"
+        "parts",
+        "primary_parent"
       ],
       "properties": {
         "summary": {
@@ -184,6 +185,27 @@
               "body": {
                 "$ref": "#/definitions/multiple_content_types"
               }
+            }
+          }
+        },
+        "primary_parent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "web_url",
+            "parent"
+          ],
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "web_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "parent": {
+              "$ref": "#/definitions/parent"
             }
           }
         }
@@ -367,6 +389,34 @@
         },
         "content_type": {
           "type": "string"
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
         }
       }
     }

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -102,6 +102,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -269,6 +269,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -351,34 +379,6 @@
         },
         "content_type": {
           "type": "string"
-        }
-      }
-    },
-    "parent": {
-      "type": "object",
-      "additionalPropeties": false,
-      "required": [
-        "title",
-        "web_url",
-        "parent"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "web_url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "parent": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "#/definitions/parent"
-            }
-          ]
         }
       }
     }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -114,7 +114,8 @@
         "change_description",
         "alert_status",
         "email_signup_link",
-        "parts"
+        "parts",
+        "primary_parent"
       ],
       "properties": {
         "summary": {
@@ -183,6 +184,27 @@
               "body": {
                 "$ref": "#/definitions/multiple_content_types"
               }
+            }
+          }
+        },
+        "primary_parent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "web_url",
+            "parent"
+          ],
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "web_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "parent": {
+              "$ref": "#/definitions/parent"
             }
           }
         }
@@ -329,6 +351,34 @@
         },
         "content_type": {
           "type": "string"
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
         }
       }
     }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -65,7 +65,8 @@
       "additionalProperties": false,
       "required": [
         "email_signup_link",
-        "countries"
+        "countries",
+        "primary_parent"
       ],
       "properties": {
         "email_signup_link": {
@@ -109,6 +110,27 @@
                   "type": "string"
                 }
               }
+            }
+          }
+        },
+        "primary_parent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "web_url",
+            "parent"
+          ],
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "web_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "parent": {
+              "$ref": "#/definitions/parent"
             }
           }
         }
@@ -205,6 +227,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -109,7 +109,8 @@
       "additionalProperties": false,
       "required": [
         "email_signup_link",
-        "countries"
+        "countries",
+        "primary_parent"
       ],
       "properties": {
         "email_signup_link": {
@@ -153,6 +154,27 @@
                   "type": "string"
                 }
               }
+            }
+          }
+        },
+        "primary_parent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "web_url",
+            "parent"
+          ],
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "web_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "parent": {
+              "$ref": "#/definitions/parent"
             }
           }
         }
@@ -249,6 +271,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -102,6 +102,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -108,7 +108,8 @@
       "additionalProperties": false,
       "required": [
         "email_signup_link",
-        "countries"
+        "countries",
+        "primary_parent"
       ],
       "properties": {
         "email_signup_link": {
@@ -152,6 +153,27 @@
                   "type": "string"
                 }
               }
+            }
+          }
+        },
+        "primary_parent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "title",
+            "web_url",
+            "parent"
+          ],
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "web_url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "parent": {
+              "$ref": "#/definitions/parent"
             }
           }
         }
@@ -211,6 +233,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -179,6 +179,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -223,6 +223,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -99,6 +99,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -188,6 +188,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -52,6 +52,26 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": ["title", "web_url", "parent"],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref":"#/definitions/parent"}
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -65,12 +65,16 @@
       }
     ],
     "primary_parent": {
-      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
-      "title": "Travel abroad",
+      "web_url": "https://www.gov.uk/foreign-travel-advice",
+      "title": "Foreign travel advice",
       "parent": {
-        "web_url": "https://www.gov.uk/browse/abroad",
-        "title": "Passports, travel and living abroad",
-        "parent": null
+        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+        "title": "Travel abroad",
+        "parent": {
+          "web_url": "https://www.gov.uk/browse/abroad",
+          "title": "Passports, travel and living abroad",
+          "parent": null
+        }
       }
     }
   },

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -63,7 +63,16 @@
         "title": "Contact FCO Travel Advice Team",
         "body": "<p>This email service only offers information and advice for British nationals planning to travel abroad. </p> <p>If you need urgent help because something has happened to a friend or relative abroad, contact the consular assistance team on 020 7008 1500 (24 hours).</p> <p>If you’re abroad and need emergency help, please contact the nearest <a href=\"https://www.gov.uk/government/world/organisations\">British embassy, consulate or high commission</a>.</p> <p>If you have a question about this travel advice, you can email us at <a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;</a></p> <p>Before you send an email, make sure you have read the travel advice for the country you’re travelling to, and the guidance on <a href=\"https://www.gov.uk/how-the-foreign-commonwealth-office-puts-together-travel-advice\">how the FCO puts travel advice together</a>.</p> "
       }
-    ]
+    ],
+    "primary_parent": {
+      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+      "title": "Travel abroad",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad",
+        "title": "Passports, travel and living abroad",
+        "parent": null
+      }
+    }
   },
   "format": "travel_advice",
   "links": {

--- a/formats/travel_advice/frontend/examples/no-parts.json
+++ b/formats/travel_advice/frontend/examples/no-parts.json
@@ -13,7 +13,16 @@
     "change_description": "Latest update: Info about the cold.",
     "alert_status": [],
     "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
-    "parts": []
+    "parts": [],
+    "primary_parent": {
+      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+      "title": "Travel abroad",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad",
+        "title": "Passports, travel and living abroad",
+        "parent": null
+      }
+    }
   },
   "format": "travel_advice",
   "links": {

--- a/formats/travel_advice/frontend/examples/no-parts.json
+++ b/formats/travel_advice/frontend/examples/no-parts.json
@@ -15,12 +15,16 @@
     "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
     "parts": [],
     "primary_parent": {
-      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
-      "title": "Travel abroad",
+      "web_url": "https://www.gov.uk/foreign-travel-advice",
+      "title": "Foreign travel advice",
       "parent": {
-        "web_url": "https://www.gov.uk/browse/abroad",
-        "title": "Passports, travel and living abroad",
-        "parent": null
+        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+        "title": "Travel abroad",
+        "parent": {
+          "web_url": "https://www.gov.uk/browse/abroad",
+          "title": "Passports, travel and living abroad",
+          "parent": null
+        }
       }
     }
   },

--- a/formats/travel_advice/publisher/details.json
+++ b/formats/travel_advice/publisher/details.json
@@ -111,26 +111,6 @@
           "type": "string"
         }
       }
-    },
-    "parent": {
-      "type": "object",
-      "additionalPropeties": false,
-      "required": ["title", "web_url", "parent"],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "web_url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "parent": {
-          "oneOf": [
-            {"type": "null"},
-            {"$ref":"#/definitions/parent"}
-          ]
-        }
-      }
     }
   }
 }

--- a/formats/travel_advice/publisher/details.json
+++ b/formats/travel_advice/publisher/details.json
@@ -10,7 +10,8 @@
      "change_description",
      "alert_status",
      "email_signup_link",
-     "parts"
+     "parts",
+     "primary_parent"
   ],
   "properties": {
     "summary": {
@@ -74,6 +75,23 @@
           }
         }
       }
+    },
+    "primary_parent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "web_url", "parent"],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "$ref": "#/definitions/parent"
+        }
+      }
     }
   },
   "definitions": {
@@ -91,6 +109,26 @@
         },
         "content_type": {
           "type": "string"
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": ["title", "web_url", "parent"],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref":"#/definitions/parent"}
+          ]
         }
       }
     }

--- a/formats/travel_advice/publisher_v2/examples/travel_advice.json
+++ b/formats/travel_advice/publisher_v2/examples/travel_advice.json
@@ -143,7 +143,16 @@
           }
         ]
       }
-    ]
+    ],
+    "primary_parent": {
+      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+      "title": "Travel abroad",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad",
+        "title": "Passports, travel and living abroad",
+        "parent": null
+      }
+    }
   },
   "format": "travel_advice",
   "locale": "en",

--- a/formats/travel_advice/publisher_v2/examples/travel_advice.json
+++ b/formats/travel_advice/publisher_v2/examples/travel_advice.json
@@ -145,12 +145,16 @@
       }
     ],
     "primary_parent": {
-      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
-      "title": "Travel abroad",
+      "web_url": "https://www.gov.uk/foreign-travel-advice",
+      "title": "Foreign travel advice",
       "parent": {
-        "web_url": "https://www.gov.uk/browse/abroad",
-        "title": "Passports, travel and living abroad",
-        "parent": null
+        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+        "title": "Travel abroad",
+        "parent": {
+          "web_url": "https://www.gov.uk/browse/abroad",
+          "title": "Passports, travel and living abroad",
+          "parent": null
+        }
       }
     }
   },

--- a/formats/travel_advice_index/frontend/examples/index.json
+++ b/formats/travel_advice_index/frontend/examples/index.json
@@ -54,7 +54,16 @@
         "change_description": "Latest update: Summary – information and advice for Manchester City fans travelling to Seville ",
         "synonyms": [ "Ibiza", "Majorca", "Mallorca", "Lanzarote", "Barcelona", "Benidorm", "Tenerife", "Canary Islands", "Canaries", "Gran Canaria" ]
       }
-    ]
+    ],
+    "primary_parent": {
+      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+      "title": "Travel abroad",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad",
+        "title": "Passports, travel and living abroad",
+        "parent": null
+      }
+    }
   },
   "format": "travel_advice_index",
   "links": {

--- a/formats/travel_advice_index/publisher/details.json
+++ b/formats/travel_advice_index/publisher/details.json
@@ -4,7 +4,8 @@
   "additionalProperties": false,
    "required": [
      "email_signup_link",
-     "countries"
+     "countries",
+     "primary_parent"
    ],
   "properties": {
     "email_signup_link": {
@@ -48,6 +49,23 @@
               "type": "string"
             }
           }
+        }
+      }
+    },
+    "primary_parent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "web_url", "parent"],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "$ref": "#/definitions/parent"
         }
       }
     }

--- a/formats/travel_advice_index/publisher_v2/examples/travel_advice_index.json
+++ b/formats/travel_advice_index/publisher_v2/examples/travel_advice_index.json
@@ -54,7 +54,16 @@
         "change_description": "Latest update: Summary – information and advice for Manchester City fans travelling to Seville ",
         "synonyms": [ "Ibiza", "Majorca", "Mallorca", "Lanzarote", "Barcelona", "Benidorm", "Tenerife", "Canary Islands", "Canaries", "Gran Canaria" ]
       }
-    ]
+    ],
+    "primary_parent": {
+      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+      "title": "Travel abroad",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad",
+        "title": "Passports, travel and living abroad",
+        "parent": null
+      }
+    }
   },
   "format": "travel_advice_index",
   "locale": "en",


### PR DESCRIPTION
https://trello.com/c/tomHUlp7/475-define-data-format-for-breadcrumbs

Proposed schema change to allow hardwired breadcrumbs through the publishing pipeline for travel advice. The structure resembles the section tag 'parent' hierarchy currently used on GOV.UK.

For now I've added the breadcrumbs structure to the travel advice details hash as it's not common across other formats and is a temporary measure until we have an idea of how dependency resolution informs breadcrumbs and related links.
 