### PR TITLE
Add withdrawn_notice{explanation, withdrawn_at} to service manual guides and topics

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -196,6 +196,18 @@
             }
           }
         },
+        "withdrawn_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "explanation": {
+              "type": "string"
+            },
+            "withdrawn_at": {
+              "format": "date-time"
+            }
+          }
+        },
         "related_discussion": {
           "type": "object",
           "properties": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -25,6 +25,18 @@
             }
           }
         },
+        "withdrawn_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "explanation": {
+              "type": "string"
+            },
+            "withdrawn_at": {
+              "format": "date-time"
+            }
+          }
+        },
         "related_discussion": {
           "type": "object",
           "properties": {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -25,6 +25,18 @@
             }
           }
         },
+        "withdrawn_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "explanation": {
+              "type": "string"
+            },
+            "withdrawn_at": {
+              "format": "date-time"
+            }
+          }
+        },
         "related_discussion": {
           "type": "object",
           "properties": {

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -205,6 +205,18 @@
               }
             }
           }
+        },
+        "withdrawn_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "explanation": {
+              "type": "string"
+            },
+            "withdrawn_at": {
+              "format": "date-time"
+            }
+          }
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -34,6 +34,18 @@
               }
             }
           }
+        },
+        "withdrawn_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "explanation": {
+              "type": "string"
+            },
+            "withdrawn_at": {
+              "format": "date-time"
+            }
+          }
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -34,6 +34,18 @@
               }
             }
           }
+        },
+        "withdrawn_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "explanation": {
+              "type": "string"
+            },
+            "withdrawn_at": {
+              "format": "date-time"
+            }
+          }
         }
       }
     },

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -21,6 +21,18 @@
         }
       }
     },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
     "related_discussion": {
       "type": "object",
       "properties": {

--- a/formats/service_manual_topic/publisher/details.json
+++ b/formats/service_manual_topic/publisher/details.json
@@ -30,6 +30,18 @@
           }
         }
       }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Withdrawn pages simply have an extra withdraw reason displayed at the
top.