### PR TITLE
Move content_owner to links for service_manual_guide

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -70,6 +70,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_owners": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -175,8 +178,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "body",
-        "content_owner"
+        "body"
       ],
       "properties": {
         "body": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -7,8 +7,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "body",
-        "content_owner"
+        "body"
       ],
       "properties": {
         "body": {
@@ -62,6 +61,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -10,6 +10,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -7,8 +7,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "body",
-        "content_owner"
+        "body"
       ],
       "properties": {
         "body": {

--- a/formats/service_manual_guide/frontend/examples/basic_with_related_discussions.json
+++ b/formats/service_manual_guide/frontend/examples/basic_with_related_discussions.json
@@ -5,10 +5,6 @@
   "locale": "en",
   "details": {
     "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "content_owner": {
-      "title": "Agile community",
-      "href": "http://sm-11.herokuapp.com/communities/design-community/"
-    },
     "related_discussion": {
       "title": "Design community on hackpad",
       "href": "https://designpatterns.hackpad.com/"
@@ -19,6 +15,18 @@
         "href": "#what-is-it-why-it-works-and-how-to-do-it"
       }
     ]
+  },
+  "links": {
+    "content_owners": [{
+      "content_id": "e5f09422-bf55-417c-b520-8a42cb409814",
+      "title": "Agile delivery community",
+      "base_path": "/service-manual/communities/agile-delivery-community",
+      "description": "Agile delivery community takes care of...",
+      "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
+      "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
+      "locale": "en",
+      "analytics_identifier": null
+    }]
   },
   "base_path": "/service-manual/agile",
   "description": "What agile is, why it works and how to do it",

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
@@ -1,0 +1,25 @@
+{
+  "content_id": "fb81a47b-7c8f-4280-b6c7-b6fa25822222",
+  "public_updated_at": "2015-10-09T08:17:10+00:00",
+  "format": "service_manual_guide",
+  "locale": "en",
+  "details": {
+    "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
+    "related_discussion": {
+      "title": "Design community on hackpad",
+      "href": "https://designpatterns.hackpad.com/"
+    },
+    "header_links": [
+      {
+        "title": "What is it, why it works and how to do it",
+        "href": "#what-is-it-why-it-works-and-how-to-do-it"
+      }
+    ]
+  },
+  "base_path": "/service-manual/agile-community",
+  "description": "The agile community",
+  "title": "Agile Community",
+  "updated_at": "2015-10-12T08:54:30+00:00",
+  "schema_name": "service_manual_guide",
+  "document_type": "service_manual_guide"
+}

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -3,8 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "body",
-    "content_owner"
+    "body"
   ],
   "properties": {
     "body": {

--- a/formats/service_manual_guide/publisher/links.json
+++ b/formats/service_manual_guide/publisher/links.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "content_owners": {
+      "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
@@ -6,10 +6,6 @@
   "locale": "en",
   "details" : {
     "body" : "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "content_owner" : {
-      "title" : "Agile community",
-      "href" : "http://sm-11.herokuapp.com/communities/design-community/"
-    },
     "related_discussion" : {
       "title" : "Design community on hackpad",
       "href" : "https://designpatterns.hackpad.com/"

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide_links.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide_links.json
@@ -1,0 +1,5 @@
+{
+  "links": {
+    "content_owners": ["f6eef5ca-be55-41b2-98be-f72b3e649b84"]
+  }
+}


### PR DESCRIPTION
The pages which represent communities who curate guides now exist. Before we had a fixed href and title for the reference from the guide to the relevant community but now we can use content_ids.

We keep the content_owner defintion while they still exist in the content store but they are no longer required. Once all items have been republished we can lose the definition.

This is a reincarnation of https://github.com/alphagov/govuk-content-schemas/pull/219