### PR TITLE
Rename `topics` to `policy_areas` in `statistics_announcement` schema

### DIFF
--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -107,13 +107,13 @@
       "additionalProperties": false,
       "required": [
         "organisations",
-        "topics"
+        "policy_areas"
       ],
       "properties": {
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "topics": {
+        "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "alpha_taxons": {
@@ -122,13 +122,13 @@
         "mainstream_browse_pages": {
           "$ref": "#/definitions/frontend_links"
         },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -151,14 +151,14 @@
       "additionalProperties": false,
       "required": [
         "organisations",
-        "topics"
+        "policy_areas"
       ],
       "properties": {
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
         },
         "alpha_taxons": {
@@ -169,6 +169,10 @@
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",
@@ -176,10 +180,6 @@
         },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -11,14 +11,14 @@
       "additionalProperties": false,
       "required": [
         "organisations",
-        "topics"
+        "policy_areas"
       ],
       "properties": {
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
         },
         "alpha_taxons": {
@@ -29,6 +29,10 @@
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",
@@ -36,10 +40,6 @@
         },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/formats/statistics_announcement/frontend/examples/cancelled_official_statistics.json
+++ b/formats/statistics_announcement/frontend/examples/cancelled_official_statistics.json
@@ -22,7 +22,7 @@
         "analytics_identifier": "L2"
       }
     ],
-    "topics": [
+    "policy_areas": [
       {
         "content_id": "848b8564-328c-4787-bebb-9e1b60ccf0d7",
         "title": "National Health Service",

--- a/formats/statistics_announcement/frontend/examples/national_statistics.json
+++ b/formats/statistics_announcement/frontend/examples/national_statistics.json
@@ -20,7 +20,7 @@
         "analytics_identifier": "L2"
       }
     ],
-    "topics": [
+    "policy_areas": [
       {
         "content_id": "848b8564-328c-4787-bebb-9e1b60ccf0d7",
         "title": "Defence and armed forces",

--- a/formats/statistics_announcement/frontend/examples/official_statistics.json
+++ b/formats/statistics_announcement/frontend/examples/official_statistics.json
@@ -20,7 +20,7 @@
         "analytics_identifier": "L2"
       }
     ],
-    "topics": [
+    "policy_areas": [
       {
         "content_id": "848b8564-328c-4787-bebb-9e1b60ccf0d7",
         "title": "National Health Service",

--- a/formats/statistics_announcement/frontend/examples/release_date_changed.json
+++ b/formats/statistics_announcement/frontend/examples/release_date_changed.json
@@ -22,7 +22,7 @@
         "analytics_identifier": "L2"
       }
     ],
-    "topics": [
+    "policy_areas": [
       {
         "content_id": "848b8564-328c-4787-bebb-9e1b60ccf0d7",
         "title": "National Health Service",

--- a/formats/statistics_announcement/publisher/links.json
+++ b/formats/statistics_announcement/publisher/links.json
@@ -4,13 +4,13 @@
   "additionalProperties": false,
   "required": [
     "organisations",
-    "topics"
+    "policy_areas"
   ],
   "properties": {
     "organisations": {
       "$ref": "#/definitions/guid_list"
     },
-    "topics": {
+    "policy_areas": {
       "$ref": "#/definitions/guid_list"
     }
   }


### PR DESCRIPTION
Statistics announcement pages currently link to a list of associated 'Topics'. This should remain the case but to preserve consistency in the backend and in light of the ongoing work around renaming `SpecialistSector`, `Topic` and `PolicyArea` the use of `policy_area` in the schema would seem to be the best approach.