### PR TITLE
Update placeholder format logo.crest property.

### DIFF
--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -205,15 +205,16 @@
             "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
           },
           "crest": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "enum": [
               "bis",
-              "custom",
               "eo",
               "hmrc",
               "ho",
               "mod",
-              "no-identity",
               "portcullis",
               "single-identity",
               "so",

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -39,15 +39,16 @@
             "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
           },
           "crest": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "enum": [
               "bis",
-              "custom",
               "eo",
               "hmrc",
               "ho",
               "mod",
-              "no-identity",
               "portcullis",
               "single-identity",
               "so",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -39,15 +39,16 @@
             "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
           },
           "crest": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "enum": [
               "bis",
-              "custom",
               "eo",
               "hmrc",
               "ho",
               "mod",
-              "no-identity",
               "portcullis",
               "single-identity",
               "so",

--- a/formats/html_publication/frontend/examples/published.json
+++ b/formats/html_publication/frontend/examples/published.json
@@ -28,7 +28,7 @@
         "title": "Environment Agency",
         "logo": {
           "formatted_title": "Environment Agency",
-          "crest": "custom"
+          "crest": null
         },
         "base_path": "/government/organisations/environment-agency",
         "api_url": "https://www.gov.uk/api/content/government/organisations/environment-agency",

--- a/formats/placeholder/publisher/details.json
+++ b/formats/placeholder/publisher/details.json
@@ -34,15 +34,13 @@
         "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
       },
       "crest": {
-        "type": "string",
+        "type": ["string", "null"],
         "enum": [
           "bis",
-          "custom",
           "eo",
           "hmrc",
           "ho",
           "mod",
-          "no-identity",
           "portcullis",
           "single-identity",
           "so",


### PR DESCRIPTION
Whitehall is being updated to stop publishing crests with the `custom` and `no-identity` values, and instead will publish `null`.

This change updates the placeholder format to be compatible, and also one of the html_publication examples to conform.

This will fix an issue in `government-frontend`, which is displaying the "Environment Agency" crest incorrectly.

**Depends on this related PR**: https://github.com/alphagov/whitehall/pull/2527

Relevant Trello ticket:
https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large