### PR TITLE
[Discuss] Allow "parent" links to contain expanded content.

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -281,6 +281,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -350,52 +378,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -253,7 +253,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -320,6 +327,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -51,7 +51,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -118,6 +125,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -266,6 +266,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -166,6 +166,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -235,52 +263,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -138,7 +138,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -205,6 +212,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -175,6 +175,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -357,6 +357,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -426,52 +454,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -329,7 +329,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -396,6 +403,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -30,7 +30,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -97,6 +104,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -363,6 +363,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -209,6 +209,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -278,52 +306,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -181,7 +181,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -248,6 +255,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -218,6 +218,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -178,6 +178,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -247,52 +275,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -150,7 +150,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -217,6 +224,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -187,6 +187,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -185,6 +185,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -254,52 +282,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -157,7 +157,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -224,6 +231,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -194,6 +194,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -168,6 +168,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -237,52 +265,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -140,7 +140,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -207,6 +214,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -177,6 +177,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -171,6 +171,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -240,52 +268,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -143,7 +143,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -210,6 +217,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -33,7 +33,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -100,6 +107,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -174,6 +174,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -173,6 +173,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -242,52 +270,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -145,7 +145,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -212,6 +219,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -182,6 +182,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -317,6 +317,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -386,52 +414,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -292,7 +292,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -359,6 +366,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -36,7 +36,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -103,6 +110,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -320,6 +320,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -275,6 +275,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -344,52 +372,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -247,7 +247,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -314,6 +321,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -284,6 +284,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -265,6 +265,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -334,52 +362,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -237,7 +237,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -304,6 +311,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -274,6 +274,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -203,6 +203,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -272,52 +300,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -179,7 +179,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -246,6 +253,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -43,7 +43,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -110,6 +117,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -200,6 +200,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -255,6 +255,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -324,52 +352,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -227,7 +227,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -294,6 +301,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -264,6 +264,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -202,6 +202,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -271,52 +299,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -174,7 +174,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -241,6 +248,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -211,6 +211,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -196,6 +196,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -265,52 +293,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -168,7 +168,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -235,6 +242,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -205,6 +205,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -289,6 +289,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -358,52 +386,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -264,7 +264,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -331,6 +338,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -46,7 +46,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -113,6 +120,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -282,6 +282,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -208,6 +208,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -282,52 +310,59 @@
       "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'"
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -180,7 +180,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -247,6 +254,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -217,6 +217,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -193,6 +193,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -1213,52 +1241,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -165,7 +165,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -232,6 +239,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -202,6 +202,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -199,6 +199,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -268,52 +296,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -175,7 +175,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -238,6 +245,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -35,7 +35,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -98,6 +105,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -204,6 +204,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -169,6 +169,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -238,52 +266,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -141,7 +141,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -208,6 +215,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -178,6 +178,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -163,6 +163,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -232,52 +260,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -135,7 +135,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -202,6 +209,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -172,6 +172,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -207,6 +207,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -276,52 +304,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -181,7 +181,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -248,6 +255,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -35,7 +35,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -102,6 +109,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -210,6 +210,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -152,6 +152,9 @@
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -162,9 +165,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
@@ -236,6 +236,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }
@@ -327,52 +355,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -196,6 +196,18 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "parent": {
+          "description": "The parent content item.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
+          "maxItems": 1
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -210,11 +222,6 @@
         },
         "organisations": {
           "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
         },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
@@ -280,6 +287,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -13,6 +13,18 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "parent": {
+          "description": "The parent content item.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
+          "maxItems": 1
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -27,11 +39,6 @@
         },
         "organisations": {
           "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
         },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
@@ -97,6 +104,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -247,6 +247,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -121,6 +121,9 @@
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -131,9 +134,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
@@ -210,6 +210,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -279,52 +307,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -165,6 +165,18 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "parent": {
+          "description": "The parent content item.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
+          "maxItems": 1
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -179,11 +191,6 @@
         },
         "organisations": {
           "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
         },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
@@ -249,6 +256,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -13,6 +13,18 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
+        "parent": {
+          "description": "The parent content item.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
+          "maxItems": 1
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -27,11 +39,6 @@
         },
         "organisations": {
           "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
         },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",
@@ -97,6 +104,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -216,6 +216,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -179,6 +179,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,
@@ -248,52 +276,59 @@
       }
     },
     "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "content_id",
+              "title",
+              "base_path",
+              "locale"
+            ],
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
                 "type": "string"
               },
-              {
-                "type": "null"
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "base_path": {
+                "$ref": "#/definitions/absolute_path"
+              },
+              "api_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "analytics_identifier": {
+                "$ref": "#/definitions/analytics_identifier"
               }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "type": "string"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/parent"
         }
-      }
+      ]
     }
   }
 }

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -151,7 +151,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -218,6 +225,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -27,7 +27,14 @@
         },
         "parent": {
           "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/guid_list"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ],
           "maxItems": 1
         },
         "policies": {
@@ -94,6 +101,34 @@
             },
             {
               "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
             }
           ]
         }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -188,6 +188,34 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": [
+        "title",
+        "web_url",
+        "parent"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/parent"
+            }
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/base_links.json
+++ b/formats/base_links.json
@@ -20,7 +20,10 @@
     },
     "parent": {
       "description": "The parent content item.",
-      "$ref": "#/definitions/guid_list",
+      "oneOf": [
+        { "$ref": "#/definitions/guid_list" },
+        { "$ref": "#/definitions/parent" }
+      ],
       "maxItems": 1
     },
     "policies": {

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -52,6 +52,26 @@
         }
       }
     },
