### PR TITLE
Add national_applicability definition and example.

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -490,6 +490,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -355,6 +355,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -282,6 +282,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -298,6 +298,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -411,6 +411,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -276,6 +276,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -237,6 +237,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -598,6 +598,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -463,6 +463,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -267,6 +267,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -421,6 +421,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -216,18 +216,6 @@
         "image": {
           "$ref": "#/definitions/image"
         },
-        "excluded_nations": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "england",
-              "scotland",
-              "wales",
-              "northern_ireland"
-            ]
-          }
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
@@ -272,6 +260,9 @@
         },
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
         }
       }
     },
@@ -490,6 +481,44 @@
         },
         "withdrawn_at": {
           "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
         }
       }
     }

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -30,18 +30,6 @@
         "image": {
           "$ref": "#/definitions/image"
         },
-        "excluded_nations": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "england",
-              "scotland",
-              "wales",
-              "northern_ireland"
-            ]
-          }
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
@@ -86,6 +74,9 @@
         },
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
         }
       }
     },
@@ -355,6 +346,44 @@
         },
         "withdrawn_at": {
           "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
         }
       }
     }

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -276,6 +276,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -30,18 +30,6 @@
         "image": {
           "$ref": "#/definitions/image"
         },
-        "excluded_nations": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "england",
-              "scotland",
-              "wales",
-              "northern_ireland"
-            ]
-          }
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
@@ -86,6 +74,9 @@
         },
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
         }
       }
     },
@@ -304,6 +295,44 @@
         },
         "withdrawn_at": {
           "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
         }
       }
     }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -472,6 +472,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -337,6 +337,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -298,6 +298,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -421,6 +421,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -286,6 +286,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -247,6 +247,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -425,6 +425,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -290,6 +290,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -251,6 +251,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -409,6 +409,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -274,6 +274,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -235,6 +235,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -412,6 +412,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -277,6 +277,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -270,6 +270,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -232,6 +232,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -414,6 +414,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -279,6 +279,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -240,6 +240,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -558,6 +558,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -426,6 +426,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -273,6 +273,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -378,6 +378,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -516,6 +516,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -381,6 +381,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -342,6 +342,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -506,6 +506,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -371,6 +371,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -332,6 +332,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -423,6 +423,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -288,6 +288,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -268,6 +268,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -245,6 +245,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -444,6 +444,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -313,6 +313,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -280,6 +280,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -258,6 +258,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -499,6 +499,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -367,6 +367,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -270,6 +270,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -322,6 +322,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -452,6 +452,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -320,6 +320,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -270,6 +270,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -275,6 +275,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -478,6 +478,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -345,6 +345,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -306,6 +306,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -534,6 +534,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -402,6 +402,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -283,6 +283,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -344,6 +344,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -477,6 +477,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -342,6 +342,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -285,6 +285,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -282,6 +282,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -471,6 +471,44 @@
         }
       }
     },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
     "anchor_href": {
       "type": "string",
       "pattern": "^#.+$",

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -337,6 +337,44 @@
         }
       }
     },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
     "anchor_href": {
       "type": "string",
       "pattern": "^#.+$",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -268,6 +268,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -294,6 +294,44 @@
         }
       }
     },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
     "anchor_href": {
       "type": "string",
       "pattern": "^#.+$",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -450,6 +450,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -317,6 +317,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -272,6 +272,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -270,6 +270,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -441,6 +441,44 @@
         }
       }
     },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
     "any_metadata": {
       "type": "object",
       "oneOf": [

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -289,6 +289,44 @@
         }
       }
     },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
     "any_metadata": {
       "type": "object",
       "oneOf": [

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -250,6 +250,44 @@
         }
       }
     },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
     "any_metadata": {
       "type": "object",
       "oneOf": [

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -440,6 +440,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -305,6 +305,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -268,6 +268,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -262,6 +262,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -410,6 +410,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -275,6 +275,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -236,6 +236,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -404,6 +404,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -269,6 +269,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -230,6 +230,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -448,6 +448,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -315,6 +315,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -272,6 +272,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -268,6 +268,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -413,6 +413,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -278,6 +278,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -267,6 +267,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -236,6 +236,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -490,6 +490,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -355,6 +355,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -267,6 +267,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -313,6 +313,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -459,6 +459,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -324,6 +324,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -267,6 +267,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -282,6 +282,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -424,6 +424,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -289,6 +289,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -250,6 +250,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -406,6 +406,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -271,6 +271,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -264,6 +264,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -232,6 +232,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   },
   "oneOf": [

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -201,6 +201,44 @@
           "format": "date-time"
         }
       }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
     }
   }
 }

