### PR TITLE
Add content_owners to service-manual-topic format

### DIFF
--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -73,6 +73,9 @@
         "linked_items": {
           "$ref": "#/definitions/frontend_links"
         },
+        "content_owners": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -57,6 +57,10 @@
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"
         },
+        "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -14,6 +14,10 @@
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"
         },
+        "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/formats/service_manual_topic/frontend/examples/service_manual_topic.json
+++ b/formats/service_manual_topic/frontend/examples/service_manual_topic.json
@@ -10,6 +10,28 @@
   "phase": "alpha",
   "analytics_identifier": null,
   "links": {
+    "content_owners": [
+      {
+        "content_id": "fb87cca9-311e-4fd3-af42-03616164a407",
+        "title": "Agile delivery community",
+        "base_path": "/service-manual/communities/agile-delivery-community",
+        "description": "Agile delivery community takes care of...",
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
+        "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
+        "locale": "en",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "d6f49e7f-4f54-44e6-815b-ac3098a5f509",
+        "title": "User research community",
+        "base_path": "/service-manual/communities/user-research-community",
+        "description": "User research community takes care of...",
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/user-research-community",
+        "web_url": "http://www.dev.gov.uk/service-manual/communities/user-research-community",
+        "locale": "en",
+        "analytics_identifier": null
+      }
+    ],
     "linked_items": [
       {
         "content_id": "60b91f03-9dfe-4cb1-a01b-d0391b261cd8",

--- a/formats/service_manual_topic/publisher/links.json
+++ b/formats/service_manual_topic/publisher/links.json
@@ -6,6 +6,10 @@
     "linked_items": {
       "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
       "$ref": "#/definitions/guid_list"
+    },
+    "content_owners": {
+      "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+      "$ref": "#/definitions/guid_list"
     }
   }
 }

--- a/formats/service_manual_topic/publisher_v2/examples/service_manual_topic_links.json
+++ b/formats/service_manual_topic/publisher_v2/examples/service_manual_topic_links.json
@@ -3,6 +3,10 @@
     "linked_items": [
       "f84918f1-de82-4a8e-a4c5-d65872307a4f",
       "1e8c2361-ad63-4513-b7c0-9888c0880092"
+    ],
+    "content_owners": [
+      "fb87cca9-311e-4fd3-af42-03616164a407",
+      "d6f49e7f-4f54-44e6-815b-ac3098a5f509"
     ]
   }
 }


### PR DESCRIPTION
The goal is to list the communities related to the guides included in a topic in the sidebar of a service manual topic page. We are calling them content_owners because that is the pattern set out by service-manual-guide.

https://trello.com/c/rZlsL4Am/152-add-communities-sidebar-to-the-topic-pages