### PR TITLE
Service Manual content owners

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -64,8 +64,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "body",
-        "content_owner"
+        "body"
       ],
       "properties": {
         "body": {
@@ -119,6 +118,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_owners": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -108,8 +108,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "body",
-        "content_owner"
+        "body"
       ],
       "properties": {
         "body": {
@@ -163,6 +162,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -10,6 +10,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -107,8 +107,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "body",
-        "content_owner"
+        "body"
       ],
       "properties": {
         "body": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -118,6 +118,9 @@
         "linked_items": {
           "$ref": "#/definitions/frontend_links"
         },
+        "content_owners": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -164,6 +164,10 @@
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"
         },
+        "content_owners": {
+          "description": "References pages of organisations responsible for maintaining a topic e.g. in case of Service Manual it's community pages 'Design community', 'Agile delivery community' etc",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -18,6 +18,10 @@
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"
         },
+        "content_owners": {
+          "description": "References pages of organisations responsible for maintaining a topic e.g. in case of Service Manual it's community pages 'Design community', 'Agile delivery community' etc",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/formats/service_manual_guide/frontend/examples/basic_with_related_discussions.json
+++ b/formats/service_manual_guide/frontend/examples/basic_with_related_discussions.json
@@ -17,6 +17,28 @@
       { "title" : "What is it, why it works and how to do it", "href" : "#what-is-it-why-it-works-and-how-to-do-it" }
     ]
   },
+  "links": {
+    "topics": [{
+      "content_id": "f08d0fbb-c14e-4c08-8260-a24c9eacceb4",
+      "title": "Agile delivery",
+      "base_path": "/service-manual/agile-delivery",
+      "description": "Agile delivery topic description",
+      "api_url": "http://content-store.dev.gov.uk/content/service-manual/agile-delivery",
+      "web_url": "http://www.dev.gov.uk/service-manual/agile-delivery",
+      "locale": "en",
+      "analytics_identifier": null
+    }],
+    "content_owners": [{
+      "content_id": "e5f09422-bf55-417c-b520-8a42cb409814",
+      "title": "Agile delivery community",
+      "base_path": "/service-manual/communities/agile-delivery-community",
+      "description": "Agile delivery community takes care of...",
+      "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
+      "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
+      "locale": "en",
+      "analytics_identifier": null
+    }]
+  },
   "base_path" : "/service-manual/agile",
   "description" : "What agile is, why it works and how to do it",
   "title" : "Agile",

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -3,8 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "body",
-    "content_owner"
+    "body"
   ],
   "properties": {
     "body": {

--- a/formats/service_manual_guide/publisher/links.json
+++ b/formats/service_manual_guide/publisher/links.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "content_owners": {
+      "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide_links.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide_links.json
@@ -1,0 +1,6 @@
+{
+  "links": {
+    "content_owners": ["f6eef5ca-be55-41b2-98be-f72b3e649b84"],
+    "topics": ["e8238ae7-39a7-47c4-bc3a-501da0b55afe"]
+  }
+}

--- a/formats/topic/frontend/examples/service_manual_topic.json
+++ b/formats/topic/frontend/examples/service_manual_topic.json
@@ -42,6 +42,18 @@
         "analytics_identifier":null
       }
     ],
+    "content_owners": [
+      {
+        "content_id": "e5f09422-bf55-417c-b520-8a42cb409814",
+        "title": "Agile delivery community",
+        "base_path": "/service-manual/communities/agile-delivery-community",
+        "description": "Agile delivery community takes care of...",
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
+        "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
+        "locale": "en",
+        "analytics_identifier": null
+      }
+    ],
     "available_translations":[
       {
         "content_id":"cd02b82d-c706-435c-a2fc-2dcabd168ef4",

--- a/formats/topic/publisher/links.json
+++ b/formats/topic/publisher/links.json
@@ -10,6 +10,10 @@
     "linked_items": {
       "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
       "$ref": "#/definitions/guid_list"
+    },
+    "content_owners": {
+      "description": "References pages of organisations responsible for maintaining a topic e.g. in case of Service Manual it's community pages 'Design community', 'Agile delivery community' etc",
+      "$ref": "#/definitions/guid_list"
     }
   }
 }


### PR DESCRIPTION
Now that we have community pages to reference, we can replace the "hardcoded" `content_owner` attribute in Service manual guides with a standard content_id type link that will get expanded and will carry an up-to-date value of title and base path in it.

We'll need to re-PUT all existing SM guide drafts to the publishing-api (there are no published items at the moment) and remove content owner field from the details hash in this repo once it's done.

I've made the details content owner an optional field. Once migrated we can make the content_owners field in links mandatory if it makes sense.

Also, the frontend application will need to be updated to prefer the links field and fall back
to the one in details (https://github.com/alphagov/government-frontend/pull/78)

Do the same for the topics: for Service Manual topics we need to render a sidebar linking to the community pages that are responsible for the guides listed in the topic. Add a similar `content_owners` link to topics as well (/cc @rboulton)