### PR TITLE
Write documentation for magic fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,15 @@ examples.
 
 To invoke the default task just invoke `rake` on its own. You can delete all of
 the derived files and force a re-run by using `rake clean build`:
+
+### Magic fields
+
+Not all fields for the frontend examples are defined in the schema, instead they're added by [GovukContentSchemas::FrontendSchemaGenerator](lib/govuk_content_schemas/frontend_schema_generator.rb). For example:
+
+- `base_path`
+- `updated_at`
+
+[GovukContentSchemas::SchemaCombiner](lib/govuk_content_schemas/schema_combiner.rb) also adds a few:
+
+- `schema_name`
+- `document_type`


### PR DESCRIPTION
I was caught off-guard by the fact that the main rake task decorates the schemas defined in `formats/` with additional fields.

I wrote this bit of documentation based on my current understanding. Any suggestions on how to improve it are welcome.