### PR TITLE
Add update_type to V2 metadata schema

### DIFF
--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -95,6 +95,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -96,6 +96,13 @@
     "previous_version": {
       "type": "string"
     },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/v2_metadata.json
+++ b/formats/v2_metadata.json
@@ -11,6 +11,9 @@
     },
     "previous_version": {
       "type": "string"
+    },
+    "update_type": {
+      "enum": [ "major", "minor", "republish" ]
     }
   }
 }


### PR DESCRIPTION
As Applications move to V2 they will start to the use the Publishing API
as a data store. When they do this, in order to persist `update_type`
between draftings, it will need to be stored as part of the metadata.
This commit adds it to the V2 metadata but doesn't make it required, as
the `update_type` can also be provided when calling the `publish`
command on the content item.