### PR TITLE
Add fields for topical event placeholders

### DIFF
--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -73,6 +73,16 @@
             "null"
           ]
         },
+        "start_date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+        },
+        "end_date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+        },
         "tags": {
           "type": "object",
           "properties": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -117,6 +117,16 @@
             "null"
           ]
         },
+        "start_date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+        },
+        "end_date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+        },
         "tags": {
           "type": "object",
           "properties": {

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -116,6 +116,16 @@
             "null"
           ]
         },
+        "start_date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+        },
+        "end_date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+        },
         "tags": {
           "type": "object",
           "properties": {

--- a/formats/placeholder/frontend/examples/battle-of-the-somme-centenary-commemorations.json
+++ b/formats/placeholder/frontend/examples/battle-of-the-somme-centenary-commemorations.json
@@ -1,0 +1,14 @@
+{
+  "content_id": "8b19c222-54e3-4e27-b0d7-67f8e2a677c9",
+  "base_path": "/government/topical-events/battle-of-the-somme-centenary-commemorations",
+  "title": "Battle of the Somme Centenary",
+  "description": "",
+  "format": "placeholder_topical_event",
+  "locale": "en",
+  "need_ids": [],
+  "public_updated_at": "2015-07-04T11:32:28.000+01:00",
+  "details": {
+    "start_date": "2015-07-01T00:00:00.000+00:00",
+    "end_date": "2016-01-01T00:00:00.000+00:00"
+  }
+}

--- a/formats/placeholder/frontend/examples/ebola-virus-government-response.json
+++ b/formats/placeholder/frontend/examples/ebola-virus-government-response.json
@@ -1,0 +1,14 @@
+{
+  "content_id": "8b19c222-54e3-4e27-b0d7-67f8e2a677c9",
+  "base_path": "/government/topical-events/ebola-virus-government-response",
+  "title": "Ebola virus: UK government response",
+  "description": "",
+  "format": "placeholder_topical_event",
+  "locale": "en",
+  "need_ids": [],
+  "public_updated_at": "2015-09-14T17:15:48.000+01:00",
+  "details": {
+    "start_date": "2015-03-11T00:00:00.000+00:00",
+    "end_date": "2016-03-11T00:00:00.000+00:00"
+  }
+}

--- a/formats/placeholder/publisher/details.json
+++ b/formats/placeholder/publisher/details.json
@@ -9,6 +9,16 @@
     "change_note": {
       "type": ["string", "null"]
     },
+    "start_date": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+    },
+    "end_date": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+    },
     "tags": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
We can't migrate topical events yet, because they are complex.

Topical event about pages can be migrated, but they need the end_date of the
topical event they are a part of in order to render the page.

The examples provide the topical events for the examples of topical event about
pages.