### PR TITLE
Extend asset_link definition to include: title, created_at, updated_a…

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -435,6 +435,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -306,6 +306,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -207,6 +207,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -246,6 +246,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -327,6 +327,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -198,6 +198,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -159,6 +159,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -514,6 +514,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -385,6 +385,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -189,6 +189,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -343,6 +343,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -374,6 +374,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -245,6 +245,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -206,6 +206,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -337,6 +337,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -208,6 +208,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -169,6 +169,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -341,6 +341,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -212,6 +212,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -173,6 +173,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -325,6 +325,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -196,6 +196,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -157,6 +157,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -328,6 +328,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -199,6 +199,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -192,6 +192,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -154,6 +154,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -330,6 +330,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -201,6 +201,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -162,6 +162,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -474,6 +474,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -348,6 +348,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -195,6 +195,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -300,6 +300,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -432,6 +432,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -303,6 +303,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -264,6 +264,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -422,6 +422,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -293,6 +293,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -254,6 +254,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -339,6 +339,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -210,6 +210,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -190,6 +190,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -167,6 +167,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -360,6 +360,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -235,6 +235,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -202,6 +202,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -180,6 +180,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -415,6 +415,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -289,6 +289,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -192,6 +192,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -244,6 +244,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -362,6 +362,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -236,6 +236,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -192,6 +192,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -191,6 +191,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -393,6 +393,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -266,6 +266,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -227,6 +227,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -450,6 +450,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -324,6 +324,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -205,6 +205,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -266,6 +266,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -379,6 +379,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -251,6 +251,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -190,6 +190,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -208,6 +208,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -359,6 +359,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -231,6 +231,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -190,6 +190,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -188,6 +188,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -372,6 +372,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -227,6 +227,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -188,6 +188,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -356,6 +356,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -227,6 +227,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -190,6 +190,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -184,6 +184,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -326,6 +326,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -197,6 +197,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -158,6 +158,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -320,6 +320,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -191,6 +191,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -152,6 +152,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -364,6 +364,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -237,6 +237,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -194,6 +194,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -190,6 +190,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -329,6 +329,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -200,6 +200,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -189,6 +189,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -158,6 +158,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -398,6 +398,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -269,6 +269,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -189,6 +189,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -227,6 +227,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -367,6 +367,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -238,6 +238,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -189,6 +189,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -196,6 +196,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -340,6 +340,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -211,6 +211,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -172,6 +172,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -322,6 +322,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -193,6 +193,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -186,6 +186,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -154,6 +154,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -125,6 +125,15 @@
         },
         "content_type": {
           "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
         }
       }
     }

--- a/formats/specialist_document/frontend/examples/aaib-reports.json
+++ b/formats/specialist_document/frontend/examples/aaib-reports.json
@@ -8,11 +8,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/aaib-report-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "aaib reports image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/aaib-report-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "aaib reports pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/asylum-support-decision.json
+++ b/formats/specialist_document/frontend/examples/asylum-support-decision.json
@@ -36,11 +36,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "asylum report image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/asylum-support-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "asylum report pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ]
   },

--- a/formats/specialist_document/frontend/examples/cma-cases.json
+++ b/formats/specialist_document/frontend/examples/cma-cases.json
@@ -10,11 +10,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/cma-cases-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "cma-cases report image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/cma-cases-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "cma-cases report pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
@@ -10,11 +10,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/countryside-stewardship-grants-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "countryside stewardship image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/countryside-stewardship-grants-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "countryside stewardship pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -10,11 +10,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/drug-device-alerts-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "drug device report image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/drug-device-alerts-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "drug device report pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/drug-safety-update.json
+++ b/formats/specialist_document/frontend/examples/drug-safety-update.json
@@ -7,11 +7,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/drug-safety-update-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "drug safety update img title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/drug-safety-update-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "drug safety update pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
@@ -33,11 +33,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/employment-appeal-tribunal-decision-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "employment appeal tribunal decision image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/employment-appeal-tribunal-decision-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "employment appeal tribunal decision pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ]
   },

--- a/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
@@ -30,11 +30,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/employment-tribunal-decision-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "employment tribunal decision image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/employment-tribunal-decision-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "employment tribunal decision image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ]
   },

--- a/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
+++ b/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
@@ -7,11 +7,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/european-structural-investment-funds-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "employment structural investment funds image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/european-structural-investment-funds-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "employment appeal tribunal decision pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/international-development-funding.json
+++ b/formats/specialist_document/frontend/examples/international-development-funding.json
@@ -7,11 +7,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/international-development-funding-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "international development image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/international-development-funding-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "international development pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/maib-reports.json
+++ b/formats/specialist_document/frontend/examples/maib-reports.json
@@ -7,11 +7,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/maib-reports-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "maib reports image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/maib-reports-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "maib reports pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/raib-reports.json
+++ b/formats/specialist_document/frontend/examples/raib-reports.json
@@ -10,11 +10,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/raib-reports-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "raib-reports image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/raib-reports-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "raib-reports pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "metadata": {

--- a/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
@@ -26,11 +26,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/tax-tribunal-decision-image.jpg",
-        "content_type": "application/jpeg"
+        "content_type": "application/jpeg",
+        "title": "tax tribunal decision image title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/tax-tribunal-decision-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "tax tribunal decision pdf title",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ]
   },

--- a/formats/specialist_document/publisher_v2/examples/specialist_document.json
+++ b/formats/specialist_document/publisher_v2/examples/specialist_document.json
@@ -13,11 +13,17 @@
     "attachments": [
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/example-cma-case-image.jpg",
-        "content_type": "application/jpg"
+        "content_type": "application/jpg",
+        "title": "example cma case image",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
         "url": "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/example-cma-case-pdf.pdf",
-        "content_type": "application/pdf"
+        "content_type": "application/pdf",
+        "title": "example cma case pdf",
+        "created_at": "2015-02-11T13:45:00.000+00:00",
+        "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
     "change_history": [],


### PR DESCRIPTION
- Extend asset_link definition to include: title, created_at, updated_at fields for specialist-publisher. 