### PR TITLE
Validate schemas explicitly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ begin
 rescue LoadError
 end
 
-task build: [:clean, :combine_schemas, :validate_uniqueness_of_frontend_example_base_paths, :validate_examples]
+task build: [:validate_source_schemas, :clean, :combine_schemas, :validate_dist_schemas, :validate_uniqueness_of_frontend_example_base_paths, :validate_examples]
 
 desc "creates the folders and files for adding a new format"
 task :new_format, [:format_name] do |_task, args|

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -19,6 +19,27 @@ def base_path(example_file)
   JSON.parse(File.read(example_file))['base_path']
 end
 
+def validate_schemas(schema_file_list)
+  validation_errors = []
+  schema_file_list.each do |schema|
+    begin
+      JSON::Validator.fully_validate(schema, {}, validate_schema: true)
+    rescue JSON::Schema::ValidationError => e
+      validation_errors << "Schema: #{schema}: #{e.message}"
+    end
+  end
+  abort "The following schemas aren't valid:\n" + validation_errors.join("\n") if validation_errors.any?
+end
+
+task :validate_source_schemas do
+  schemas = Rake::FileList.new("formats/**/*.json")
+  validate_schemas(schemas)
+end
+
+task :validate_dist_schemas do
+  validate_schemas(Rake::FileList.new("dist/formats/**/*.json"))
+end
+
 task :validate_examples do
   examples = Rake::FileList.new("formats/**/examples/*.json")
   failed_examples = examples.reject { |example| valid?(example) }


### PR DESCRIPTION
I made a mistake whilst modifying a schema. It was combined successfully and
all the tests passed. but it was only when I added an example that the schema
was validated and I realised the problem. The error was not descriptive and it took time for me to realise the problem was actually in the schema, not the example. Let's shorten the feedback loop and
make it an explicit step.