### PR TITLE
Bump dummy content store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 gem 'json-schema'
 gem 'rake'
 gem 'rspec'
-gem 'govuk-dummy_content_store', '0.0.3'
+gem 'govuk-dummy_content_store', '0.0.4'
 gem 'foreman', '0.78.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     foreman (0.78.0)
       thor (~> 0.19.1)
     git-version-bump (0.15.1)
-    govuk-dummy_content_store (0.0.3)
+    govuk-dummy_content_store (0.0.4)
       rack
       rack-contrib
     json-schema (2.5.0)
@@ -35,7 +35,10 @@ PLATFORMS
 
 DEPENDENCIES
   foreman (= 0.78.0)
-  govuk-dummy_content_store (= 0.0.3)
+  govuk-dummy_content_store (= 0.0.4)
   json-schema
   rake
   rspec
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Bump to version 0.0.4, so that dummy content store only shows front-end examples.
https://github.com/alphagov/govuk-dummy_content_store/pull/4