### PR TITLE
Add summary to service_manual_guide

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -181,6 +181,10 @@
         "body"
       ],
       "properties": {
+        "summary": {
+          "type": "string",
+          "description": "A single line short summary that does not contain formatting."
+        },
         "body": {
           "type": "string"
         },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -10,6 +10,10 @@
         "body"
       ],
       "properties": {
+        "summary": {
+          "type": "string",
+          "description": "A single line short summary that does not contain formatting."
+        },
         "body": {
           "type": "string"
         },

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -10,6 +10,10 @@
         "body"
       ],
       "properties": {
+        "summary": {
+          "type": "string",
+          "description": "A single line short summary that does not contain formatting."
+        },
         "body": {
           "type": "string"
         },

--- a/formats/service_manual_guide/frontend/examples/point_page.json
+++ b/formats/service_manual_guide/frontend/examples/point_page.json
@@ -1,0 +1,24 @@
+{
+  "content_id": "fb81a47b-7c8f-4280-b6c7-b6fa25822222",
+  "public_updated_at": "2015-10-09T08:17:10+00:00",
+  "format": "service_manual_guide",
+  "locale": "en",
+  "details": {
+    "summary": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
+    "body": "<h2>Why it's in the standard</h2>\n<p>You need to know the people who use your service (your users) and what they want to do (their user needs) if you want to build a service that works for them.</p>\n",
+    "header_links": [
+      {
+        "title": "Why it's in the standard",
+        "href": "#why-its-in-the-standard"
+      }
+    ]
+  },
+  "links": {
+  },
+  "base_path": "/service-standard/point-1",
+  "description": "Understand user needs.",
+  "title": "Point 1",
+  "updated_at": "2015-10-12T08:54:30+00:00",
+  "schema_name": "service_manual_guide",
+  "document_type": "service_manual_guide"
+}

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -6,6 +6,10 @@
     "body"
   ],
   "properties": {
+    "summary": {
+      "type": "string",
+      "description": "A single line short summary that does not contain formatting."
+    },
     "body": {
       "type": "string"
     },

--- a/formats/service_manual_guide/publisher_v2/examples/point_page.json
+++ b/formats/service_manual_guide/publisher_v2/examples/point_page.json
@@ -1,0 +1,23 @@
+{
+  "publishing_app": "service-manual-publisher",
+  "rendering_app": "government-frontend",
+  "public_updated_at" : "2015-10-09T08:17:10+00:00",
+  "format": "service_manual_guide",
+  "locale": "en",
+  "details" : {
+    "summary": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
+    "body": "<h2>Why it's in the standard</h2>\n<p>You need to know the people who use your service (your users) and what they want to do (their user needs) if you want to build a service that works for them.</p>\n",
+    "header_links" : [
+      { "title" : "Why it's in the standard", "href" : "#why-its-in-the-standard" }
+    ]
+  },
+  "base_path" : "/service-standard/point-1",
+  "description" : "Understand user needs.",
+  "title" : "Point 1",
+  "routes": [
+    {
+      "path": "/service-standard/point-1",
+      "type": "exact"
+    }
+  ]
+}


### PR DESCRIPTION
We are extending service_manual_guide to also handle the "points page" in the service manual. A points page represents one of the points in the service standard. The design of the points page requires a lede just after the title. Because these lede / standfirst sections are fairly common across GOV.UK we think it is acceptable to give this to the other two pages that use this format, the guide page and the guide community page.