### PR TITLE
Specialist documents has Govspeak and html in body

### DIFF
--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -13,7 +13,7 @@
       ],
       "properties": {
         "body": {
-          "type": "string"
+          "$ref": "#/definitions/multiple_content_types"
         },
         "attachments": {
           "type": "array",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -13,7 +13,7 @@
       ],
       "properties": {
         "body": {
-          "type": "string"
+          "$ref": "#/definitions/multiple_content_types"
         },
         "attachments": {
           "type": "array",

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "body": {
-      "type": "string"
+      "$ref": "#/definitions/multiple_content_types"
     },
     "attachments": {
       "type": "array",
@@ -21,7 +21,7 @@
       "$ref": "#/definitions/any_metadata"
     },
 
-    "headers" : {
+    "headers": {
       "$ref": "#/definitions/nested_headers"
     },
     "change_history": {

--- a/formats/specialist_document/publisher_v2/examples/specialist_document.json
+++ b/formats/specialist_document/publisher_v2/examples/specialist_document.json
@@ -9,7 +9,16 @@
   "locale": "en",
   "phase": "live",
   "details": {
-    "body": "## Header\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case",
+    "body": [
+      {
+        "content_type": "text/govspeak",
+        "content": "## Header\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case"
+      },
+      {
+        "content_type": "text/html",
+        "content": "<h2 id=\"header\">Header</h2>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n\n<p>This is the long body of an example CMA case</p>\n"
+      }
+    ],
     "attachments": [
       {
         "content_id": "0aa1aa33-36b9-4677-a643-52b9034a1c32",


### PR DESCRIPTION
In V2 of specialist publisher, we want to save Govspeak content ([PR here](https://github.com/alphagov/specialist-publisher/pull/697)), so we
can use it for editing and previews.