### PR TITLE
Add publisher v2 examples for email-campaign

### DIFF
--- a/formats/financial_release/publisher_v2/examples/financial_release.json
+++ b/formats/financial_release/publisher_v2/examples/financial_release.json
@@ -1,0 +1,26 @@
+{
+  "base_path": "/lloyds-share-offer",
+  "title": "Financial Release",
+  "description": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,quis nostrud exercitation",
+  "format": "financial_release",
+  "locale": "en",
+  "public_updated_at": "2015-12-01T00:00:00.000Z",
+  "publishing_app": "share-sale-publisher",
+  "rendering_app": "email-campaign-frontend",
+  "phase": "live",
+  "details": {
+    "header_legal_disclaimer": "<p>Dummy content for header legal disclaimer<p>",
+    "first_published_at": "2015-10-05",
+    "body": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p><p> Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p><p>Excepteur sint occaecat cupidatat nonproident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p><p>This can be found at <a href='/lloydsshares'>lloydsshares</a>.</p>",
+    "footer_legal_disclaimer": "<p>Dummy content for footer legal disclaimer<p>"
+  },
+  "routes": [
+    {
+      "path": "/lloyds-share-offer",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "update_type": "major"
+}
+

--- a/formats/financial_releases_campaign/publisher_v2/examples/financial_releases_campaign.json
+++ b/formats/financial_releases_campaign/publisher_v2/examples/financial_releases_campaign.json
@@ -1,0 +1,30 @@
+{
+  "base_path": "/lloydsshares",
+  "title": "Financial releases campaign page",
+  "description": "Campaign page for financial press releases",
+  "locale": "en",
+  "public_updated_at": "2015-12-07T11:22:21.000Z",
+  "format": "financial_releases_campaign",
+  "publishing_app": "share-sale-publisher",
+  "rendering_app": "email-campaign-frontend",
+  "phase": "live",
+  "details": {
+    "image": {
+      "alt_text": "HM Government",
+      "url": "campaign.large.jpg"
+    },
+    "header_legal_disclaimer": "Header legal disclaimer Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad  be available from <a href='/lloydsshares'>www.gov.uk/lloydsshares</a>.",
+    "body": "<p>Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensibus theophrastus consectetuer.</p><p>Sumo solum quaestio has cu. Eu oblique euismod deleniti eum, congue necessitatibus ne sit.</p><p>No eum mutat soleat definiebas, ut argumentum efficiantur delicatissimi ius. At feugait adversarium vel. At cum mutat numquam graecis. Sit appareat adolescens constituto eu, te eleifend postulant theophrastus eam</p><div class='video-container'> <iframe src='https://player.vimeo.com/video/145640349?title=0%26byline=0%26portrait=0' width='500' height='281' frameborder='0' webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe> </div><details><summary><span class='summary'>Transcript for video</span></summary><div class='panel panel-border-narrow'><p>Transcript text it eu solum Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensi Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensi Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensi Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensi Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensi Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensi Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensi mediocrem, est te pertinax suavitate temporibus, et est incorrupte comprehensam.</p></div></details> <p> <small>This video is not a recommendation. Nulla regione quaeque ei pro.</small> </p><p>Nulla regione quaeque ei pro, pro vulputate temporibus efficiantur id. Sit eu solum mediocrem, est te pertinax suavitate temporibus, et est incorrupte comprehensam.</p><p>Ne patrioque democritum mea, per natum doctus eu. Vel eu doming iudicabit. Al probo erant euripidis nec, blandit singulis euripidis an vel.</p><p>If you would like to receive email updates for daily ice cream flavours, send us a hand written note.</p><p>Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. If you like yoga <a id='lloyds-factsheet' href='/lloydsfactsheet' target='_blank'>click here</a></p>",
+    "legend": "Register your interest in this share offer",
+    "email_caption": "email caption. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad yed at that point.",
+    "footer_legal_disclaimer": "<p><small>Legal disclaimer: Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad </small></p>"
+  },
+  "routes": [
+    {
+      "path": "/lloydsshares",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "update_type": "major"
+}

--- a/formats/financial_releases_geoblocker/publisher_v2/examples/financial_releases_campaign_geoblocker.json
+++ b/formats/financial_releases_geoblocker/publisher_v2/examples/financial_releases_campaign_geoblocker.json
@@ -1,0 +1,23 @@
+{
+  "base_path": "/lloydsshares/location",
+  "title": "Financial Releases geoblocker",
+  "description": "The government will be making shares in Lloyds Banking Group available for sale to the general public.",
+  "format": "financial_releases_geoblocker",
+  "locale": "en",
+  "public_updated_at": "2015-12-01T00:00:00.000Z",
+  "publishing_app": "share-sale-publisher",
+  "rendering_app": "email-campaign-frontend",
+  "phase": "live",
+  "details": {
+    "body": "<h2 class='heading-medium'>Choose your country of residence</h2><p>The information in this advertisement is intended to be available only to persons located in the United Kingdom.</p><p>Select the country where you are located from the drop-down menu below. By clicking on the ‘Submit’ button you confirm that: (1) you are a person located only in the country you have selected from the drop-down menu and (2) you are not located in the United States of America.</p>",
+    "footer_legal_disclaimer": "This notice and its content are not and should not be deemed to be an offer or invitation to engage in any investment activity. The securities have not been and will not be registered under the U.S. Securities Act of 1933 and may not be offered or sold in the U.S. absent registration or an exemption therefrom."
+  },
+  "routes": [
+    {
+      "path": "/lloydsshares/location",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "update_type": "major"
+}

--- a/formats/financial_releases_index/publisher_v2/examples/financial_releases_index.json
+++ b/formats/financial_releases_index/publisher_v2/examples/financial_releases_index.json
@@ -1,0 +1,25 @@
+{
+  "base_path": "/lloyds-share-offer-press-releases",
+  "title": "Financial releases index",
+  "description": "Index page for listing financial press releases",
+  "locale": "en",
+  "public_updated_at": "2015-12-02T17:11:23+01:00",
+  "format": "financial_releases_index",
+  "publishing_app": "share-sale-publisher",
+  "rendering_app": "email-campaign-frontend",
+  "phase": "live",
+  "details": {
+    "image": {
+      "url": "pressrelease.jpg",
+      "alt_text": "lloyds-logo"
+    }
+  },
+  "routes": [
+    {
+      "path": "/lloyds-share-offer-press-releases",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "update_type": "major"
+}

--- a/formats/financial_releases_index/publisher_v2/examples/financial_releases_index_links.json
+++ b/formats/financial_releases_index/publisher_v2/examples/financial_releases_index_links.json
@@ -1,0 +1,9 @@
+{
+  "links": {
+    "press_releases": [
+      "57add221-0376-4f3e-a025-849954df97ac",
+      "b6c5373e-4b5d-4cd2-a0f2-97aa527545cb"
+    ]
+  }
+}
+

--- a/formats/financial_releases_success/publisher_v2/examples/financial_releases_success.json
+++ b/formats/financial_releases_success/publisher_v2/examples/financial_releases_success.json
@@ -1,0 +1,23 @@
+{
+  "base_path": "/lloydsshares/register-interest-success",
+  "locale": "en",
+  "public_updated_at": "2015-12-07T11:22:21.000Z",
+  "title": "dummy title content for success page",
+  "format": "financial_releases_success",
+  "publishing_app": "share-sale-publisher",
+  "rendering_app": "email-campaign-frontend",
+  "phase": "live",
+  "details": {
+    "header_legal_disclaimer": "<p><small>Header legal disclaimer Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad  be available from <a href='/lloydsshares'>www.gov.uk/lloydsshares</a>.</small></p>",
+    "body": "<p>Thank you for registering interest: /p>",
+    "footer_legal_disclaimer": "<p><small>Legal disclaimer: Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad Vel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. Nec quot deserunt dissentiet ut, ad </small></p>"
+  },
+  "routes": [
+    {
+      "path": "/lloydsshares/register-interest-success",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "update_type": "major"
+}


### PR DESCRIPTION
Adds publisher v2 examples for email-campaign formats.
Part of [this story](https://trello.com/c/QOevhBRK/114-114-refactor-content-store-specs)