### PR TITLE
Remove Related Discussion field from SM guides

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -84,18 +84,6 @@
             }
           }
         },
-        "related_discussion": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "header_links": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -128,18 +128,6 @@
             }
           }
         },
-        "related_discussion": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "header_links": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -127,18 +127,6 @@
             }
           }
         },
-        "related_discussion": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "header_links": {
           "type": "array",
           "items": {

--- a/formats/service_manual_guide/frontend/examples/basic_with_related_discussions.json
+++ b/formats/service_manual_guide/frontend/examples/basic_with_related_discussions.json
@@ -9,10 +9,6 @@
       "title" : "Agile community",
       "href" : "http://sm-11.herokuapp.com/communities/design-community/"
     },
-    "related_discussion" : {
-      "title" : "Design community on hackpad",
-      "href" : "https://designpatterns.hackpad.com/"
-    },
     "header_links" : [
       { "title" : "What is it, why it works and how to do it", "href" : "#what-is-it-why-it-works-and-how-to-do-it" }
     ]

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -22,18 +22,6 @@
         }
       }
     },
-    "related_discussion": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "href": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
     "header_links": {
       "type": "array",
       "items": {

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
@@ -10,10 +10,6 @@
       "title" : "Agile community",
       "href" : "http://sm-11.herokuapp.com/communities/design-community/"
     },
-    "related_discussion" : {
-      "title" : "Design community on hackpad",
-      "href" : "https://designpatterns.hackpad.com/"
-    },
     "header_links" : [
       { "title" : "What is it, why it works and how to do it", "href" : "#what-is-it-why-it-works-and-how-to-do-it" }
     ]


### PR DESCRIPTION
A decision within the team has been made to not use this field anymore. This is
safe to remove because:

- We do not have any content that's published or ready to be published
- The field is not used by the frontend application
- The field is no longer published by the publishing application
- This was an optional field