### PR TITLE
Add change history to service manual guide

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -227,24 +227,7 @@
           ]
         },
         "change_history": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "public_timestamp": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "note": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "public_timestamp",
-              "note"
-            ]
-          }
+          "$ref": "#/definitions/change_history"
         },
         "tags": {
           "type": "object",
@@ -448,6 +431,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     }
   }

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -38,24 +38,7 @@
           ]
         },
         "change_history": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "public_timestamp": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "note": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "public_timestamp",
-              "note"
-            ]
-          }
+          "$ref": "#/definitions/change_history"
         },
         "tags": {
           "type": "object",
@@ -319,6 +302,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     }
   },

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -221,6 +221,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -38,24 +38,7 @@
           ]
         },
         "change_history": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "public_timestamp": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "note": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "public_timestamp",
-              "note"
-            ]
-          }
+          "$ref": "#/definitions/change_history"
         },
         "tags": {
           "type": "object",
@@ -259,6 +242,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     }
   },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -341,6 +341,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -212,6 +212,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -173,6 +173,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -528,6 +528,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -399,6 +399,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -203,6 +203,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -357,6 +357,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -402,6 +402,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -273,6 +273,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -234,6 +234,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -351,6 +351,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -222,6 +222,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -183,6 +183,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -355,6 +355,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -226,6 +226,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -187,6 +187,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -339,6 +339,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -210,6 +210,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -171,6 +171,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -342,6 +342,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -213,6 +213,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -206,6 +206,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -168,6 +168,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -344,6 +344,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -215,6 +215,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -176,6 +176,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -488,6 +488,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -362,6 +362,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -209,6 +209,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -314,6 +314,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -446,6 +446,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -317,6 +317,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -278,6 +278,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -436,6 +436,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -307,6 +307,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -268,6 +268,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -353,6 +353,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -224,6 +224,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -204,6 +204,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -181,6 +181,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -374,6 +374,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -249,6 +249,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -216,6 +216,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -194,6 +194,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -429,6 +429,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -303,6 +303,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -206,6 +206,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -258,6 +258,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -376,6 +376,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -250,6 +250,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -206,6 +206,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -205,6 +205,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -407,6 +407,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -280,6 +280,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -241,6 +241,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -464,6 +464,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -338,6 +338,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -219,6 +219,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -280,6 +280,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -237,6 +237,9 @@
               "href"
             ]
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },
@@ -392,6 +395,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     },
     "anchor_href": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -66,6 +66,9 @@
               "href"
             ]
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },
@@ -264,6 +267,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     },
     "anchor_href": {

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -204,6 +204,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -66,6 +66,9 @@
               "href"
             ]
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },
@@ -221,6 +224,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     },
     "anchor_href": {

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -373,6 +373,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -245,6 +245,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -204,6 +204,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -202,6 +202,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -212,24 +212,7 @@
           "$ref": "#/definitions/nested_headers"
         },
         "change_history": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "public_timestamp": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "note": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "public_timestamp",
-              "note"
-            ]
-          }
+          "$ref": "#/definitions/change_history"
         }
       }
     },
@@ -385,6 +368,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     },
     "any_metadata": {

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -28,24 +28,7 @@
           "$ref": "#/definitions/nested_headers"
         },
         "change_history": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "public_timestamp": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "note": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "public_timestamp",
-              "note"
-            ]
-          }
+          "$ref": "#/definitions/change_history"
         }
       }
     },
@@ -240,6 +223,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     },
     "any_metadata": {

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -28,24 +28,7 @@
           "$ref": "#/definitions/nested_headers"
         },
         "change_history": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "public_timestamp": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "note": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "public_timestamp",
-              "note"
-            ]
-          }
+          "$ref": "#/definitions/change_history"
         }
       }
     },
@@ -201,6 +184,26 @@
         "updated_at": {
           "format": "date-time"
         }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
       }
     },
     "any_metadata": {

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -370,6 +370,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -241,6 +241,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -204,6 +204,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -198,6 +198,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -340,6 +340,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -211,6 +211,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -172,6 +172,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -334,6 +334,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -205,6 +205,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -166,6 +166,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -378,6 +378,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -251,6 +251,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -208,6 +208,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -204,6 +204,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -343,6 +343,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -214,6 +214,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -203,6 +203,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -172,6 +172,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -412,6 +412,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -283,6 +283,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -203,6 +203,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -241,6 +241,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -381,6 +381,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -252,6 +252,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -203,6 +203,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -210,6 +210,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -354,6 +354,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -225,6 +225,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -186,6 +186,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -336,6 +336,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -207,6 +207,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -200,6 +200,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -168,6 +168,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   },
   "oneOf": [

--- a/formats/case_study/publisher/details.json
+++ b/formats/case_study/publisher/details.json
@@ -28,24 +28,7 @@
       ]
     },
     "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "note": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
+      "$ref": "#/definitions/change_history"
     },
     "tags": {
       "type": "object",

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -139,6 +139,26 @@
           "format": "date-time"
         }
       }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
     }
   }
 }

--- a/formats/service_manual_guide/frontend/examples/with_change_history.json
+++ b/formats/service_manual_guide/frontend/examples/with_change_history.json
@@ -1,0 +1,47 @@
+{
+  "content_id": "2b81a47b-7c8f-4280-b6c7-b6fa25822222",
+  "public_updated_at": "2015-10-09T08:17:10+00:00",
+  "format": "service_manual_guide",
+  "locale": "en",
+  "details": {
+    "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
+    "related_discussion": {
+      "title": "Design community on hackpad",
+      "href": "https://designpatterns.hackpad.com/"
+    },
+    "header_links": [
+      {
+        "title": "What is it, why it works and how to do it",
+        "href": "#what-is-it-why-it-works-and-how-to-do-it"
+      }
+    ],
+    "change_history": [
+      {
+        "public_timestamp": "2015-10-09T08:17:10+00:00",
+        "note": "This is a change"
+      },
+      {
+        "public_timestamp": "2016-01-09T08:17:10+00:00",
+        "note": "This is another change"
+      }
+    ]
+  },
+  "links": {
+    "content_owners": [{
+      "content_id": "e5f09422-bf55-417c-b520-8a42cb409814",
+      "title": "Agile delivery community",
+      "base_path": "/service-manual/communities/agile-delivery-community",
+      "description": "Agile delivery community takes care of...",
+      "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
+      "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
+      "locale": "en",
+      "analytics_identifier": null
+    }]
+  },
+  "base_path": "/service-manual/with-change-history",
+  "description": "This guide has some change history",
+  "title": "Agile",
+  "updated_at": "2015-10-12T08:54:30+00:00",
+  "schema_name": "service_manual_guide",
+  "document_type": "service_manual_guide"
+}

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -62,6 +62,9 @@
           "href"
         ]
       }
+    },
+    "change_history": {
+      "$ref": "#/definitions/change_history"
     }
   },
   "definitions": {

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -24,26 +24,8 @@
     "headers" : {
       "$ref": "#/definitions/nested_headers"
     },
-
     "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "note": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
+      "$ref": "#/definitions/change_history"
     }
   },
   "definitions": {


### PR DESCRIPTION
https://trello.com/c/qzHbv9S9/181-show-change-notes-and-page-history-at-the-bottom-of-guidance-page

Dependent on:

https://github.com/alphagov/government-frontend/pull/129
https://github.com/alphagov/service-manual-publisher/pull/209
https://github.com/alphagov/govuk-content-schemas/pull/274
Add change history to service manual guide
    
Extract `change_history` into definitions, and use this reference
inside `case_study/publisher/schema.json` and
`special_document/publisher/schema.json`
