### PR TITLE
Service manual topic expanded by default

### DIFF
--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -181,6 +181,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "visually_collapsed": {
+          "type": "boolean",
+          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic."
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -7,6 +7,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "visually_collapsed": {
+          "type": "boolean",
+          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic."
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -7,6 +7,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "visually_collapsed": {
+          "type": "boolean",
+          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic."
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/formats/service_manual_topic/frontend/examples/service_manual_topic.json
+++ b/formats/service_manual_topic/frontend/examples/service_manual_topic.json
@@ -78,6 +78,7 @@
   },
   "description": "Service Manual Topic description",
   "details": {
+    "visually_collapsed": true,
     "groups": [
       {
         "name": "Group 1",

--- a/formats/service_manual_topic/frontend/examples/service_manual_topic_collapsed.json
+++ b/formats/service_manual_topic/frontend/examples/service_manual_topic_collapsed.json
@@ -1,7 +1,7 @@
 {
-  "base_path": "/service-manual/test-expanded-topic",
+  "base_path": "/service-manual/test-topic",
   "content_id": "cd02b82d-c706-435c-a2fc-2dcabd168ef4",
-  "title": "Service Manual Test Expanded Topic",
+  "title": "Service Manual Test Topic",
   "format": "service_manual_topic",
   "need_ids": [],
   "locale": "en",
@@ -78,6 +78,7 @@
   },
   "description": "Service Manual Topic description",
   "details": {
+    "visually_collapsed": true,
     "groups": [
       {
         "name": "Group 1",

--- a/formats/service_manual_topic/publisher/details.json
+++ b/formats/service_manual_topic/publisher/details.json
@@ -3,6 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "visually_collapsed": {
+      "type": "boolean",
+      "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic."
+    },
     "groups": {
       "type": "array",
       "items": {

--- a/formats/service_manual_topic/publisher_v2/examples/service_manual_topic.json
+++ b/formats/service_manual_topic/publisher_v2/examples/service_manual_topic.json
@@ -16,6 +16,7 @@
     }
   ],
   "details": {
+    "visually_collapsed": true,
     "groups": [
       {
         "name":"Security",


### PR DESCRIPTION
The service_manual_topic has multiple sections which are normally collapsed. Sometimes there aren't enough sections or items within a section to justify collapsing and it appears there aren't a set of rules that can be applied which will let the frontend decide for itself. Instead we are adding this boolean which the publisher will set so a pair of human eyes can decide whether it should be collapsed or expanded.

If the attribute is false or missing then the default behaviour will be that it is expanded.