### PR TITLE
Remove alternative_format_provider_organisation detailed guide link.

### DIFF
--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -85,9 +85,6 @@
         "related_guides": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alternative_format_provider_organisation": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "related_mainstream": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -102,9 +102,6 @@
         "related_guides": {
           "$ref": "#/definitions/guid_list"
         },
-        "alternative_format_provider_organisation": {
-          "$ref": "#/definitions/guid_list"
-        },
         "related_mainstream": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -19,9 +19,6 @@
         "related_guides": {
           "$ref": "#/definitions/guid_list"
         },
-        "alternative_format_provider_organisation": {
-          "$ref": "#/definitions/guid_list"
-        },
         "related_mainstream": {
           "$ref": "#/definitions/guid_list"
         },

--- a/formats/detailed_guide/publisher/links.json
+++ b/formats/detailed_guide/publisher/links.json
@@ -12,9 +12,6 @@
     "related_guides": {
       "$ref": "#/definitions/guid_list"
     },
-    "alternative_format_provider_organisation": {
-      "$ref": "#/definitions/guid_list"
-    },
     "related_mainstream": {
       "$ref": "#/definitions/guid_list"
     }


### PR DESCRIPTION
This field is used by whitehall when rendering attachments. When an
attachment isn't accessible, a link to an alternative format provider is
displayed to the user.

Since we publish the fully rendered body through the content store,
including the aforementioned accessibility notice, this link isn't
necessary or useful.