### PR TITLE
Add optional max_cache_time to travel_advice(_index)…

### DIFF
--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -256,6 +256,10 @@
               }
             }
           }
+        },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
         }
       }
     },

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -85,6 +85,10 @@
               }
             }
           }
+        },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
         }
       }
     },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -85,6 +85,10 @@
               }
             }
           }
+        },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -225,6 +225,10 @@
               }
             }
           }
+        },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -54,6 +54,10 @@
               }
             }
           }
+        },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -54,6 +54,10 @@
               }
             }
           }
+        },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
         }
       }
     },

--- a/formats/travel_advice/frontend/examples/alt-country.json
+++ b/formats/travel_advice/frontend/examples/alt-country.json
@@ -189,7 +189,8 @@
     "document": {
       "url": "https://www.gov.uk/media/55e5d9b2ed915d06a100000e/Turkey.pdf",
       "content_type": "application/pdf"
-    }
+    },
+    "max_cache_time": 10
   },
   "schema_name": "travel_advice",
   "document_type": "travel_advice"

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -63,7 +63,8 @@
         "title": "Contact FCO Travel Advice Team",
         "body": "<p>This email service only offers information and advice for British nationals planning to travel abroad. </p> <p>If you need urgent help because something has happened to a friend or relative abroad, contact the consular assistance team on 020 7008 1500 (24 hours).</p> <p>If you’re abroad and need emergency help, please contact the nearest <a href=\"https://www.gov.uk/government/world/organisations\">British embassy, consulate or high commission</a>.</p> <p>If you have a question about this travel advice, you can email us at <a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;</a></p> <p>Before you send an email, make sure you have read the travel advice for the country you’re travelling to, and the guidance on <a href=\"https://www.gov.uk/how-the-foreign-commonwealth-office-puts-together-travel-advice\">how the FCO puts travel advice together</a>.</p> "
       }
-    ]
+    ],
+    "max_cache_time": 10
   },
   "format": "travel_advice",
   "links": {

--- a/formats/travel_advice/frontend/examples/no-parts.json
+++ b/formats/travel_advice/frontend/examples/no-parts.json
@@ -13,7 +13,8 @@
     "change_description": "Latest update: Info about the cold.",
     "alert_status": [],
     "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
-    "parts": []
+    "parts": [],
+    "max_cache_time": 10
   },
   "format": "travel_advice",
   "links": {

--- a/formats/travel_advice/publisher/details.json
+++ b/formats/travel_advice/publisher/details.json
@@ -74,6 +74,10 @@
           }
         }
       }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds.",
+      "type": "integer"
     }
   }
 }

--- a/formats/travel_advice/publisher_v2/examples/travel_advice.json
+++ b/formats/travel_advice/publisher_v2/examples/travel_advice.json
@@ -143,7 +143,8 @@
           }
         ]
       }
-    ]
+    ],
+    "max_cache_time": 10
   },
   "format": "travel_advice",
   "locale": "en",

--- a/formats/travel_advice_index/frontend/examples/index.json
+++ b/formats/travel_advice_index/frontend/examples/index.json
@@ -69,7 +69,8 @@
           "Gran Canaria"
         ]
       }
-    ]
+    ],
+    "max_cache_time": 10
   },
   "format": "travel_advice_index",
   "links": {

--- a/formats/travel_advice_index/publisher/details.json
+++ b/formats/travel_advice_index/publisher/details.json
@@ -50,6 +50,10 @@
           }
         }
       }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds.",
+      "type": "integer"
     }
   }
 }

--- a/formats/travel_advice_index/publisher_v2/examples/travel_advice_index.json
+++ b/formats/travel_advice_index/publisher_v2/examples/travel_advice_index.json
@@ -54,7 +54,8 @@
         "change_description": "Latest update: Summary – information and advice for Manchester City fans travelling to Seville ",
         "synonyms": [ "Ibiza", "Majorca", "Mallorca", "Lanzarote", "Barcelona", "Benidorm", "Tenerife", "Canary Islands", "Canaries", "Gran Canaria" ]
       }
-    ]
+    ],
+    "max_cache_time": 10
   },
   "format": "travel_advice_index",
   "locale": "en",


### PR DESCRIPTION
We’d like to specify a smaller cache time for
Travel Advice content. This change introduces a
max_cache_time field that can optionally be set.
There will be some subsequent work in Content
Store to respect this field.

We can extend this out to other formats if needed
in the future.