### PR TITLE
Add "internal_name" to policy details.

### DIFF
--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -195,6 +195,10 @@
         "facets"
       ],
       "properties": {
+        "internal_name": {
+          "type": "string",
+          "description": "An internal name for admin interfaces. Includes parent."
+        },
         "document_noun": {
           "type": "string"
         },

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -11,6 +11,10 @@
         "facets"
       ],
       "properties": {
+        "internal_name": {
+          "type": "string",
+          "description": "An internal name for admin interfaces. Includes parent."
+        },
         "document_noun": {
           "type": "string"
         },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -11,6 +11,10 @@
         "facets"
       ],
       "properties": {
+        "internal_name": {
+          "type": "string",
+          "description": "An internal name for admin interfaces. Includes parent."
+        },
         "document_noun": {
           "type": "string"
         },

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -7,6 +7,10 @@
     "facets"
   ],
   "properties": {
+    "internal_name": {
+      "type": "string",
+      "description": "An internal name for admin interfaces. Includes parent."
+    },
     "document_noun": {
       "type": "string"
     },


### PR DESCRIPTION
An internal name for admin interfaces. Includes parent.