### PR TITLE
Add `detailed_guide` definition and example.

### DIFF
--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -1,0 +1,441 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "title",
+    "locale",
+    "public_updated_at",
+    "content_id",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "format": {
+      "type": "string",
+      "enum": [
+        "detailed_guide"
+      ]
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lead_organisations"
+      ],
+      "properties": {
+        "related_guides": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "alternative_format_provider_organisation": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "related_mainstream": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "alpha_taxons": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "detailed_guide"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "links": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "parent": {
+                "$ref": "#/definitions/guid_list"
+              }
+            }
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body",
+        "first_public_at"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "related_mainstream_content": {
+          "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "excluded_nations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "england",
+              "scotland",
+              "wales",
+              "northern_ireland"
+            ]
+          }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "alternative_scotland_url": {
+          "type": "string"
+        },
+        "alternative_wales_url": {
+          "type": "string"
+        },
+        "alternative_nothern_ireland_url": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    }
+  }
+}

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -1,0 +1,544 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body",
+        "first_public_at"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "related_mainstream_content": {
+          "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "excluded_nations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "england",
+              "scotland",
+              "wales",
+              "northern_ireland"
+            ]
+          }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "alternative_scotland_url": {
+          "type": "string"
+        },
+        "alternative_wales_url": {
+          "type": "string"
+        },
+        "alternative_nothern_ireland_url": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lead_organisations"
+      ],
+      "properties": {
+        "related_guides": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "alternative_format_provider_organisation": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "related_mainstream": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "alpha_taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "These are for collecting content related to a particular government policy.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "detailed_guide"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        }
+      },
+      "required": [
+        "format",
+        "title",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "public_updated_at",
+        "content_id",
+        "update_type"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "schema_name": {
+          "type": "string",
+          "enum": [
+            "detailed_guide"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        }
+      },
+      "required": [
+        "document_type",
+        "schema_name",
+        "title",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "public_updated_at",
+        "content_id",
+        "update_type"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -1,0 +1,242 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "previous_version": {
+      "type": "string"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lead_organisations"
+      ],
+      "properties": {
+        "related_guides": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "alternative_format_provider_organisation": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "related_mainstream": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "alpha_taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "These are for collecting content related to a particular government policy.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    }
+  }
+}

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -1,0 +1,485 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body",
+        "first_public_at"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "related_mainstream_content": {
+          "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "excluded_nations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "england",
+              "scotland",
+              "wales",
+              "northern_ireland"
+            ]
+          }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "alternative_scotland_url": {
+          "type": "string"
+        },
+        "alternative_wales_url": {
+          "type": "string"
+        },
+        "alternative_nothern_ireland_url": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "detailed_guide"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "previous_version": {
+          "type": "string"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        }
+      },
+      "required": [
+        "format",
+        "title",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "public_updated_at",
+        "base_path"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "schema_name": {
+          "type": "string",
+          "enum": [
+            "detailed_guide"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "previous_version": {
+          "type": "string"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        }
+      },
+      "required": [
+        "document_type",
+        "schema_name",
+        "title",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "public_updated_at",
+        "base_path"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/formats/detailed_guide/frontend/examples/detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/detailed_guide.json
@@ -1,0 +1,96 @@
+{
+  "content_id": "c9e77115-22aa-45a2-8c0d-827d92462758",
+  "base_path": "/guidance/salary-sacrifice-and-the-effects-on-paye",
+  "description": "Find out how salary sacrifice arrangements work and how they might affect an employee's current and future income.",
+  "public_updated_at": "2016-02-18T15:45:44.000+00:00",
+  "title": "Salary sacrifice",
+  "updated_at": "2016-02-18T10:37:00Z",
+  "schema_name": "detailed_guide",
+  "document_type": "detailed_guide",
+  "format": "detailed_guide",
+  "locale": "en",
+  "details": {
+    "body": "<div class=\"govspeak\">\n<h2 id=\"the-basics\">The basics</h2>\n\n<p>A salary sacrifice arrangement is an agreement between an employer and an employee to change the terms of the employment contract to reduce the employee’s entitlement to cash pay. This sacrifice of cash entitlement is usually made in return for some form of non-cash benefit.</p>\n\n<p>Salary sacrifice can be financially beneficial for both employer and employee. For example, when part of an employee’s remuneration shifts from cash - on which tax and National Insurance contributions (<abbr title=\"National Insurance contributions\">NICs</abbr>) are due - to non-cash benefits that are wholly or partially exempt.</p>\n\n<p>A salary sacrifice arrangement can’t reduce an employee’s cash earnings below the \n<a rel=\"external\" href=\"https://www.gov.uk/national-minimum-wage-rates\">National Minimum Wage rates</a>.</p>\n\n<h2 id=\"changing-the-terms-of-a-salary-sacrifice-arrangement\">Changing the terms of a salary sacrifice arrangement</h2>\n\n<p>If an employee wants to opt in or out of a salary sacrifice arrangement, employers must alter their contract with each change. The employee’s contract must be clear on what their cash and non-cash entitlements are at any given time.</p>\n\n<p>It may be necessary to change the terms of a salary sacrifice arrangement where a ‘lifestyle change’ significantly alters an employee’s financial circumstances. Examples include marriage, divorce, or an employee’s spouse or partner becoming redundant or pregnant. Salary sacrifice arrangements can allow opting in or out in the event of lifestyle changes like these.</p>\n\n<p>If an employee can swap between cash earnings and a non-cash benefit whenever they like, it’s not a salary sacrifice. In these circumstances, any expected tax and <abbr title=\"National Insurance contributions\">NICs</abbr> advantages under a salary sacrifice arrangement won’t apply.</p>\n\n<h2 id=\"tax-and-nics\">Tax and <abbr title=\"National Insurance contributions\">NICs</abbr>\n</h2>\n\n<p>The impact on tax and <abbr title=\"National Insurance contributions\">NICs</abbr> payable for any employee will depend on the pay and non-cash benefits that make up the salary sacrifice arrangement. An employer’s key responsibility is to make sure that they pay and deduct the right amount of tax and <abbr title=\"National Insurance contributions\">NICs</abbr> for the cash and benefits they provide.</p>\n\n<p>For the cash component, that means operating the PAYE system correctly through their payroll.</p>\n\n<p>For any non-cash benefits, it means checking the tax and <abbr title=\"National Insurance contributions\">NICs</abbr> rules that apply and implementing them correctly.</p>\n\n<h3 id=\"employers-reporting-requirements-for-non-cash-benefits\">Employers’ reporting requirements for non-cash benefits</h3>\n\n<p>Reporting requirements for many non-cash benefits are different to those for cash earnings. In general, benefits must be reported to HM Revenue and Customs (<abbr title=\"HM Revenue and Customs\">HMRC</abbr>) at the end of the tax year using forms <a rel=\"external\" href=\"https://www.gov.uk/government/publications/paye-end-of-year-expenses-and-benefits-p11d\">P11D</a> or <a rel=\"external\" href=\"https://www.gov.uk/government/publications/paye-end-of-year-expenses-and-benefits-p9d\">P9D</a>. </p>\n\n<h3 id=\"tax-and-nics-exemptions-on-non-cash-benefits\">Tax and <abbr title=\"National Insurance contributions\">NICs</abbr> exemptions on non-cash benefits</h3>\n\n<p>Some non-cash benefits qualify for an exemption from tax. Some may be disregarded before calculating <abbr title=\"National Insurance contributions\">NICs</abbr>. If this is the case for a benefit an employer provides to an employee as part of a salary sacrifice arrangement, any conditions that apply to the exemption must be satisfied.</p>\n\n<p>For example, if a benefit has to be made available to all employees in order to be exempt, then this condition must be fully satisfied, whether or not all employees have a salary sacrifice arrangement.</p>\n\n<p>Guidance for employers on particular <a rel=\"external\" href=\"https://www.gov.uk/expenses-and-benefits-a-to-z\">expenses and benefits</a> is available. </p>\n\n<h3 id=\"ask-hmrc-to-confirm-the-tax-and-nics\">Ask <abbr title=\"HM Revenue and Customs\">HMRC</abbr> to confirm the tax and <abbr title=\"National Insurance contributions\">NICs</abbr>\n</h3>\n\n<p>Once a salary sacrifice arrangement is in place, employers can ask the <abbr title=\"HM Revenue and Customs\">HMRC</abbr> Clearances Team to confirm the tax and <abbr title=\"National Insurance contributions\">NICs</abbr> implications. <abbr title=\"HM Revenue and Customs\">HMRC</abbr> won’t comment on a proposed salary sacrifice arrangement before it has been put in place.</p>\n\n<div class=\"address\"><div class=\"adr org fn\"><p>\n\n<abbr title=\"HM Revenue and Customs\">HMRC</abbr> Clearances Team\n<br>Alexander House\n<br>21 Victoria Avenue \n<br>Southend-on-Sea\n<br>Essex\n<br>SS99 1BD\n<br>\n</p></div></div>\n\n<p>Alternatively they can email the <abbr title=\"HM Revenue and Customs\">HMRC</abbr> Clearances Team at <a href=\"mailto:hmrc.southendteam@hmrc.gsi.gov.uk\">hmrc.southendteam@hmrc.gsi.gov.uk</a></p>\n\n<p>To be satisfied that the change has been effective at the right time and not applied retrospectively, <abbr title=\"HM Revenue and Customs\">HMRC</abbr> would need to see:</p>\n\n<ul>\n  <li>evidence of the variation of terms and conditions (if there is a written contract)</li>\n  <li>payslips before and after the variation</li>\n</ul>\n\n<h2 id=\"examples-of-salary-sacrifice\">Examples of salary sacrifice</h2>\n\n<table>\n  <thead>\n    <tr>\n      <th>Salary</th>\n      <th>Salary sacrificed</th>\n      <th>Non cash benefit received</th>\n      <th>Consequence</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>£350 per week</td>\n      <td>£50 of that salary</td>\n      <td>Childcare voucher to the same value</td>\n      <td>Only £300 is subject to tax and <abbr title=\"National Insurance contributions\">NICs</abbr>, childcare vouchers are exempt from both tax and Class 1 <abbr title=\"National Insurance contributions\">NICs</abbr> up to a limit of £55 per week</td>\n    </tr>\n    <tr>\n      <td>£350 per week</td>\n      <td>£100 of that salary</td>\n      <td>Childcare vouchers to the same value</td>\n      <td>£295 is subject to tax and <abbr title=\"National Insurance contributions\">NICs</abbr> - PAYE is operated on the £250 cash component, childcare vouchers are exempt from both tax and Class 1 <abbr title=\"National Insurance contributions\">NICs</abbr> up to a limit of £55 per week, £45 is reported as a non-cash benefit  at the end of the tax year using forms P11D or P9D</td>\n    </tr>\n    <tr>\n      <td>£5,000 bonus</td>\n      <td>£5,000</td>\n      <td>£5,000 employer contribution to registered pension scheme</td>\n      <td>No employment income tax or <abbr title=\"National Insurance contributions\">NICs</abbr> charge to the employee - the full amount is invested in the pension fund</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3 id=\"childcare-vouchers-and-tax-credits\">Childcare vouchers and tax credits</h3>\n\n<p>Childcare vouchers from an employer may affect the amount of tax credits an employee gets. Employees can <a rel=\"external\" href=\"https://www.gov.uk/childcare-vouchers-better-off-calculator\">use a calculator</a> to help them decide if they’re better off taking the vouchers or not.</p>\n\n<h2 id=\"earnings-related-payments\">Earnings related payments</h2>\n\n<p>Employers usually decide how earnings related payments such as occupational pension contributions, overtime rates, pay rises, etc are calculated. Such payments can be based on the notional salary or the new reduced cash salary, but this must be made clear to the employee.</p>\n\n<h2 id=\"earnings-related-benefits\">Earnings related benefits</h2>\n\n<p>Salary sacrifice can affect an employee’s entitlement to earnings related benefits such as <a rel=\"external\" href=\"https://www.gov.uk/maternity-allowance\">Maternity Allowance</a> and <a rel=\"external\" href=\"https://www.gov.uk/additional-state-pension\">Additional State Pension</a>. The amount they receive may be less than the full standard rate or they may lose the entitlement altogether.</p>\n\n<h2 id=\"contribution-based-benefits\">Contribution based benefits</h2>\n\n<p>Salary sacrifice may affect an employee’s entitlement to contribution based benefits such as <a rel=\"external\" href=\"https://www.gov.uk/incapacity-benefit\">Incapacity Benefit</a> and <a rel=\"external\" href=\"https://www.gov.uk/state-pension\">State Pension</a>. Salary sacrifice may reduce the cash earnings on which <abbr title=\"National Insurance contributions\">NICs</abbr> are charged. Employees may therefore pay – or be treated as paying – less or no <abbr title=\"National Insurance contributions\">NICs</abbr>.</p>\n\n<h2 id=\"statutory-payments\">Statutory payments</h2>\n\n<p>Salary sacrifice can affect the amount of <a rel=\"external\" href=\"https://www.gov.uk/government/collections/statutory-pay\">statutory pay</a> an employee receives. It can cause some employees to lose their entitlement altogether. If a salary sacrifice arrangement reduces an employee’s average weekly earnings below the lower earnings limit, then the employer doesn’t have to make any statutory payments to them.</p>\n\n<h2 id=\"workplace-pension-schemes\">Workplace pension schemes</h2>\n\n<p>The employer decides whether salary sacrifice affects contributions into a <a rel=\"external\" href=\"https://www.gov.uk/workplace-pensions-employers\">workplace pension</a> scheme. Often, employers will use a notional level of pay to calculate employer and employee pension contributions, so that employees who participate in salary sacrifice arrangements are not put at a disadvantage. </p>\n\n<p>However, employers should always check with their scheme provider to make sure any such arrangements are allowable.\nOther salary sacrifice arrangements are possible. For example, an employer might agree to pay more than the minimum amount required, to cover some or all of the employee’s contribution. The employee may then become entitled to a lower cash salary. </p>\n\n<h3 id=\"auto-enrolment\">Auto-enrolment</h3>\n\n<p>Where an employee has been automatically enrolled into a workplace pension scheme, it will be a registered pension scheme for tax purposes. No tax is charged on the contributions an employer pays to a registered pension scheme in respect of an employee.</p>\n\n<p>Where an employee <a rel=\"external\" href=\"https://www.gov.uk/workplace-pensions/if-you-want-to-leave-your-workplace-pension-scheme\">opts out</a> of a workplace pension scheme, it is possible that they will have received reduced earnings under the salary sacrifice arrangement. If the employer ‘makes good’ that shortfall to the employee then the payment should be made subject to tax and <abbr title=\"National Insurance contributions\">NICs</abbr>.</p>\n\n<h2 id=\"technical-guidance\">Technical guidance</h2>\n\n<p>The following guides contain more detailed information:</p>\n\n<ul>\n  <li>Employment Income Manual - <a rel=\"external\" href=\"http://www.hmrc.gov.uk/manuals/eimanual/EIM42750.htm\">Salary sacrifice</a>\n</li>\n  <li>Employment Income Manual - <a rel=\"external\" href=\"http://www.hmrc.gov.uk/manuals/eimanual/EIM21600.htm\">Particular benefits</a>\n</li>\n  <li>Employment Income Manual - <a rel=\"external\" href=\"http://www.hmrc.gov.uk/manuals/eimanual/EIM42775.htm\">Salary sacrifice: contributions to a registered pension scheme: income tax effects</a>\n</li>\n  <li>Tax Credits Technical Manual - <a rel=\"external\" href=\"http://www.hmrc.gov.uk/manuals/tctmanual/tctm04104.htm\">Income: Employment Income Rules: Salary sacrifice</a>\n</li>\n</ul>\n\n</div>",
+    "first_public_at": "2014-06-12T10:00:00+01:00",
+    "change_history": [
+      {
+        "public_timestamp": "2016-02-18T10:37:00+00:00",
+        "note": "The second entry in the table Examples of salary sacrifice has been amended to correct the explanation of how much of the salary is subject to tax and National Insurance contributions."
+      },
+      {
+        "public_timestamp": "2015-05-26T18:19:27+01:00",
+        "note": "Information for employees added to guide."
+      },
+      {
+        "public_timestamp": "2014-06-12T10:00:00+01:00",
+        "note": "First published."
+      }
+    ],
+    "tags": {
+      "browse_pages": [],
+      "topics": [],
+      "policies": []
+    }
+  },
+  "links": {
+    "lead_organisations": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue & Customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "api_url": "https://www.gov.uk/api/organisations/hm-revenue-customs",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
+        "locale": "en",
+        "analytics_identifier": "D25"
+      }
+    ],
+    "policy_areas": [
+      {
+        "content_id": "8034be95-4ac2-4fff-93c5-e7514ed9504a",
+        "title": "Tax and revenue",
+        "base_path": "/government/topics/tax-and-revenue",
+        "api_url": "https://www.gov.uk/api/content/government/world/topics/tax-and-revenue",
+        "web_url": "https://www.gov.uk/government/world/topics/tax-and-revenue",
+        "locale": "en"
+      }
+    ],
+    "parent": [
+      {
+        "content_id": "6e1d83bc-d37a-447c-bdac-31be4b441417",
+        "title": "PAYE",
+        "base_path": "/topic/business-tax/paye",
+        "api_url": "https://www.gov.uk/api/content/topic/business-tax/paye",
+        "web_url": "https://www.gov.uk/topic/business-tax/paye",
+        "locale": "en",
+        "parent": [
+          {
+            "content_id": "a481832e-5f10-4d3b-8131-a064b36730ae",
+            "title": "Business tax",
+            "base_path": "/topic/business-tax",
+            "api_url": "https://www.gov.uk/api/content/topic/business-tax",
+            "web_url": "https://www.gov.uk/topic/business-tax",
+            "locale": "en"
+          }
+        ]
+      }
+    ],
+    "topics": [
+      {
+        "content_id": "6e1d83bc-d37a-447c-bdac-31be4b441417",
+        "title": "PAYE",
+        "base_path": "/topic/business-tax/paye",
+        "api_url": "https://www.gov.uk/api/content/topic/business-tax/paye",
+        "web_url": "https://www.gov.uk/topic/business-tax/paye",
+        "locale": "en"
+      },
+      {
+        "content_id": "a481832e-5f10-4d3b-8131-a064b36730ae",
+        "title": "Business tax",
+        "base_path": "/topic/business-tax",
+        "api_url": "https://www.gov.uk/api/content/topic/business-tax",
+        "web_url": "https://www.gov.uk/topic/business-tax",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/detailed_guide/publisher/details.json
+++ b/formats/detailed_guide/publisher/details.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "body",
+    "first_public_at"
+  ],
+  "properties": {
+    "body": {
+      "type": "string"
+    },
+    "related_mainstream_content": {
+      "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "first_public_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "image": {
+      "$ref": "#/definitions/image"
+    },
+    "excluded_nations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["england", "scotland", "wales", "northern_ireland"]
+      }
+    },
+    "change_history": {
+      "$ref": "#/definitions/change_history"
+    },
+    "alternative_scotland_url": {
+      "type": "string"
+    },
+    "alternative_wales_url": {
+      "type": "string"
+    },
+    "alternative_nothern_ireland_url": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/formats/detailed_guide/publisher/links.json
+++ b/formats/detailed_guide/publisher/links.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "lead_organisations"
+  ],
+  "properties": {
+    "related_guides": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "alternative_format_provider_organisation": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "related_mainstream": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}


### PR DESCRIPTION
This defines the detailed guide links and details.

Only one basic example is defined so far. Suggestions (or better yet, `slug`s) are welcome with examples of other guides which feature particular edge cases that we have not covered.

Relevant Trello ticket:
https://trello.com/c/HyUyYqDu/314-6-detailed-guides-migration-content-schema-and-example-large

cc @binaryberry @tijmenb @mgrassotti