### PR TITLE
Add content_id field to asset_link definition

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -429,6 +429,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -300,6 +300,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -201,6 +201,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -240,6 +240,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -321,6 +321,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -192,6 +192,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -153,6 +153,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -508,6 +508,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -379,6 +379,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -183,6 +183,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -337,6 +337,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -368,6 +368,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -239,6 +239,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -200,6 +200,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -331,6 +331,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -202,6 +202,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -163,6 +163,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -335,6 +335,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -206,6 +206,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -167,6 +167,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -319,6 +319,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -190,6 +190,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -151,6 +151,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -322,6 +322,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -193,6 +193,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -186,6 +186,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -148,6 +148,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -324,6 +324,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -195,6 +195,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -156,6 +156,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -468,6 +468,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -342,6 +342,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -189,6 +189,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -294,6 +294,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -426,6 +426,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -297,6 +297,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -258,6 +258,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -416,6 +416,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -287,6 +287,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -248,6 +248,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -333,6 +333,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -204,6 +204,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -184,6 +184,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -161,6 +161,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -354,6 +354,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -229,6 +229,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -196,6 +196,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -174,6 +174,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -409,6 +409,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -283,6 +283,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -186,6 +186,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -238,6 +238,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -356,6 +356,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -230,6 +230,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -186,6 +186,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -185,6 +185,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -387,6 +387,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -260,6 +260,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -221,6 +221,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -444,6 +444,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -318,6 +318,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -199,6 +199,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -260,6 +260,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -373,6 +373,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -245,6 +245,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -184,6 +184,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -202,6 +202,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -353,6 +353,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -225,6 +225,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -184,6 +184,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -182,6 +182,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -366,6 +366,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -221,6 +221,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -182,6 +182,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -350,6 +350,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -221,6 +221,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -184,6 +184,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -178,6 +178,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -320,6 +320,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -191,6 +191,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -152,6 +152,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -314,6 +314,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -185,6 +185,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -146,6 +146,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -358,6 +358,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -231,6 +231,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -188,6 +188,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -184,6 +184,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -323,6 +323,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -194,6 +194,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -183,6 +183,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -152,6 +152,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -392,6 +392,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -263,6 +263,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -183,6 +183,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -221,6 +221,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -361,6 +361,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -232,6 +232,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -183,6 +183,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -190,6 +190,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -334,6 +334,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -205,6 +205,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -166,6 +166,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -316,6 +316,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -187,6 +187,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -180,6 +180,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -148,6 +148,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -119,6 +119,9 @@
         "content_type"
       ],
       "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/formats/specialist_document/publisher_v2/examples/specialist_document.json
+++ b/formats/specialist_document/publisher_v2/examples/specialist_document.json
@@ -12,6 +12,7 @@
     "body": "## Header\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case",
     "attachments": [
       {
+        "content_id": "0aa1aa33-36b9-4677-a643-52b9034a1c32",
         "url": "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/example-cma-case-image.jpg",
         "content_type": "application/jpg",
         "title": "example cma case image",
@@ -19,6 +20,7 @@
         "updated_at": "2015-02-13T13:45:00.000+00:00"
       },
       {
+        "content_id": "130d2b69-e32f-437f-9caa-89a4246fbe39",
         "url": "https://assets.digital.cabinet-office.gov.uk/media/56e7fc15ed915d037a000004/example-cma-case-pdf.pdf",
         "content_type": "application/pdf",
         "title": "example cma case pdf",


### PR DESCRIPTION
- Specialist publisher requires attachments to have a unique identifier - an optional content_id field has been added to the asset_link definition to cater for this; 