### PR TITLE
Add request_id to travel advice formats

### DIFF
--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -260,6 +260,10 @@
         "max_cache_time": {
           "description": "The maximum length of time the content should be cached, in seconds.",
           "type": "integer"
+        },
+        "publishing_request_id": {
+          "description": "A unique identifier used to track publishing requests to rendered content",
+          "type": "string"
         }
       }
     },

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -89,6 +89,10 @@
         "max_cache_time": {
           "description": "The maximum length of time the content should be cached, in seconds.",
           "type": "integer"
+        },
+        "publishing_request_id": {
+          "description": "A unique identifier used to track publishing requests to rendered content",
+          "type": "string"
         }
       }
     },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -89,6 +89,10 @@
         "max_cache_time": {
           "description": "The maximum length of time the content should be cached, in seconds.",
           "type": "integer"
+        },
+        "publishing_request_id": {
+          "description": "A unique identifier used to track publishing requests to rendered content",
+          "type": "string"
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -229,6 +229,10 @@
         "max_cache_time": {
           "description": "The maximum length of time the content should be cached, in seconds.",
           "type": "integer"
+        },
+        "publishing_request_id": {
+          "description": "A unique identifier used to track publishing requests to rendered content",
+          "type": "string"
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -58,6 +58,10 @@
         "max_cache_time": {
           "description": "The maximum length of time the content should be cached, in seconds.",
           "type": "integer"
+        },
+        "publishing_request_id": {
+          "description": "A unique identifier used to track publishing requests to rendered content",
+          "type": "string"
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -58,6 +58,10 @@
         "max_cache_time": {
           "description": "The maximum length of time the content should be cached, in seconds.",
           "type": "integer"
+        },
+        "publishing_request_id": {
+          "description": "A unique identifier used to track publishing requests to rendered content",
+          "type": "string"
         }
       }
     },

--- a/formats/travel_advice/frontend/examples/alt-country.json
+++ b/formats/travel_advice/frontend/examples/alt-country.json
@@ -190,7 +190,8 @@
       "url": "https://www.gov.uk/media/55e5d9b2ed915d06a100000e/Turkey.pdf",
       "content_type": "application/pdf"
     },
-    "max_cache_time": 10
+    "max_cache_time": 10,
+    "publishing_request_id": "2546-1460985144476-19268198-3242"
   },
   "schema_name": "travel_advice",
   "document_type": "travel_advice"

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -64,7 +64,8 @@
         "body": "<p>This email service only offers information and advice for British nationals planning to travel abroad. </p> <p>If you need urgent help because something has happened to a friend or relative abroad, contact the consular assistance team on 020 7008 1500 (24 hours).</p> <p>If you’re abroad and need emergency help, please contact the nearest <a href=\"https://www.gov.uk/government/world/organisations\">British embassy, consulate or high commission</a>.</p> <p>If you have a question about this travel advice, you can email us at <a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">&#084;&#114;&#097;&#118;&#101;&#108;&#065;&#100;&#118;&#105;&#099;&#101;&#080;&#117;&#098;&#108;&#105;&#099;&#069;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;</a></p> <p>Before you send an email, make sure you have read the travel advice for the country you’re travelling to, and the guidance on <a href=\"https://www.gov.uk/how-the-foreign-commonwealth-office-puts-together-travel-advice\">how the FCO puts travel advice together</a>.</p> "
       }
     ],
-    "max_cache_time": 10
+    "max_cache_time": 10,
+    "publishing_request_id": "2546-1460985144476-19268198-3242"
   },
   "format": "travel_advice",
   "links": {

--- a/formats/travel_advice/frontend/examples/no-parts.json
+++ b/formats/travel_advice/frontend/examples/no-parts.json
@@ -14,7 +14,8 @@
     "alert_status": [],
     "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
     "parts": [],
-    "max_cache_time": 10
+    "max_cache_time": 10,
+    "publishing_request_id": "2546-1460985144476-19268198-3242"
   },
   "format": "travel_advice",
   "links": {

--- a/formats/travel_advice/publisher/details.json
+++ b/formats/travel_advice/publisher/details.json
@@ -78,6 +78,10 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds.",
       "type": "integer"
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
     }
   }
 }

--- a/formats/travel_advice/publisher_v2/examples/travel_advice.json
+++ b/formats/travel_advice/publisher_v2/examples/travel_advice.json
@@ -144,7 +144,8 @@
         ]
       }
     ],
-    "max_cache_time": 10
+    "max_cache_time": 10,
+    "publishing_request_id": "2546-1460985144476-19268198-3242"
   },
   "format": "travel_advice",
   "locale": "en",

--- a/formats/travel_advice_index/frontend/examples/index.json
+++ b/formats/travel_advice_index/frontend/examples/index.json
@@ -70,7 +70,8 @@
         ]
       }
     ],
-    "max_cache_time": 10
+    "max_cache_time": 10,
+    "publishing_request_id": "2546-1460985144476-19268198-3242"
   },
   "format": "travel_advice_index",
   "links": {

--- a/formats/travel_advice_index/publisher/details.json
+++ b/formats/travel_advice_index/publisher/details.json
@@ -54,6 +54,10 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds.",
       "type": "integer"
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
     }
   }
 }

--- a/formats/travel_advice_index/publisher_v2/examples/travel_advice_index.json
+++ b/formats/travel_advice_index/publisher_v2/examples/travel_advice_index.json
@@ -55,7 +55,8 @@
         "synonyms": [ "Ibiza", "Majorca", "Mallorca", "Lanzarote", "Barcelona", "Benidorm", "Tenerife", "Canary Islands", "Canaries", "Gran Canaria" ]
       }
     ],
-    "max_cache_time": 10
+    "max_cache_time": 10,
+    "publishing_request_id": "2546-1460985144476-19268198-3242"
   },
   "format": "travel_advice_index",
   "locale": "en",


### PR DESCRIPTION
https://trello.com/c/Io2JYTFv/27-ensure-request-id-is-available-to-multipage-frontend-and-frontend-apps

In order to trace the `request_id` thoroughly for travel advice content updates we will need to persist it and render it. The [request id will come from the load balancer](https://github.com/alphagov/govuk-puppet/pull/4320/commits/fdfbc827bf6d39e32dc4227c95fd01633b1ed582) and be [added to worker jobs](https://github.com/alphagov/travel-advice-publisher/pull/139/commits/e31ed8a3f56920fe973346547f08698d5cf300af), it will also flow through the publishing pipeline and be present in the page source of rendered content.