### PR TITLE
Remove worldwide priorities from schemas

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -88,9 +88,6 @@
         "worldwide_organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "worldwide_priorities": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -104,9 +104,6 @@
         "worldwide_organisations": {
           "$ref": "#/definitions/guid_list"
         },
-        "worldwide_priorities": {
-          "$ref": "#/definitions/guid_list"
-        },
         "document_collections": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -29,9 +29,6 @@
         "worldwide_organisations": {
           "$ref": "#/definitions/guid_list"
         },
-        "worldwide_priorities": {
-          "$ref": "#/definitions/guid_list"
-        },
         "document_collections": {
           "$ref": "#/definitions/guid_list"
         },

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -58,7 +58,6 @@
     "supporting_organisations": [],
     "world_locations": [],
     "worldwide_organisations": [],
-    "worldwide_priorities": [],
     "available_translations": [
       {
         "content_id": "3933c3df-9fdd-4a56-99cd-9a9351cbbf99",

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -55,7 +55,6 @@
         "analytics_identifier": "W4"
       }
     ],
-    "worldwide_priorities": [],
     "available_translations": [
       {
         "content_id": "cc717565-1290-4a22-b8d4-4b25facb3c8f",

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -21,9 +21,6 @@
     "worldwide_organisations": {
       "$ref": "#/definitions/guid_list"
     },
-    "worldwide_priorities": {
-      "$ref": "#/definitions/guid_list"
-    },
     "document_collections": {
       "$ref": "#/definitions/guid_list"
     }

--- a/formats/case_study/publisher_v2/examples/case_study_links.json
+++ b/formats/case_study/publisher_v2/examples/case_study_links.json
@@ -11,7 +11,6 @@
     "worldwide_organisations": [
       "f1ec569a-3471-4de0-947c-a4f3bcccb983"
     ],
-    "worldwide_priorities": [],
     "document_collections": [
       "def40c5f-52d0-4dca-80ea-b0da5caeebcd"
     ]


### PR DESCRIPTION
The format has been removed, and all data deleted.

Government frontend no longer consumes these: 
https://github.com/alphagov/government-frontend/commit/9b35ecefe0e086fc687e311797152bd7be478f7c

Whitehall no longer publishes:
https://github.com/alphagov/whitehall/pull/2246/commits/fb66f4240d1e5f72267cf3a15cb0ef7223b269ea

Part of:
https://trello.com/c/AtYGioxe/321-worldwide-priorities-deleting-the-format-medium

## Question
Do we need these schemas to help us delete the existing data from content-store?