### PR TITLE
Add administrative appeals tribunal decisions schema and examples

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -115,6 +115,7 @@
         "medical_safety_alert",
         "raib_report",
         "tax_tribunal_decision",
+        "utaac_decision",
         "vehicle_recalls_and_faults_alert"
       ]
     },
@@ -436,6 +437,9 @@
         },
         {
           "$ref": "#/definitions/tax_tribunal_decision_metadata"
+        },
+        {
+          "$ref": "#/definitions/utaac_decision_metadata"
         },
         {
           "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata"
@@ -1266,6 +1270,64 @@
         },
         "tribunal_decision_category_name": {
           "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "utaac_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "utaac_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_judges_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_decision_date": {
           "type": "string",

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -293,6 +293,9 @@
           "$ref": "#/definitions/tax_tribunal_decision_metadata"
         },
         {
+          "$ref": "#/definitions/utaac_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata"
         }
       ]
@@ -1131,6 +1134,64 @@
         }
       }
     },
+    "utaac_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "utaac_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_judges_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
     "vehicle_recalls_and_faults_alert_metadata": {
       "type": "object",
       "additionalProperties": false,
@@ -1334,6 +1395,7 @@
             "medical_safety_alert",
             "raib_report",
             "tax_tribunal_decision",
+            "utaac_decision",
             "vehicle_recalls_and_faults_alert"
           ]
         },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -254,6 +254,9 @@
           "$ref": "#/definitions/tax_tribunal_decision_metadata"
         },
         {
+          "$ref": "#/definitions/utaac_decision_metadata"
+        },
+        {
           "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata"
         }
       ]
