### PR TITLE
Remove details>organisations from required attributes in hmrc manuals

### DIFF
--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -65,8 +65,7 @@
       "additionalProperties": false,
       "required": [
         "section_id",
-        "manual",
-        "organisations"
+        "manual"
       ],
       "properties": {
         "section_id": {

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -109,8 +109,7 @@
       "additionalProperties": false,
       "required": [
         "section_id",
-        "manual",
-        "organisations"
+        "manual"
       ],
       "properties": {
         "section_id": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -108,8 +108,7 @@
       "additionalProperties": false,
       "required": [
         "section_id",
-        "manual",
-        "organisations"
+        "manual"
       ],
       "properties": {
         "section_id": {

--- a/formats/hmrc_manual_section/frontend/examples/vatgpb1000.json
+++ b/formats/hmrc_manual_section/frontend/examples/vatgpb1000.json
@@ -75,6 +75,16 @@
         "web_url": "https://www.preview.alphagov.co.uk/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
         "locale": "en"
       }
+    ],
+    "organisations": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue & Customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
+        "locale": "en"
+      }
     ]
   }
 }

--- a/formats/hmrc_manual_section/publisher/details.json
+++ b/formats/hmrc_manual_section/publisher/details.json
@@ -4,8 +4,7 @@
   "additionalProperties": false,
   "required": [
     "section_id",
-    "manual",
-    "organisations"
+    "manual"
   ],
   "properties": {
     "section_id": {


### PR DESCRIPTION
The hmrc-manuals-api is being updated to publish organisation data in the
links hash rather than the details hash, as per current convention for
documents across GOVUK. This change drops details>organisations as a
required attribute. Cleanup of details>organisations in the examples
will follow after further updates to the hmrc-manuals-api.