### PR TITLE
Adds lead organisations link type

### DIFF
--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -216,6 +216,7 @@
       ],
       "properties": {
         "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
@@ -249,6 +250,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -14,6 +14,7 @@
       ],
       "properties": {
         "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
@@ -47,6 +48,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -89,6 +89,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -134,6 +134,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -280,6 +280,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -325,6 +325,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -26,6 +26,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -132,6 +132,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -177,6 +177,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -101,6 +101,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -146,6 +146,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -108,6 +108,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -153,6 +153,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -91,6 +91,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -136,6 +136,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -94,6 +94,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -139,6 +139,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -29,6 +29,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -96,6 +96,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -141,6 +141,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -243,6 +243,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -288,6 +288,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -32,6 +32,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -198,6 +198,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -243,6 +243,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -188,6 +188,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -233,6 +233,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -126,6 +126,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -175,6 +175,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -39,6 +39,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -178,6 +178,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -223,6 +223,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -125,6 +125,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -170,6 +170,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -119,6 +119,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -164,6 +164,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -215,6 +215,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -260,6 +260,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -42,6 +42,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -131,6 +131,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -176,6 +176,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -116,6 +116,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -161,6 +161,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -125,6 +125,9 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -155,6 +155,7 @@
       ],
       "properties": {
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "policy_areas": {
@@ -171,6 +172,10 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -15,6 +15,7 @@
       ],
       "properties": {
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "policy_areas": {
@@ -31,6 +32,10 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -92,6 +92,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -137,6 +137,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -86,6 +86,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -131,6 +131,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -130,6 +130,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -177,6 +177,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -31,6 +31,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -164,6 +164,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -209,6 +209,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -26,6 +26,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -133,6 +133,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -178,6 +178,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -26,6 +26,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -102,6 +102,9 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -147,6 +147,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -23,6 +23,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/formats/base_links.json
+++ b/formats/base_links.json
@@ -16,6 +16,11 @@
       "$ref": "#/definitions/guid_list"
     },
     "organisations": {
+      "description": "All organisations linked to this content item. This should include lead organisations.",
+      "$ref": "#/definitions/guid_list"
+    },
+    "lead_organisations": {
+      "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
       "$ref": "#/definitions/guid_list"
     },
     "parent": {

--- a/formats/policy/frontend/examples/minimal_policy_area.json
+++ b/formats/policy/frontend/examples/minimal_policy_area.json
@@ -19,6 +19,7 @@
    },
    "links": {
       "organisations":[],
+      "lead_organisations":[],
       "people": [],
       "working_groups": [],
       "related":[],

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -67,6 +67,17 @@
           "locale": "en"
         }
       ],
+      "lead_organisations":[
+        {
+          "content_id": "a4759607-4fd8-4cf0-9d56-af9d14a71162",
+          "title": "Department for Work and Pensions",
+          "base_path": "/government/organisations/department-for-work-and-pensions",
+          "api_url": "https://www.gov.uk/api/organisations/department-for-work-and-pensions",
+          "web_url": "https://www.gov.uk/government/organisations/department-for-work-and-pensions",
+          "locale": "en"
+        }
+      ],
+
       "people": [],
       "working_groups": [],
       "related":[],

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -66,6 +66,16 @@
           "locale": "en"
         }
       ],
+      "lead_organisations":[
+        {
+          "content_id": "9417d532-a080-4856-9a0f-08b1d9d78c98",
+          "title": "Department for Work and Pensions",
+          "base_path": "/government/organisations/department-for-work-and-pensions",
+          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-and-pensions",
+          "web_url": "https://www.gov.uk/government/organisations/department-for-work-and-pensions",
+          "locale": "en"
+        }
+      ],
       "people": [
         {
           "content_id": "295ce3e3-a68b-4952-8f13-72ea62f5c16b",

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -60,6 +60,16 @@
           "locale": "en"
         }
       ],
+      "lead_organisations":[
+        {
+          "content_id": "8927158f-e4b2-4361-b55d-02de7599b220",
+          "title": "Northern Ireland Office",
+          "base_path": "/government/organisations/northern-ireland-office",
+          "api_url": "https://www.gov.uk/api/organisations/northern-ireland-office",
+          "web_url": "https://www.gov.uk/government/organisations/northern-ireland-office",
+          "locale": "en"
+        }
+      ],
       "people": [
         {
           "content_id": "70dc1901-2d36-4c3d-98ee-e1d5587a5ba9",

--- a/formats/policy/publisher_v2/examples/policy_links.json
+++ b/formats/policy/publisher_v2/examples/policy_links.json
@@ -3,6 +3,9 @@
     "organisations":[
       "a4759607-4fd8-4cf0-9d56-af9d14a71162"
     ],
+    "lead_organisations":[
+      "a4759607-4fd8-4cf0-9d56-af9d14a71162"
+    ],
     "people": [],
     "working_groups": [],
     "related":[],


### PR DESCRIPTION
Currently users can explicitly order the organisations in
policy-publisher when publishing the policy, but this will change
once policy-puplisher is migrated to use publishing api for storing
link data.

We think that all users need to be able to do is distinguish between
lead and supporting organisations, in a similar manner to whitehall.

The lead_organisations field here is intended to overlap with the
organisations one, so that other uses of organisations are not
impacted by the change.

This relates to https://trello.com/c/BQDQ824W/468-use-publishing-api-v2-for-policy-publisher