### PR TITLE
Add Manuals to Manual Section links

### DIFF
--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -114,6 +114,15 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "manual": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -121,9 +130,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
         "lead_organisations": {
@@ -136,9 +142,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -158,6 +158,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "manual": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -168,10 +178,6 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -10,6 +10,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "manual": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -20,10 +30,6 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/formats/manual_section/publisher/links.json
+++ b/formats/manual_section/publisher/links.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "organisations": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "manual": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "available_translations": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}


### PR DESCRIPTION
In order to port Manual Sections to V2, the relationship to the `manual`
needs to be added to the schema. This commit adds it to the `links`
hash.