@@ -1082,6 +1085,64 @@
         },
         "tribunal_decision_category_name": {
           "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "utaac_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "utaac_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_judges_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_decision_date": {
           "type": "string",

--- a/formats/finder/frontend/examples/utaac-decisions.json
+++ b/formats/finder/frontend/examples/utaac-decisions.json
@@ -1,0 +1,135 @@
+{
+  "content_id": "e9e7fcff-bb0d-4723-af25-9f78d730f6f8",
+  "base_path": "/administrative-appeals-tribunal-decisions",
+  "title": "Administrative appeals tribunal decisions",
+  "description": "Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.",
+  "format": "finder",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2016-04-06T11:04:06.312Z",
+  "public_updated_at": "2016-04-05T08:20:40.000+00:00",
+  "details": {
+    "document_noun": "decision",
+    "filter": {
+      "document_type": "utaac_decision"
+    },
+    "format_name": "Administrative appeals tribunal decision",
+    "show_summaries": true,
+    "summary": "<p>Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.</p><p>Includes decisions after January 2016. Find details of <a rel=\"external\" href=\"http://www.osscsc.gov.uk/Aspx/default.aspx\">older cases.</a></p>",
+    "facets": [
+      {
+        "key": "tribunal_decision_categories",
+        "name": "Categories",
+        "type": "text",
+        "preposition": "categorised as",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Benefits for children",
+            "value": "benefits-for-children"
+          },
+          {
+            "label": "Bereavement and death benefits",
+            "value": "bereavement-and-death-benefits"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_categories_name",
+        "name": "Categories name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_sub_categories",
+        "name": "Sub-categories",
+        "type": "text",
+        "preposition": "sub-categorised as",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Benefits for children - benefit increases for children",
+            "value": "benefits-for-children-benefit-increases-for-children"
+          },
+          {
+            "label": "Bereavement and death benefits - bereaved parents allowance",
+            "value": "bereavement-and-death-benefits-bereaved-parents-allowance"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_sub_categories_name",
+        "name": "Sub-categories name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_judges",
+        "name": "Judges",
+        "type": "text",
+        "preposition": "by judge",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Angus, R",
+            "value": "angus-r"
+          },
+          {
+            "label": "Bano, A",
+            "value": "bano-a"
+          }
+        ]
+      },
+      {
+        "key": "tribunal_decision_judges_name",
+        "name": "Judges name",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "tribunal_decision_decision_date",
+        "name": "Decision date",
+        "short_name": "Decided",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ]
+  },
+  "phase": "beta",
+  "analytics_identifier": null,
+  "links": {
+    "organisations": [],
+    "related": [],
+    "email_alert_signup": [
+      {
+        "content_id": "13e59efa-6c0d-48e8-a0b9-092b62cdc912",
+        "title": "Administrative appeals tribunal decisions",
+        "base_path": "/administrative-appeals-tribunal-decisions/email-signup",
+        "description": "You'll get an email each time a decision is updated or a new decision is published.",
+        "api_url": "http://content-store.dev.gov.uk/content/administrative-appeals-tribunal-decisions/email-signup",
+        "web_url": "http://www.dev.gov.uk/administrative-appeals-tribunal-decisions/email-signup",
+        "locale": "en"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "e9e7fcff-bb0d-4723-af25-9f78d730f6f8",
+        "title": "Administrative appeals tribunal decisions",
+        "base_path": "/administrative-appeals-tribunal-decisions",
+        "description": "Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.",
+        "api_url": "http://content-store.dev.gov.uk/content/administrative-appeals-tribunal-decisions",
+        "web_url": "http://www.dev.gov.uk/administrative-appeals-tribunal-decisions",
+        "locale": "en"
+      }
+    ]
+  },
+  "schema_name": "finder",
+  "document_type": "finder"
+}

--- a/formats/specialist_document/frontend/examples/utaac-decision.json
+++ b/formats/specialist_document/frontend/examples/utaac-decision.json
@@ -1,0 +1,53 @@
+{
+  "content_id": "3917cb0e-0928-45b7-bf63-20f9bc113a7b",
+  "base_path": "/administrative-appeals-tribunal-decisions/example-utaac-decision",
+  "title": "Example UTAAC Decision",
+  "description": "Example text.",
+  "format": "specialist_document",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2016-04-05T14:41:08.625Z",
+  "public_updated_at": "2016-04-05T14:41:08.000+00:00",
+  "details": {
+    "metadata": {
+      "hidden_indexable_content": "Example text.",
+      "tribunal_decision_categories": [
+        "benefits-for-children",
+        "bereavement-and-death-benefits"
+      ],
+      "tribunal_decision_decision_date": "2015-08-30",
+      "tribunal_decision_judges": [
+        "angus-r"
+      ],
+      "tribunal_decision_sub_categories": [
+        "benefits-for-children-benefit-increases-for-children",
+        "bereavement-and-death-benefits-bereaved-parents-allowance"
+      ],
+      "bulk_published": false,
+      "document_type": "utaac_decision"
+    },
+    "change_history": [
+      {
+        "public_timestamp": "2016-04-05T14:41:08+00:00",
+        "note": "First published."
+      }
+    ],
+    "body": "<p>Example text.</p>\n"
+  },
+  "phase": "beta",
+  "links": {
+    "available_translations": [
+      {
+        "content_id": "3917cb0e-0928-45b7-bf63-20f9bc113a7c",
+        "title": "Example UTAAC Decision",
+        "base_path": "/administrative-appeals-tribunal-decisions/example-utaac-decision",
+        "description": "Example text.",
+        "api_url": "http://content-store.dev.gov.uk/content/administrative-appeals-tribunal-decisions/example-utaac-decision",
+        "web_url": "http://www.dev.gov.uk/administrative-appeals-tribunal-decisions/example-utaac-decision",
+        "locale": "en"
+      }
+    ]
+  },
+  "schema_name": "specialist_document",
+  "document_type": "utaac_decision"
+}

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -45,6 +45,7 @@
         { "$ref": "#/definitions/medical_safety_alert_metadata" },
         { "$ref": "#/definitions/raib_report_metadata" },
         { "$ref": "#/definitions/tax_tribunal_decision_metadata" },
+        { "$ref": "#/definitions/utaac_decision_metadata" },
         { "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata" }
       ]
     },
@@ -870,6 +871,64 @@
         },
         "tribunal_decision_category_name": {
           "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-([012][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "utaac_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "utaac_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_judges_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_decision_date": {
           "type": "string",

--- a/formats/specialist_document/publisher/document_types.json
+++ b/formats/specialist_document/publisher/document_types.json
@@ -27,6 +27,7 @@
         "medical_safety_alert",
         "raib_report",
         "tax_tribunal_decision",
+        "utaac_decision",
         "vehicle_recalls_and_faults_alert"
       ]
     }


### PR DESCRIPTION
The Upper Tribunal Administrative Appeals Chamber (UTAAC) publishes decisions that describe the outcome of a tribunal case.

Tribunal decision finders are used by public, professionals and the tribunals themselves to search for past decisions.

Published decisions form a part of case law and are used for research purposes and to prepare for current or future cases.