### PR TITLE
Remove organisations and parent from HTML publications `links.json`

### DIFF
--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -80,12 +80,6 @@
         "organisations"
       ],
       "properties": {
-        "parent": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -95,7 +89,13 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -36,15 +36,6 @@
         "organisations"
       ],
       "properties": {
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -57,9 +48,18 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
         "lead_organisations": {
           "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -14,15 +14,6 @@
         "organisations"
       ],
       "properties": {
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -35,9 +26,18 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
         "lead_organisations": {
           "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "policies": {
           "description": "These are for collecting content related to a particular government policy.",

--- a/formats/html_publication/publisher/links.json
+++ b/formats/html_publication/publisher/links.json
@@ -6,14 +6,5 @@
     "parent",
     "organisations"
   ],
-  "properties": {
-    "parent": {
-      "description": "The parent content item.",
-      "$ref": "#/definitions/guid_list",
-      "maxItems": 1
-    },
-    "organisations": {
-      "$ref": "#/definitions/guid_list"
-    }
-  }
+  "properties": {}
 }


### PR DESCRIPTION
These are provided by `base_links`, this is duplication – if one of these was changed (either base or the one in links) it might have unexpected results.