### PR TITLE
Add max_cache_time field to specialist-document format

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -215,6 +215,10 @@
         "metadata": {
           "$ref": "#/definitions/any_metadata"
         },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
+        },
         "headers": {
           "$ref": "#/definitions/nested_headers"
         },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -24,6 +24,10 @@
         "metadata": {
           "$ref": "#/definitions/any_metadata"
         },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
+        },
         "headers": {
           "$ref": "#/definitions/nested_headers"
         },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -24,6 +24,10 @@
         "metadata": {
           "$ref": "#/definitions/any_metadata"
         },
+        "max_cache_time": {
+          "description": "The maximum length of time the content should be cached, in seconds.",
+          "type": "integer"
+        },
         "headers": {
           "$ref": "#/definitions/nested_headers"
         },

--- a/formats/specialist_document/frontend/examples/aaib-reports.json
+++ b/formats/specialist_document/frontend/examples/aaib-reports.json
@@ -33,6 +33,7 @@
       "registration": "G-PCPC",
       "document_type": "aaib_report"
     },
+    "max_cache_time": 10,
     "headers": [
       {
         "text": "Summary:",

--- a/formats/specialist_document/frontend/examples/asylum-support-decision.json
+++ b/formats/specialist_document/frontend/examples/asylum-support-decision.json
@@ -22,6 +22,7 @@
       "hidden_indexable_content": "The appellant, an Iranian Kurd born on 20 February 1979, appeals against the decision of the Secretary of State who refused support under Section 4 of the Immigration and Asylum Act 1999 (“the Act”) on 8 April 2006 on the grounds that the appellant did not satisfy one or more of the conditions set out in Regulation 3 of the Immigration and Asylum (Provision of Accommodation to Failed Asylum Seekers) Regulations 2005 (“the 2005 Regulations”). \r\n...\r\n",
       "document_type": "asylum_support_decision"
     },
+    "max_cache_time": 10,
     "change_history": [
       {
         "public_timestamp": "2015-09-04T09:03:56+00:00",

--- a/formats/specialist_document/frontend/examples/cma-cases.json
+++ b/formats/specialist_document/frontend/examples/cma-cases.json
@@ -33,6 +33,7 @@
       "opened_date": "2015-07-10",
       "closed_date": "2015-08-20"
     },
+    "max_cache_time": 10,
     "headers": [
       {
         "text": "Statutory timetable",

--- a/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
@@ -39,6 +39,7 @@
       ],
       "document_type": "countryside_stewardship_grant"
     },
+    "max_cache_time": 10,
     "headers": [
       {
         "text": "How much will be paid",

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -36,6 +36,7 @@
       "issued_date": "2015-07-06",
       "document_type": "medical_safety_alert"
     },
+    "max_cache_time": 10,
     "headers": [
       {
         "text": "Action",

--- a/formats/specialist_document/frontend/examples/drug-safety-update.json
+++ b/formats/specialist_document/frontend/examples/drug-safety-update.json
@@ -27,6 +27,7 @@
       ],
       "document_type": "drug_safety_update"
     },
+    "max_cache_time": 10,
     "headers": [
       {
         "text": "Reports of diabetic acidosis",

--- a/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
@@ -23,6 +23,7 @@
         "race-discrimination-direct"
       ]
     },
+    "max_cache_time": 10,
     "change_history": [
       {
         "public_timestamp": "2015-10-29T15:50:37+00:00",

--- a/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
@@ -20,6 +20,7 @@
       "bulk_published": false,
       "document_type": "employment_tribunal_decision"
     },
+    "max_cache_time": 10,
     "change_history": [
       {
         "public_timestamp": "2015-10-15T12:00:37+00:00",

--- a/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
+++ b/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
@@ -35,6 +35,7 @@
       "closing_date": "2015-05-29",
       "document_type": "esi_fund"
     },
+    "max_cache_time": 10,
     "headers": [
       {
         "text": "Important Notice for this Call",

--- a/formats/specialist_document/frontend/examples/international-development-funding.json
+++ b/formats/specialist_document/frontend/examples/international-development-funding.json
@@ -43,6 +43,7 @@
       ],
       "document_type": "international_development_fund"
     },
+    "max_cache_time": 10,
     "headers": [
       {
         "text": "Overview",

--- a/formats/specialist_document/frontend/examples/maib-reports.json
+++ b/formats/specialist_document/frontend/examples/maib-reports.json
@@ -30,6 +30,7 @@
       "date_of_occurrence": "2014-12-21",
       "document_type": "maib_report"
     },
+    "max_cache_time": 10,
     "headers": [
       {
         "text": "Accident Investigation Report 16/2015",

--- a/formats/specialist_document/frontend/examples/raib-reports.json
+++ b/formats/specialist_document/frontend/examples/raib-reports.json
@@ -32,6 +32,7 @@
       "date_of_occurrence": "2014-09-24",
       "document_type": "raib_report"
     },
+    "max_cache_time": 10,
     "change_history": [
       {
         "note": "First published.",

--- a/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
@@ -16,6 +16,7 @@
       "tribunal_decision_decision_date": "2015-09-08",
       "hidden_indexable_content": "whether FTT entitled not to find or infer that car dealer had accounted for VAT on bonuses paid by manufacturers to dealer on purchase of demonstrator and courtesy cars in claim periods - appeal dismissed"
     },
+    "max_cache_time": 10,
     "change_history": [
       {
         "public_timestamp": "2015-10-07T10:54:48+00:00",

--- a/formats/specialist_document/frontend/examples/utaac-decision.json
+++ b/formats/specialist_document/frontend/examples/utaac-decision.json
@@ -26,6 +26,7 @@
       "bulk_published": false,
       "document_type": "utaac_decision"
     },
+    "max_cache_time": 10,
     "change_history": [
       {
         "public_timestamp": "2016-04-05T14:41:08+00:00",

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -20,7 +20,10 @@
     "metadata": {
       "$ref": "#/definitions/any_metadata"
     },
-
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds.",
+      "type": "integer"
+    },
     "headers" : {
       "$ref": "#/definitions/nested_headers"
     },

--- a/formats/specialist_document/publisher_v2/examples/specialist_document.json
+++ b/formats/specialist_document/publisher_v2/examples/specialist_document.json
@@ -46,7 +46,8 @@
       "market_sector": ["energy"],
       "outcome_type": "ca98-commitment",
       "document_type": "cma_case"
-    }
+    },
+    "max_cache_time": 10
   },
  "routes": [
     {


### PR DESCRIPTION
- Add max_cache_time for specialist-document format (this is the same level as Travel Advice Publisher as agreed with infrastructure.);
- [Trello Card](https://trello.com/c/WGlWkWT5/70-reduce-cache-on-specialist-publisher-medium)