### PR TITLE
Add countries to the list of valid email_alert_types

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -183,7 +183,8 @@
           "type": "string",
           "enum": [
             "topics",
-            "policies"
+            "policies",
+            "countries"
           ]
         },
         "signup_tags": {
@@ -195,6 +196,9 @@
               "type": "array"
             },
             "topics": {
+              "type": "array"
+            },
+            "countries": {
               "type": "array"
             }
           }

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -15,7 +15,8 @@
           "type": "string",
           "enum": [
             "topics",
-            "policies"
+            "policies",
+            "countries"
           ]
         },
         "signup_tags": {
@@ -27,6 +28,9 @@
               "type": "array"
             },
             "topics": {
+              "type": "array"
+            },
+            "countries": {
               "type": "array"
             }
           }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -15,7 +15,8 @@
           "type": "string",
           "enum": [
             "topics",
-            "policies"
+            "policies",
+            "countries"
           ]
         },
         "signup_tags": {
@@ -27,6 +28,9 @@
               "type": "array"
             },
             "topics": {
+              "type": "array"
+            },
+            "countries": {
               "type": "array"
             }
           }

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -9,7 +9,7 @@
   "properties": {
     "email_alert_type": {
       "type": "string",
-      "enum": ["topics", "policies"]
+      "enum": ["topics", "policies", "countries"]
     },
     "signup_tags": {
       "type": "object",
@@ -17,7 +17,8 @@
       "additionalProperties": false,
       "properties": {
         "policies": { "type": "array" },
-        "topics": { "type": "array" }
+        "topics": { "type": "array" },
+        "countries": { "type": "array" }
       }
     },
     "summary": {


### PR DESCRIPTION
Relates to https://trello.com/c/oqGCU2XP/525-add-email-signup-links-to-travel-advice-on-frontend