### PR TITLE
Update frontend example for service manual guide

### DIFF
--- a/formats/service_manual_guide/frontend/examples/with_change_history.json
+++ b/formats/service_manual_guide/frontend/examples/with_change_history.json
@@ -17,12 +17,14 @@
     ],
     "change_history": [
       {
-        "public_timestamp": "2015-10-09T08:17:10+00:00",
-        "note": "This is a change"
+        "public_timestamp": "2017-10-09T08:17:10+00:00",
+        "note": "This is a change",
+        "reason_for_change": "This is our latest change"
       },
       {
         "public_timestamp": "2016-01-09T08:17:10+00:00",
-        "note": "This is another change"
+        "note": "This is another change",
+        "reason_for_change": "This is why we made this change\nand it has a second line of text"
       }
     ]
   },


### PR DESCRIPTION
It didn't include the new optional reason_for_change in change history.