### PR TITLE
Update schemas to use the new subscriber_list details format

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -175,13 +175,43 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "signup_tags",
+        "subscriber_list",
         "summary"
       ],
       "properties": {
-        "subscriber_list_document_type": {
-          "type": "string",
-          "description": "The document_type to pass through to the email alert api when creating a subscriber list"
+        "subscriber_list": {
+          "type": "object",
+          "description": "The attributes used to match subscriber lists in email-alert-api",
+          "minProperties": 1,
+          "properties": {
+            "tags": {
+              "type": "object",
+              "description": "DEPRECATED: The tags used to match subscribers lists",
+              "additionalProperties": false,
+              "properties": {
+                "policies": {
+                  "type": "array"
+                },
+                "topics": {
+                  "type": "array"
+                }
+              }
+            },
+            "links": {
+              "type": "object",
+              "description": "The links used to match subscribers lists",
+              "additionalProperties": false,
+              "properties": {
+                "countries": {
+                  "type": "array"
+                }
+              }
+            },
+            "document_type": {
+              "type": "string",
+              "description": "The document_type used to match subscribers lists"
+            }
+          }
         },
         "email_alert_type": {
           "type": "string",
@@ -190,22 +220,6 @@
             "policies",
             "countries"
           ]
-        },
-        "signup_tags": {
-          "type": "object",
-          "description": "The content item for which this is handling email signups",
-          "additionalProperties": false,
-          "properties": {
-            "policies": {
-              "type": "array"
-            },
-            "topics": {
-              "type": "array"
-            },
-            "countries": {
-              "type": "array"
-            }
-          }
         },
         "summary": {
           "type": "string"

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -7,13 +7,43 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "signup_tags",
+        "subscriber_list",
         "summary"
       ],
       "properties": {
-        "subscriber_list_document_type": {
-          "type": "string",
-          "description": "The document_type to pass through to the email alert api when creating a subscriber list"
+        "subscriber_list": {
+          "type": "object",
+          "description": "The attributes used to match subscriber lists in email-alert-api",
+          "minProperties": 1,
+          "properties": {
+            "tags": {
+              "type": "object",
+              "description": "DEPRECATED: The tags used to match subscribers lists",
+              "additionalProperties": false,
+              "properties": {
+                "policies": {
+                  "type": "array"
+                },
+                "topics": {
+                  "type": "array"
+                }
+              }
+            },
+            "links": {
+              "type": "object",
+              "description": "The links used to match subscribers lists",
+              "additionalProperties": false,
+              "properties": {
+                "countries": {
+                  "type": "array"
+                }
+              }
+            },
+            "document_type": {
+              "type": "string",
+              "description": "The document_type used to match subscribers lists"
+            }
+          }
         },
         "email_alert_type": {
           "type": "string",
@@ -22,22 +52,6 @@
             "policies",
             "countries"
           ]
-        },
-        "signup_tags": {
-          "type": "object",
-          "description": "The content item for which this is handling email signups",
-          "additionalProperties": false,
-          "properties": {
-            "policies": {
-              "type": "array"
-            },
-            "topics": {
-              "type": "array"
-            },
-            "countries": {
-              "type": "array"
-            }
-          }
         },
         "summary": {
           "type": "string"

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -7,13 +7,43 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "signup_tags",
+        "subscriber_list",
         "summary"
       ],
       "properties": {
-        "subscriber_list_document_type": {
-          "type": "string",
-          "description": "The document_type to pass through to the email alert api when creating a subscriber list"
+        "subscriber_list": {
+          "type": "object",
+          "description": "The attributes used to match subscriber lists in email-alert-api",
+          "minProperties": 1,
+          "properties": {
+            "tags": {
+              "type": "object",
+              "description": "DEPRECATED: The tags used to match subscribers lists",
+              "additionalProperties": false,
+              "properties": {
+                "policies": {
+                  "type": "array"
+                },
+                "topics": {
+                  "type": "array"
+                }
+              }
+            },
+            "links": {
+              "type": "object",
+              "description": "The links used to match subscribers lists",
+              "additionalProperties": false,
+              "properties": {
+                "countries": {
+                  "type": "array"
+                }
+              }
+            },
+            "document_type": {
+              "type": "string",
+              "description": "The document_type used to match subscribers lists"
+            }
+          }
         },
         "email_alert_type": {
           "type": "string",
@@ -22,22 +52,6 @@
             "policies",
             "countries"
           ]
-        },
-        "signup_tags": {
-          "type": "object",
-          "description": "The content item for which this is handling email signups",
-          "additionalProperties": false,
-          "properties": {
-            "policies": {
-              "type": "array"
-            },
-            "topics": {
-              "type": "array"
-            },
-            "countries": {
-              "type": "array"
-            }
-          }
         },
         "summary": {
           "type": "string"

--- a/formats/email_alert_signup/frontend/examples/policy_email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/policy_email_alert_signup.json
@@ -10,10 +10,12 @@
   "public_updated_at": "2015-04-14T10:56:00.000+00:00",
   "details": {
     "email_alert_type": "policies",
-    "signup_tags": {
-      "policies": [
-        "employment"
-      ]
+    "subscriber_list": {
+      "tags": {
+        "policies": [
+          "employment"
+        ]
+      }
     },
     "breadcrumbs": [
       {

--- a/formats/email_alert_signup/frontend/examples/travel_advice_country_email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/travel_advice_country_email_alert_signup.json
@@ -1,0 +1,34 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/foreign-travel-advice/afghanistan/email-signup",
+  "content_id": "46a855db-51ff-4bf2-b31b-a61bceb9ab43",
+  "description": "Afghanistan travel advice Email Alert Signup",
+  "details": {
+    "breadcrumbs": [
+      {
+        "link": "/foreign-travel-advice/afghanistan",
+        "title": "Afghanistan travel advice"
+      }
+    ],
+    "govdelivery_title": "Afghanistan travel advice",
+    "subscriber_list": {
+      "document_type": "travel_advice",
+      "links": {
+        "countries": [
+          "5a292f20-a9b6-46ea-b35f-584f8b3d7392"
+        ]
+      }
+    },
+    "summary": "You'll get an email each time Afghanistan travel advice is updated."
+  },
+  "format": "email_alert_signup",
+  "links": { },
+  "locale": "en",
+  "need_ids": [],
+  "phase": "live",
+  "public_updated_at": "2016-03-09T10:13:52.000+00:00",
+  "title": "Afghanistan travel advice",
+  "updated_at": "2016-03-09T10:13:52.428Z",
+  "schema_name": "email_alert_signup",
+  "document_type": "email_alert_signup"
+}

--- a/formats/email_alert_signup/frontend/examples/travel_advice_index_email_alert_signup.json
+++ b/formats/email_alert_signup/frontend/examples/travel_advice_index_email_alert_signup.json
@@ -1,0 +1,29 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/foreign-travel-advice/email-signup",
+  "content_id": "1aebfc97-7723-4cb6-82f4-434639efc185",
+  "description": "Foreign travel advice email alert signup",
+  "details": {
+    "breadcrumbs": [
+      {
+        "link": "/foreign-travel-advice",
+        "title": "Foreign travel advice"
+      }
+    ],
+    "govdelivery_title": "Foreign travel advice",
+    "subscriber_list": {
+      "document_type": "travel_advice"
+    },
+    "summary": "You'll get an email each time a country is updated."
+  },
+  "format": "email_alert_signup",
+  "links": {},
+  "locale": "en",
+  "need_ids": [],
+  "phase": "live",
+  "public_updated_at": "2016-03-09T10:13:07.000+00:00",
+  "title": "Foreign travel advice",
+  "updated_at": "2016-03-09T10:13:07.444Z",
+  "schema_name": "email_alert_signup",
+  "document_type": "email_alert_signup"
+}

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -3,27 +3,41 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "signup_tags",
+    "subscriber_list",
     "summary"
   ],
   "properties": {
-    "subscriber_list_document_type": {
-      "type": "string",
-      "description": "The document_type to pass through to the email alert api when creating a subscriber list"
+    "subscriber_list": {
+      "type": "object",
+      "description": "The attributes used to match subscriber lists in email-alert-api",
+      "minProperties": 1,
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "DEPRECATED: The tags used to match subscribers lists",
+          "additionalProperties": false,
+          "properties": {
+            "policies": { "type": "array" },
+            "topics": { "type": "array" }
+          }
+        },
+        "links": {
+          "type": "object",
+          "description": "The links used to match subscribers lists",
+          "additionalProperties": false,
+          "properties": {
+            "countries": { "type": "array" }
+          }
+        },
+        "document_type": {
+          "type": "string",
+          "description": "The document_type used to match subscribers lists"
+        }
+      }
     },
     "email_alert_type": {
       "type": "string",
       "enum": ["topics", "policies", "countries"]
-    },
-    "signup_tags": {
-      "type": "object",
-      "description": "The content item for which this is handling email signups",
-      "additionalProperties": false,
-      "properties": {
-        "policies": { "type": "array" },
-        "topics": { "type": "array" },
-        "countries": { "type": "array" }
-      }
     },
     "summary": {
       "type": "string"

--- a/formats/email_alert_signup/publisher_v2/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/publisher_v2/examples/email_alert_signup.json
@@ -10,10 +10,12 @@
   "rendering_app": "government-frontend",
   "details": {
     "email_alert_type": "policies",
-    "signup_tags": {
-      "policies": [
-        "employment"
-      ]
+    "subscriber_list": {
+      "tags": {
+        "policies": [
+          "employment"
+        ]
+      }
     },
     "breadcrumbs": [
       {


### PR DESCRIPTION
**We will merge the pull requests ourselves in the Publishing Platform team when everyone's happy.**

https://trello.com/c/oqGCU2XP/525-add-email-signup-links-to-travel-advice-on-frontend

We've been migrating travel advice over to use the new email-alert-frontend workflow rather than the old pagewatch workflow.

Whilst doing this work, we noticed that policy publisher passes through subscriber list information as implicit links on the signup content item (which should really be reserved for more general associations with other content items). After talking with @tijmenb and @mobaig in Finding Things we concluded that the details hash is the best place for that information.

Therefore, this work consists of four parts:

1) An update to travel advice publisher to create the new email alert signup forms
https://github.com/alphagov/travel-advice-publisher/pull/123

2) An update to policy publisher to change the structure of the subscriber list data
https://github.com/alphagov/policy-publisher/pull/129

3) An update the email-alert-frontend to support searching by document_type (required for travel index)
https://github.com/alphagov/email-alert-frontend/pull/25

4) An update to the content schemas to reflect the new subscriber list data structure
https://github.com/alphagov/govuk-content-schemas/pull/261

We'd like to merge and deploy all four pull requests at (roughly) the same time. Please could comment as usual and state whether you are happy for the pull requests to be merged.