--- a/formats/detailed_guide/frontend/examples/national_applicability_alternative_url_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/national_applicability_alternative_url_detailed_guide.json
@@ -1,0 +1,65 @@
+{
+  "content_id": "5f20e4c6-7631-11e4-a3cb-005056011aef",
+  "base_path": "/guidance/report-lost-or-stolen-cattle",
+  "description": "What to do if any of your cattle, bison or buffalo are lost or stolen, and if you get them back. ",
+  "public_updated_at": "2014-05-06T13:03:41+01:00",
+  "title": "Report lost or stolen cattle",
+  "schema_name": "detailed_guide",
+  "document_type": "detailed_guide",
+  "format": "detailed_guide",
+  "locale": "en",
+  "details": {
+    "body": "<div class=\"govspeak\"><p>You must report any loss or theft of an animal to the police and to the British Cattle Movement Service (BCMS) and inform them if the animal is recovered.</p>\n\n<h2 id=\"if-an-animal-is-lost-or-stolen\">If an animal is lost or stolen</h2>\n\n<p>You must:</p>\n\n<ul>\n  <li>report the loss or theft to the police and obtain an incident number</li>\n  <li>post the animal’s passport or certificate of registration to arrive with BCMS within 7 days of becoming aware of the loss or theft, at the following address:</li>\n</ul>\n\n<div class=\"address\"><div class=\"adr org fn\"><p>\n\nBCMS\n<br>Curwen Road\n<br>Workington \n<br>CA14 2DD \n<br>\n</p></div></div>\n\n<p>You should also make a note of the date of the loss or theft in your <a rel=\"external\" href=\"https://www.gov.uk/keep-a-holding-register-for-cattle\">holding register</a>.</p>\n\n<h2 id=\"if-the-animal-is-recovered\">If the animal is recovered</h2>\n\n<p>You must:</p>\n\n<ul>\n  <li>confirm this in writing with BCMS at the address above</li>\n  <li>inform the police that the animal has been recovered</li>\n  <li>update your farm records to show the animal has been recovered</li>\n</ul>\n\n<p>BCMS will send you a replacement passport.</p>\n</div>",
+    "first_public_at": "2014-05-06T13:03:41+01:00",
+    "tags": {
+      "browse_pages": [],
+      "topics": ["keeping-farmed-animals/cattle-identity-registration"],
+      "policies": []
+    },
+    "government": {
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "current": false
+    },
+    "change_history": [
+      {
+        "public_timestamp": "2014-05-06T13:03:41+01:00",
+        "note": "First published."
+      }
+    ],
+    "political": false,
+    "national_applicability": {
+      "england": {
+        "label": "England",
+        "applicable": true
+      },
+      "northern_ireland": {
+        "label": "Northern Ireland",
+        "applicable": false,
+        "alternative_url": "http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for"
+      },
+      "scotland": {
+        "label": "Scotland",
+        "applicable": true
+      },
+      "wales": {
+        "label": "Wales",
+        "applicable": true
+      }
+    }
+  },
+  "links": {
+    "lead_organisations": [
+      {
+        "content_id": "49e09fa7-f65b-49d6-b4ab-0ca82a548e93",
+        "title": "British Cattle Movement Service",
+        "base_path": "/government/organisations/british-cattle-movement-service",
+        "api_url": "https://www.gov.uk/api/organisations/british-cattle-movement-service",
+        "web_url": "https://www.gov.uk/government/organisations/british-cattle-movement-service",
+        "locale": "en",
+        "analytics_identifier": "OT1051"
+      }
+    ],
+    "parent": []
+  }
+}