+    "parent": {
+      "type": "object",
+      "additionalPropeties": false,
+      "required": ["title", "web_url", "parent"],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "parent": {
+          "oneOf": [
+            {"type": "null"},
+            {"$ref":"#/definitions/parent"}
+          ]
+        }
+      }
+    },
     "route": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -1,49 +1,56 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-      "content_id",
-      "title",
-      "base_path",
-      "locale"
-    ],
-    "properties": {
-      "content_id": {
-        "$ref": "#/definitions/guid"
-      },
-      "title": {
-        "type": "string"
-      },
-      "description": {
-        "anyOf": [
-          {
+  "oneOf": [
+    {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
             "type": "string"
           },
-          {
-            "type": "null"
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref" : "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           }
-        ]
-      },
-      "base_path": {
-        "$ref" : "#/definitions/absolute_path"
-      },
-      "api_url": {
-        "type": "string",
-        "format": "uri"
-      },
-      "web_url": {
-        "type": "string",
-        "format": "uri"
-      },
-      "locale": {
-        "type": "string"
-      },
-      "analytics_identifier": {
-        "$ref": "#/definitions/analytics_identifier"
+        }
       }
+    },
+    {
+      "$ref": "#/definitions/parent"
     }
-  }
+  ]
 }

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -122,7 +122,20 @@
         "web_url": "https://www.gov.uk/foreign-travel-advice/albania",
         "locale": "en"
       }
-    ]
+    ],
+    "parent": {
+      "web_url": "https://www.gov.uk/foreign-travel-advice",
+      "title": "Foreign travel advice",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+        "title": "Travel abroad",
+        "parent": {
+          "web_url": "https://www.gov.uk/browse/abroad",
+          "title": "Passports, travel and living abroad",
+          "parent": null
+        }
+      }
+    }
   },
   "locale": "en",
   "need_ids": ["101191"],

--- a/formats/travel_advice/frontend/examples/no-parts.json
+++ b/formats/travel_advice/frontend/examples/no-parts.json
@@ -72,7 +72,20 @@
         "web_url": "https://www.gov.uk/foreign-travel-advice/antarctica",
         "locale": "en"
       }
-    ]
+    ],
+    "parent": {
+      "web_url": "https://www.gov.uk/foreign-travel-advice",
+      "title": "Foreign travel advice",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+        "title": "Travel abroad",
+        "parent": {
+          "web_url": "https://www.gov.uk/browse/abroad",
+          "title": "Passports, travel and living abroad",
+          "parent": null
+        }
+      }
+    }
   },
   "locale": "en",
   "need_ids": ["101191"],

--- a/formats/travel_advice/publisher/links.json
+++ b/formats/travel_advice/publisher/links.json
@@ -3,8 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-     "related": {
-       "$ref": "#/definitions/guid_list"
-     }
+    "related": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "parent": {
+      "$ref": "#/definitions/parent"
+    }
   }
 }

--- a/formats/travel_advice/publisher_v2/examples/travel_advice_links.json
+++ b/formats/travel_advice/publisher_v2/examples/travel_advice_links.json
@@ -10,7 +10,20 @@
     "related": [
       "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
       "e4d06cb9-9e2e-4e82-b802-0aad013ae16c"
-    ]
+    ],
+    "parent": {
+      "web_url": "https://www.gov.uk/foreign-travel-advice",
+      "title": "Foreign travel advice",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+        "title": "Travel abroad",
+        "parent": {
+          "web_url": "https://www.gov.uk/browse/abroad",
+          "title": "Passports, travel and living abroad",
+          "parent": null
+        }
+      }
+    }
   },
   "previous_version": "2"
 }

--- a/formats/travel_advice_index/frontend/examples/index.json
+++ b/formats/travel_advice_index/frontend/examples/index.json
@@ -113,7 +113,16 @@
         "web_url": "https://www.gov.uk/foreign-travel-advice",
         "locale": "en"
       }
-    ]
+    ],
+    "parent": {
+      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+      "title": "Travel abroad",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad",
+        "title": "Passports, travel and living abroad",
+        "parent": null
+      }
+    }
   },
   "locale": "en",
   "need_ids": ["101191"],

--- a/formats/travel_advice_index/publisher/links.json
+++ b/formats/travel_advice_index/publisher/links.json
@@ -3,8 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-     "related": {
-       "$ref": "#/definitions/guid_list"
-     }
+    "related": {
+     "$ref": "#/definitions/guid_list"
+    },
+    "parent": {
+      "$ref": "#/definitions/parent"
+    }
   }
 }

--- a/formats/travel_advice_index/publisher_v2/examples/travel_advice_index_links.json
+++ b/formats/travel_advice_index/publisher_v2/examples/travel_advice_index_links.json
@@ -10,7 +10,16 @@
     "related": [
       "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
       "e4d06cb9-9e2e-4e82-b802-0aad013ae16c"
-    ]
+    ],
+    "parent": {
+      "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
+      "title": "Travel abroad",
+      "parent": {
+        "web_url": "https://www.gov.uk/browse/abroad",
+        "title": "Passports, travel and living abroad",
+        "parent": null
+      }
+    }
   },
   "previous_version": "1"
 }


### PR DESCRIPTION
https://trello.com/c/vm54jvVo/477-send-hard-coded-breadcrumbs-to-publishing-api is the underpinning need for this work or something similar to accommodate expanded links.
[This change to the publishing api](https://github.com/alphagov/publishing-api/pull/193) allows for expanded links to pass through to the content store which unblocks rendering breadcrumbs and other dependency related content.


