### PR TITLE
Remove organisations from details hash in hmrc_manual and hmrc_manual_sections

### DIFF
--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -144,29 +144,6 @@
             }
           }
         },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "abbreviation",
-              "web_url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "abbreviation": {
-                "type": "string"
-              },
-              "web_url": {
-                "type": "string"
-              }
-            }
-          }
-        },
         "tags": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -188,29 +188,6 @@
             }
           }
         },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "abbreviation",
-              "web_url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "abbreviation": {
-                "type": "string"
-              },
-              "web_url": {
-                "type": "string"
-              }
-            }
-          }
-        },
         "tags": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -187,29 +187,6 @@
             }
           }
         },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "abbreviation",
-              "web_url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "abbreviation": {
-                "type": "string"
-              },
-              "web_url": {
-                "type": "string"
-              }
-            }
-          }
-        },
         "tags": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -65,8 +65,7 @@
       "additionalProperties": false,
       "required": [
         "section_id",
-        "manual",
-        "organisations"
+        "manual"
       ],
       "properties": {
         "section_id": {
@@ -103,29 +102,6 @@
           "properties": {
             "base_path": {
               "$ref": "#/definitions/absolute_path"
-            }
-          }
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "abbreviation",
-              "web_url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "abbreviation": {
-                "type": "string"
-              },
-              "web_url": {
-                "type": "string"
-              }
             }
           }
         },

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -109,8 +109,7 @@
       "additionalProperties": false,
       "required": [
         "section_id",
-        "manual",
-        "organisations"
+        "manual"
       ],
       "properties": {
         "section_id": {
@@ -147,29 +146,6 @@
           "properties": {
             "base_path": {
               "$ref": "#/definitions/absolute_path"
-            }
-          }
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "abbreviation",
-              "web_url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "abbreviation": {
-                "type": "string"
-              },
-              "web_url": {
-                "type": "string"
-              }
             }
           }
         },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -108,8 +108,7 @@
       "additionalProperties": false,
       "required": [
         "section_id",
-        "manual",
-        "organisations"
+        "manual"
       ],
       "properties": {
         "section_id": {
@@ -146,29 +145,6 @@
           "properties": {
             "base_path": {
               "$ref": "#/definitions/absolute_path"
-            }
-          }
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "abbreviation",
-              "web_url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "abbreviation": {
-                "type": "string"
-              },
-              "web_url": {
-                "type": "string"
-              }
             }
           }
         },

--- a/formats/hmrc_manual/frontend/examples/vat-government-public-bodies.json
+++ b/formats/hmrc_manual/frontend/examples/vat-government-public-bodies.json
@@ -109,13 +109,6 @@
         "published_at": "2015-03-05T15:11:32+00:00",
         "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5350"
       }
-    ],
-    "organisations": [
-      {
-        "title": "HM Revenue & Customs",
-        "abbreviation": "HMRC",
-        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
-      }
     ]
   },
   "links": {

--- a/formats/hmrc_manual/publisher/details.json
+++ b/formats/hmrc_manual/publisher/details.json
@@ -83,29 +83,6 @@
         }
       }
     },
-    "organisations": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "tags": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/hmrc_manual/publisher_v2/examples/hmrc_manual.json
+++ b/formats/hmrc_manual/publisher_v2/examples/hmrc_manual.json
@@ -109,13 +109,6 @@
         "published_at": "2015-03-05T15:11:32+00:00",
         "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5350"
       }
-    ],
-    "organisations": [
-      {
-        "title": "HM Revenue & Customs",
-        "abbreviation": "HMRC",
-        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
-      }
     ]
   },
   "routes": [

--- a/formats/hmrc_manual_section/frontend/examples/vatgpb1000.json
+++ b/formats/hmrc_manual_section/frontend/examples/vatgpb1000.json
@@ -56,14 +56,7 @@
     ],
     "manual": {
       "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies"
-    },
-    "organisations": [
-      {
-        "title": "HM Revenue & Customs",
-        "abbreviation": "HMRC",
-        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
-      }
-    ]
+    }
   },
   "links": {
     "available_translations": [
@@ -73,6 +66,16 @@
         "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
         "api_url": "https://content-store.preview.alphagov.co.uk/content/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
         "web_url": "https://www.preview.alphagov.co.uk/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
+        "locale": "en"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue & Customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
         "locale": "en"
       }
     ]

--- a/formats/hmrc_manual_section/publisher/details.json
+++ b/formats/hmrc_manual_section/publisher/details.json
@@ -4,8 +4,7 @@
   "additionalProperties": false,
   "required": [
     "section_id",
-    "manual",
-    "organisations"
+    "manual"
   ],
   "properties": {
     "section_id": {
@@ -42,29 +41,6 @@
       "properties": {
         "base_path": {
           "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "organisations": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
         }
       }
     },

--- a/formats/hmrc_manual_section/publisher_v2/examples/hmrc_manual_section.json
+++ b/formats/hmrc_manual_section/publisher_v2/examples/hmrc_manual_section.json
@@ -57,14 +57,7 @@
     ],
     "manual": {
       "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies"
-    },
-    "organisations": [
-      {
-        "title": "HM Revenue & Customs",
-        "abbreviation": "HMRC",
-        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
-      }
-    ]
+    }
   },
  "routes": [
     {


### PR DESCRIPTION
hmrc-manuals-api is being updated to publish organisation data in the
links hash rather than the details hash, as per current convention for
documents across GOVUK. This change drops details>organisations as a
required attribute and updates the hmrc_manual_section frontend example.