--- a/formats/detailed_guide/frontend/examples/national_applicability_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/national_applicability_detailed_guide.json
@@ -1,0 +1,64 @@
+{
+  "content_id": "5d5ea667-7631-11e4-a3cb-005056011aef",
+  "base_path": "/guidance/housing-finance-and-household-expenditure-notes-and-definitions",
+  "description": "Information on how statistics on housing finance and household expenditure are compiled.",
+  "public_updated_at": "2013-02-27T12:01:17+00:00",
+  "title": "Housing finance and household expenditure: notes and definitions",
+  "schema_name": "detailed_guide",
+  "document_type": "detailed_guide",
+  "format": "detailed_guide",
+  "locale": "en",
+  "details": {
+    "body": "<div class=\"govspeak\"><h2 id=\"overview\">Overview</h2>\n\n<p>This guidance is to be read in conjunction with the <a rel=\"external\" href=\"https://www.gov.uk/government/organisations/department-for-communities-and-local-government/series/housing-finance-and-household-expenditure-social-housing\">series on housing finance and household expenditure</a> which includes the latest sets of live tables.</p>\n\n<h2 id=\"expenditure-and-income-on-housing-from-housing-revenue-account\">Expenditure and income on housing from Housing Revenue Account</h2>\n\n<p>Each local authority is required by statute to keep a Housing Revenue Account in which are recorded the annual revenue income and expenditure in respect of dwellings and other property provided under <a rel=\"external\" href=\"http://www.legislation.gov.uk/ukpga/1985/68/part/II\" title=\"Housing Act 1985: Part II\">Part II of the Housing Act 1985.</a> Housing Revenue Account self-financing was implemented as part of the <a rel=\"external\" href=\"http://www.legislation.gov.uk/ukpga/2011/20/contents/enacted\" title=\"Localism Act 2011\">Localism Act 2011.</a> As a result of this, the previous subsidy system ceased in April 2012 and we are in the process of reviewing the basis of the <a href=\"http://www.dev.gov.uk/government/statistical-data-sets/live-tables-on-housing-finance-and-household-expenditure\" title=\"Live tables on housing finance and household expenditure\">live tables</a>.</p>\n\n<p>The main items of expenditure are:</p>\n\n<ul>\n  <li>loan charges in respect of moneys borrowed for the provision or improvement of local authority housing accommodation mainly under Part II of the Housing Act 1985</li>\n  <li>supervision and management</li>\n  <li>housing repairs</li>\n</ul>\n\n<p>The main items of income are:</p>\n\n<ul>\n  <li>rents (excluding rates and water charges)</li>\n  <li>Exchequer housing subsidies</li>\n  <li>investment and interest income from the sale of dwellings</li>\n</ul>\n\n<p>Figures of expenditure and income for each authority are collected annually by the Department for Communities and Local Government in housing subsidy claim forms.</p>\n\n<h2 id=\"renewal-grants\">Renewal grants</h2>\n\n<p>Live table 313 relates to grants paid under the <a rel=\"external\" href=\"http://www.legislation.gov.uk/ukpga/1996/53/contents\" title=\"Housing Grants, Construction and Regeneration Act 1996\">Housing Grants, Construction and Regeneration Act 1996.</a></p>\n\n<p>The Housing Grants, Construction and Regeneration 1996 Act came into operation in December 1996, replacing the Local Government and Housing Act 1989. The main effect of the 1996 Act was to make most grants discretionary rather than to change significantly the nature of the grants, although there were some modifications. Just one area of the 1989 Act, renewal areas, was left completely unchanged. It was repealed in July 2003. However, payments will continue for grants previously approved.</p>\n\n<p>Some of the main types of grants are detailed below.</p>\n\n<h3 id=\"home-repair-assistance\">Home Repair Assistance</h3>\n\n<p>Home Repair Assistance (<abbr title=\"Home Repair Assistance\">HRA</abbr>) was available at the authority’s discretion for financial support or materials to facilitate small-scale works of improvement, adaptation or improvement of a dwelling. It replaced Minor Works Assistance (1989 Act) and was intended, like its predecessor, to compliment the mainstream system of renovation grants. <abbr title=\"Home Repair Assistance\">HRA</abbr> was limited to a maximum of £2,000 per application, and no more than £4,000 was granted to any 1 property over a 3 year period.</p>\n\n<p><abbr title=\"Home Repair Assistance\">HRA</abbr> was not directly means-tested, although to be considered for a grant, an applicant would have had to be in receipt of at least 1 state benefit. In addition, they would have had to be over 18, had the power to carry out the works, and have lived in the dwelling as their only or main residence, or care for an elderly, infirm or disabled person. This grant was available to people living in mobile homes and houseboats.</p>\n\n<p>Examples of typical <abbr title=\"Home Repair Assistance\">HRA</abbr> works are:</p>\n\n<ul>\n  <li>securing the basic fabric of the property from wind or rain</li>\n  <li>protecting the occupants from immediate exposure to danger (that is, emergency works)</li>\n  <li>replacement of lead pipes</li>\n  <li>repairs to doors or windows</li>\n  <li>removal of radon</li>\n  <li>crime prevention measures</li>\n  <li>wheelchair ramps or grip rails</li>\n</ul>\n\n<h3 id=\"renovation-grants\">Renovation grants</h3>\n\n<p>This grant was the main type of grant for the improvement and/or repair of dwellings and for the conversion of houses and other buildings into flats for letting. It was mainly available to owner-occupiers and landlords (other than Houses in Multiple Occupation landlords), though it was available to tenants who were liable for works under the terms of their lease. The amount of grant was decided by the costs of the works concerned and the test of financial resources.</p>\n\n<p>The main purposes of the grant were:</p>\n\n<ul>\n  <li>to bring property up to the standard of fitness for human habitation (see below) - if a property is below this standard, then action will be required by the local authority, and if renovation is most appropriate then a grant is mandatory to owner-occupiers; grant is only mandatory to landlords if the works are required to comply with a repair notice</li>\n  <li>to repair and/or improve a property beyond the standard of fitness - grant is discretionary and it can be given in addition to mandatory grant, or on its own in the case of property already fit; for this reason the numbers of grants given out may exceed the numbers of dwellings renovated</li>\n  <li>for home insulation, where grant is discretionary</li>\n  <li>for heating, where again grant is discretionary, unless it is to make a property meet the fitness standard</li>\n  <li>for providing satisfactory internal arrangements, where grant is discretionary</li>\n  <li>for conversions, where grant is discretionary</li>\n</ul>\n\n<h3 id=\"common-parts-grants\">Common parts grants</h3>\n\n<p>This grant was available to help with the improvement or repair of the common parts of buildings containing one or more flats, where at least three-quarters of the flats have occupying tenants (that is owner-occupiers, long leaseholders or tenants whose flat is their main residence). Grants were available to landlords, landlords together with occupying tenants, or to occupying tenants if their lease made them liable for the works in question. Grants for works by a landlord to comply with a repair notice would have been mandatory; all other grants were discretionary. The amount of grant was decided by the test of financial resources.</p>\n\n<h3 id=\"houses-in-multiple-occupation-grants\">Houses in Multiple Occupation grants</h3>\n\n<p>This grant was available to cover works on Houses in Multiple Occupation (HMOs) where the occupants did not form a single household. It was only available to landlords. If works were required to comply with a statutory notice, then the grant was mandatory. Otherwise work to bring the <abbr title=\"House in Multiple Occupation\">HMO</abbr> up to the standard of fitness was discretionary. Discretionary grants were available for works to HMOs similar to those described in relation to the renovation grant. They were also available for the conversion of property into a <abbr title=\"House in Multiple Occupation\">HMO</abbr>. The amount of grant again depended on the test of financial resources.</p>\n\n<h3 id=\"minor-works-assistance\">Minor Works Assistance</h3>\n\n<p>This was available for carrying out small-scale works (costing up to £1,080), including insulation work. Assistance was only available to owner-occupiers or private sector tenants (including housing association tenants) who received an income related benefit. This assistance was for the following purposes:</p>\n\n<ul>\n  <li>to improve thermal insulation</li>\n  <li>for minor works to repair, improve or adapt a property for elderly occupants</li>\n  <li>to adapt property to enable an elderly person to move in with the occupants</li>\n  <li>to carry out minor repairs to a property in a clearance area</li>\n  <li>to replace lead piping in the water supply</li>\n</ul>\n\n<h2 id=\"disabled-facilities-grants\">Disabled Facilities Grants</h2>\n\n<p>Live table 314 provides data on the number and amount of Disabled Facilities Grants paid out by local authorities. For years up to and including 2007 to 2008, data were collected in the Housing Strategy Statistical Appendix (<abbr title=\"Housing Strategy Statistical Appendix\">HSSA</abbr>) return. For 2008 to 2009, this section was removed from the <abbr title=\"Housing Strategy Statistical Appendix\">HSSA</abbr> form to avoid duplication and data are taken from the Disabled Facilities Grant subsidy claim forms. Expenditure covers central Disabled Facilities Grant monies provided by the Department for Communities and Local Government to local authorities and any additional expenditure made by authorities directly.</p>\n\n<p>This grant is available for adapting, or providing facilities for, the home of a disabled person to make it more suitable for them to live in. It is also available for adaptations to the common parts of buildings containing 1 or more flats for a disabled person. Grants are available to, or on behalf of, registered or eligible disabled persons. They can be made to owner-occupiers, housing association tenants or to landlords on behalf of disabled tenants.</p>\n\n<p>The funding arrangements for providing adaptations to local authority tenants is different as the local authority must pay for them from their own resources. They cannot access the specific grant paid by the government to local authorities to reimburse them for expenditure incurred on Disabled Facilities Grants. Mandatory grants are available for works to make the disabled person manage more independently at home. The amount of grant is subject to a test of financial resources and has a grant maximum currently set at £30,000. Discretionary grant is available for other works to make a home suitable for disabled occupant’s accommodation, welfare or employment.</p>\n\n</div>",
+    "first_public_at": "2013-02-27T12:01:17+00:00",
+    "tags": {
+      "browse_pages": [],
+      "topics": ["government/national-and-official-statistics"],
+      "policies": []
+    },
+    "government": {
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "current": false
+    },
+    "change_history": [
+      {
+        "public_timestamp": "2013-02-27T12:01:17+00:00",
+        "note": "First published."
+      }
+    ],
+    "political": false,
+    "national_applicability": {
+      "england": {
+        "label": "England",
+        "applicable": true
+      },
+      "northern_ireland": {
+        "label": "Northern Ireland",
+        "applicable": false
+      },
+      "scotland": {
+        "label": "Scotland",
+        "applicable": false
+      },
+      "wales": {
+        "label": "Wales",
+        "applicable": false
+      }
+    }
+  },
+  "links": {
+    "lead_organisations": [
+      {
+        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "title": "Department for Communities and Local Government",
+        "base_path": "/government/organisations/department-for-communities-and-local-government",
+        "api_url": "https://www.gov.uk/api/organisations/department-for-communities-and-local-government",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-communities-and-local-government",
+        "locale": "en",
+        "analytics_identifier": "D4"
+      }
+    ],
+    "parent": []
+  }
+}

--- a/formats/detailed_guide/publisher/details.json
+++ b/formats/detailed_guide/publisher/details.json
@@ -26,13 +26,6 @@
     "image": {
       "$ref": "#/definitions/image"
     },
-    "excluded_nations": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "enum": ["england", "scotland", "wales", "northern_ireland"]
-      }
-    },
     "change_history": {
       "$ref": "#/definitions/change_history"
     },
@@ -77,6 +70,9 @@
     },
     "withdrawn_notice": {
       "$ref": "#/definitions/withdrawn_notice"
+    },
+    "national_applicability": {
+      "$ref": "#/definitions/national_applicability"
     }
   }
 }


### PR DESCRIPTION
This replaces `excluded_nations` with something which is more
frontend-friendly. Using this structure means that frontends don't need to
invert the list of all nations to determine which nations a publication
`Applies to:`.

Review commit by commit for simplicity.