### PR TITLE
Contacts: Put `organisation` in the links hash, not the details hash

### DIFF
--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -77,50 +77,6 @@
         "description": {
           "type": "string"
         },
-        "organisation": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "contact_index_content_id"
-          ],
-          "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "title": {
-              "type": "string"
-            },
-            "format": {
-              "type": "string"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "abbreviation": {
-              "type": "string"
-            },
-            "govuk_status": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "updated_at": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "ancestry": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "contact_index_content_id": {
-              "type": "string"
-            }
-          }
-        },
         "quick_links": {
           "type": "array",
           "maxItems": 3,
@@ -383,6 +339,9 @@
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -390,9 +349,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -121,50 +121,6 @@
         "description": {
           "type": "string"
         },
-        "organisation": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "contact_index_content_id"
-          ],
-          "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "title": {
-              "type": "string"
-            },
-            "format": {
-              "type": "string"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "abbreviation": {
-              "type": "string"
-            },
-            "govuk_status": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "updated_at": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "ancestry": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "contact_index_content_id": {
-              "type": "string"
-            }
-          }
-        },
         "quick_links": {
           "type": "array",
           "maxItems": 3,
@@ -427,6 +383,9 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -437,9 +396,6 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -13,6 +13,9 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -23,9 +26,6 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -120,50 +120,6 @@
         "description": {
           "type": "string"
         },
-        "organisation": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "contact_index_content_id"
-          ],
-          "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "title": {
-              "type": "string"
-            },
-            "format": {
-              "type": "string"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "abbreviation": {
-              "type": "string"
-            },
-            "govuk_status": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "updated_at": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "ancestry": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "contact_index_content_id": {
-              "type": "string"
-            }
-          }
-        },
         "quick_links": {
           "type": "array",
           "maxItems": 3,

--- a/formats/contact/frontend/examples/contact.json
+++ b/formats/contact/frontend/examples/contact.json
@@ -66,18 +66,6 @@
     "slug": "customs-excise-and-vat-fraud-reporting",
     "title": "Customs, Excise and VAT fraud reporting",
     "description": "Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud",
-    "organisation": {
-      "id": 1,
-      "title": "HM Revenue & Customs",
-      "format": "Non-ministerial department",
-      "slug": "hm-revenue-customs",
-      "abbreviation": "HMRC",
-      "govuk_status": "live",
-      "created_at": "2014-04-09T13:06:30.000Z",
-      "updated_at": "2015-01-23T12:32:09.000Z",
-      "ancestry": null,
-      "contact_index_content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
-    },
     "quick_links": [
       {
         "title": "Report smuggling ",

--- a/formats/contact/publisher/details.json
+++ b/formats/contact/publisher/details.json
@@ -16,47 +16,6 @@
     "description": {
       "type": "string"
     },
-    "organisation": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "contact_index_content_id"
-      ],
-      "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "format": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "abbreviation": {
-          "type": "string"
-        },
-        "govuk_status": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "ancestry": {
-          "type": ["string", "null"]
-        },
-        "contact_index_content_id": {
-          "type": "string"
-        }
-      }
-    },
     "quick_links": {
       "type": "array",
       "maxItems": 3,

--- a/formats/contact/publisher/links.json
+++ b/formats/contact/publisher/links.json
@@ -5,6 +5,9 @@
   "properties": {
     "related": {
       "$ref": "#/definitions/guid_list"
+    },
+    "organisations": {
+      "$ref": "#/definitions/guid_list"
     }
   }
 }


### PR DESCRIPTION
- This was being sent by contacts-admin in both places prior to
  https://trello.com/c/HEB3ukuP/263-remove-organisations-from-details-hash-for-contacts.
  We only need it in the one place - the links hash - as that's the
  convention now. It works as it is - contacts currently uses
  organisations from the links hash, but we should tidy up here.

The build is failing on contacts-admin because of https://github.com/alphagov/contacts-admin/pull/224 not being on master yet. Once that's merged and the build here is rerun, this _should_ go green.

Edit: That PR is merged, so this has indeed gone green. :green_heart: