### PR TITLE
Add an optional subscriber_list_document_type…

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -179,6 +179,10 @@
         "summary"
       ],
       "properties": {
+        "subscriber_list_document_type": {
+          "type": "string",
+          "description": "The document_type to pass through to the email alert api when creating a subscriber list"
+        },
         "email_alert_type": {
           "type": "string",
           "enum": [

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -11,6 +11,10 @@
         "summary"
       ],
       "properties": {
+        "subscriber_list_document_type": {
+          "type": "string",
+          "description": "The document_type to pass through to the email alert api when creating a subscriber list"
+        },
         "email_alert_type": {
           "type": "string",
           "enum": [

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -11,6 +11,10 @@
         "summary"
       ],
       "properties": {
+        "subscriber_list_document_type": {
+          "type": "string",
+          "description": "The document_type to pass through to the email alert api when creating a subscriber list"
+        },
         "email_alert_type": {
           "type": "string",
           "enum": [

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -7,6 +7,10 @@
     "summary"
   ],
   "properties": {
+    "subscriber_list_document_type": {
+      "type": "string",
+      "description": "The document_type to pass through to the email alert api when creating a subscriber list"
+    },
     "email_alert_type": {
       "type": "string",
       "enum": ["topics", "policies", "countries"]


### PR DESCRIPTION
See https://trello.com/c/gPjk5P2A/611-add-document-type-only-query-to-email-alert-api