### PR TITLE
Use document_type for "publication type"

### DIFF
--- a/formats/publication/frontend/examples/political_publication.json
+++ b/formats/publication/frontend/examples/political_publication.json
@@ -81,5 +81,5 @@
     ]
   },
   "schema_name": "publication",
-  "document_type": "publication"
+  "document_type": "policy_paper"
 }

--- a/formats/publication/frontend/examples/publication.json
+++ b/formats/publication/frontend/examples/publication.json
@@ -41,5 +41,5 @@
     ]
   },
   "schema_name": "publication",
-  "document_type": "publication"
+  "document_type": "notice"
 }

--- a/formats/publication/frontend/examples/withdrawn_publication.json
+++ b/formats/publication/frontend/examples/withdrawn_publication.json
@@ -54,5 +54,5 @@
     ]
   },
   "schema_name": "publication",
-  "document_type": "publication"
+  "document_type": "guidance"
 }


### PR DESCRIPTION
All publications use the schema or format “publication”, but have a required publication type – we can use `document_type` for this, as specified in RFC 41:
https://gov-uk.atlassian.net/wiki/pages/viewpage.action?spaceKey=GOVUK&title=RFC+41%3A+Separate+document+type+from+format

> We will deprecate the current format field, and replace it with two new fields:
> schema_name - determines which file in govuk-content-schemas is used to validate the item.
> document_type - used for frontend display and for filtering in publishing apps “

(Although, in the case of publications, all document types look exactly the same – the only difference being the context string used in their title component. Semantics basically.)