### PR TITLE
Make title a required property

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "base_path",
+    "title",
     "format",
     "locale",
     "public_updated_at",

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -3,6 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "title",
     "format",
     "publishing_app",
     "rendering_app",


### PR DESCRIPTION
publishing-api requires it to be present for things which aren't gones or
redirects. Sot let's make it required for things which aren't those things.

We (initially) missed a title from the Topical Event About Page example over here: https://github.com/alphagov/govuk-content-schemas/pull/220