### PR TITLE
Update policy links schema to reflect live behaviour

### DIFF
--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -184,8 +184,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "organisations",
-        "related"
+        "organisations"
       ],
       "properties": {
         "people": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -228,8 +228,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "organisations",
-        "related"
+        "organisations"
       ],
       "properties": {
         "people": {

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -10,8 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "organisations",
-        "related"
+        "organisations"
       ],
       "properties": {
         "people": {

--- a/formats/policy/frontend/examples/minimal_policy_area.json
+++ b/formats/policy/frontend/examples/minimal_policy_area.json
@@ -22,7 +22,6 @@
       "lead_organisations":[],
       "people": [],
       "working_groups": [],
-      "related":[],
       "email_alert_signup":[
         {
           "content_id": "2054b5e5-8d58-456b-8832-66c0d2b72565",

--- a/formats/policy/publisher/links.json
+++ b/formats/policy/publisher/links.json
@@ -3,8 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "organisations",
-    "related"
+    "organisations"
   ],
   "properties": {
     "people": {


### PR DESCRIPTION
The related links array is not always returned by content store if there are no links of this type.

See https://github.com/alphagov/finder-frontend/pull/244

On that PR, @tommyp suggested adding an example to the schemas so we can have a regression test for this bug.

This is not actually possible without changing the schema itself, but I think it makes sense to have this reflect reality. Also, rather than add a new one I thought it would be easier to change the "minimal" example.

Once merged I'll need to raise another PR against finder frontend to extend the specs for this example.