### PR TITLE
Add sections to Manual links

### DIFF
--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -167,6 +167,15 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "sections": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -174,9 +183,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
         "lead_organisations": {
@@ -189,9 +195,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -211,6 +211,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "sections": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -221,10 +231,6 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -10,6 +10,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "sections": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -20,10 +30,6 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/formats/manual/publisher/links.json
+++ b/formats/manual/publisher/links.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "organisations": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "sections": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "available_translations": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}


### PR DESCRIPTION
In order to port Manuals to V2, sections need to be supplied as part of
the `links` hash. This commit updates the schema to allow that to
happen.