### PR TITLE
Allow rendering_app & publishing_app in frontend schemas

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -38,6 +38,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -39,6 +39,12 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
     "locale": {
       "type": "string"
     },

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -9,11 +9,14 @@ class GovukContentSchemas::FrontendSchemaGenerator
 
   INTERNAL_PROPERTIES = %w{
     access_limited
-    publishing_app
     redirects
-    rendering_app
     routes
     update_type
+  }.freeze
+
+  OPTIONAL_PROPERTIES = %w{
+    publishing_app
+    rendering_app
   }.freeze
 
   def initialize(publisher_schema, frontend_links_definition)
@@ -42,7 +45,7 @@ private
     if required.empty?
       []
     else
-      ['base_path'] + (required - INTERNAL_PROPERTIES)
+      ['base_path'] + (required - INTERNAL_PROPERTIES - OPTIONAL_PROPERTIES)
     end
   end
 

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   }
 
   let(:internal_properties) {
-    %w{publishing_app redirects rendering_app routes update_type}
+    GovukContentSchemas::FrontendSchemaGenerator::INTERNAL_PROPERTIES
   }
 
   it "does not modify its input" do


### PR DESCRIPTION
The current frontend schemas do not allow `rendering_app` & `publishing_app` to be set.

Since https://github.com/alphagov/content-store/pull/209 we expose those attributes, making the schemas invalid.

To prevent the current examples and API response from being invalid, we make the attributes optional. Once all is deployed we should update the examples and make the attributes required.
