### PR TITLE
[WIP] Remove `update_type`

### DIFF
--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -322,13 +322,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -434,13 +427,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -231,13 +231,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -343,13 +336,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -419,13 +419,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -531,13 +524,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -282,13 +282,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -394,13 +387,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -245,13 +245,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -357,13 +350,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -246,13 +246,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -358,13 +351,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -233,13 +233,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -345,13 +338,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -230,13 +230,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -342,13 +335,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -238,13 +238,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -350,13 +343,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -376,13 +376,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -488,13 +481,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -340,13 +340,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -452,13 +445,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -330,13 +330,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -442,13 +435,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -243,13 +243,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -355,13 +348,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -256,13 +256,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -368,13 +361,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -320,13 +320,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -432,13 +425,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -267,13 +267,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -379,13 +372,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -271,13 +271,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -382,13 +375,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -342,13 +342,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -454,13 +447,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -277,13 +277,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -389,13 +382,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -252,13 +252,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -364,13 +357,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1209,13 +1209,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -1321,13 +1314,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -260,13 +260,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -372,13 +365,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -234,13 +234,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -346,13 +339,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -228,13 +228,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -340,13 +333,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -266,13 +266,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -378,13 +371,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -234,13 +234,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -346,13 +339,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -320,13 +320,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -432,13 +425,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -272,13 +272,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -384,13 +377,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -244,13 +244,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -356,13 +349,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -230,13 +230,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -342,13 +335,6 @@
         },
         "previous_version": {
           "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [

--- a/formats/financial_release/publisher_v2/examples/financial_release.json
+++ b/formats/financial_release/publisher_v2/examples/financial_release.json
@@ -51,7 +51,5 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
+  "redirects": []
 }
-

--- a/formats/financial_releases_campaign/publisher_v2/examples/financial_releases_campaign.json
+++ b/formats/financial_releases_campaign/publisher_v2/examples/financial_releases_campaign.json
@@ -70,6 +70,5 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
+  "redirects": []
 }

--- a/formats/financial_releases_geoblocker/publisher_v2/examples/financial_releases_campaign_geoblocker.json
+++ b/formats/financial_releases_geoblocker/publisher_v2/examples/financial_releases_campaign_geoblocker.json
@@ -18,7 +18,5 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
+  "redirects": []
 }
-

--- a/formats/financial_releases_index/publisher_v2/examples/financial_releases_index.json
+++ b/formats/financial_releases_index/publisher_v2/examples/financial_releases_index.json
@@ -20,6 +20,5 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
+  "redirects": []
 }

--- a/formats/financial_releases_success/publisher_v2/examples/financial_releases_success.json
+++ b/formats/financial_releases_success/publisher_v2/examples/financial_releases_success.json
@@ -18,6 +18,5 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
+  "redirects": []
 }

--- a/formats/service_manual_topic/publisher_v2/examples/service_manual_topic.json
+++ b/formats/service_manual_topic/publisher_v2/examples/service_manual_topic.json
@@ -3,7 +3,6 @@
   "rendering_app":"government-frontend",
   "format":"service_manual_topic",
   "locale":"en",
-  "update_type":"minor",
   "base_path":"/service-manual/technology",
   "public_updated_at":"2016-02-11T15:42:55Z",
   "title":"Technology",

--- a/formats/v2_metadata.json
+++ b/formats/v2_metadata.json
@@ -11,9 +11,6 @@
     },
     "previous_version": {
       "type": "string"
-    },
-    "update_type": {
-      "enum": [ "major", "minor", "republish" ]
     }
   }
 }


### PR DESCRIPTION
The `update_type` field is sent to the publishing-api on publish, not in the main payload.



