### PR TITLE
Allow placeholder start/end dates to be null

### DIFF
--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -74,14 +74,28 @@
           ]
         },
         "start_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time",
+              "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "end_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time",
+              "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "tags": {
           "type": "object",

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -118,14 +118,28 @@
           ]
         },
         "start_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time",
+              "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "end_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time",
+              "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "tags": {
           "type": "object",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -117,14 +117,28 @@
           ]
         },
         "start_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time",
+              "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "end_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time",
+              "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "tags": {
           "type": "object",

--- a/formats/placeholder/publisher/details.json
+++ b/formats/placeholder/publisher/details.json
@@ -10,14 +10,28 @@
       "type": ["string", "null"]
     },
     "start_date": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "end_date": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "tags": {
       "type": "object",


### PR DESCRIPTION
It turns out that Topical Events don't have to have dates.