### PR TITLE
Remove updated_at from detailed_guide examples.

### DIFF
--- a/formats/detailed_guide/frontend/examples/detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/detailed_guide.json
@@ -4,7 +4,6 @@
   "description": "Find out how salary sacrifice arrangements work and how they might affect an employee's current and future income.",
   "public_updated_at": "2016-02-18T15:45:44.000+00:00",
   "title": "Salary sacrifice",
-  "updated_at": "2016-02-18T10:37:00Z",
   "schema_name": "detailed_guide",
   "document_type": "detailed_guide",
   "format": "detailed_guide",

--- a/formats/detailed_guide/frontend/examples/political_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/political_detailed_guide.json
@@ -4,7 +4,6 @@
   "description": "Onshore wind is a home-grown energy source that will protect UK consumers from energy price shocks and help meet renewable energy targets.",
   "public_updated_at": "2013-01-22T12:03:00+00:00",
   "title": "Onshore wind: part of the UK's energy mix",
-  "updated_at": "2013-01-22T12:03:00+00:00",
   "schema_name": "detailed_guide",
   "document_type": "detailed_guide",
   "format": "detailed_guide",

--- a/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
@@ -4,7 +4,6 @@
   "description": "Advice for British people living in Fiji, including information on health, education, benefits, residence requirements and more.",
   "public_updated_at": "2014-01-22T07:11:48+00:00",
   "title": "Living in Fiji",
-  "updated_at": "2014-01-22T07:11:48+00:00",
   "schema_name": "detailed_guide",
   "document_type": "detailed_guide",
   "format": "detailed_guide",

--- a/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
@@ -4,7 +4,6 @@
   "description": "Guidance on implementing REACH (Registration, Evaluation, Authorisation and Restriction of Chemicals) in businesses.",
   "public_updated_at": "2016-02-18T15:45:44.000+00:00",
   "title": "EU rules on the use of chemicals",
-  "updated_at": "2015-01-28T13:09:02Z",
   "schema_name": "detailed_guide",
   "document_type": "detailed_guide",
   "format": "detailed_guide",


### PR DESCRIPTION
Whitehall won't publish these, and they're not being used.
`public_updated_at` is used instead in `government-frontend`.