### PR TITLE
Add `emphasised_organisations` to details hash

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -270,6 +270,13 @@
               "format": "date-time"
             }
           }
+        },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
         }
       }
     },

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -78,6 +78,13 @@
               "format": "date-time"
             }
           }
+        },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
         }
       }
     },
@@ -96,6 +103,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "supporting_organisations": {
+          "description": "DEPRECATED: this field will be removed.",
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -21,6 +21,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "supporting_organisations": {
+          "description": "DEPRECATED: this field will be removed.",
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -78,6 +78,13 @@
               "format": "date-time"
             }
           }
+        },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
         }
       }
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -258,6 +258,13 @@
         "political": {
           "$ref": "#/definitions/political"
         },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
         },

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -72,6 +72,13 @@
         "political": {
           "$ref": "#/definitions/political"
         },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
         },

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -72,6 +72,13 @@
         "political": {
           "$ref": "#/definitions/political"
         },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
         },

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -79,6 +79,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "supporting_organisations": {
+          "description": "DEPRECATED: this field is being removed.",
           "$ref": "#/definitions/guid_list"
         },
         "ministers": {

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -17,6 +17,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "supporting_organisations": {
+          "description": "DEPRECATED: this field is being removed.",
           "$ref": "#/definitions/guid_list"
         },
         "ministers": {

--- a/formats/case_study/publisher/details.json
+++ b/formats/case_study/publisher/details.json
@@ -68,6 +68,13 @@
           "format": "date-time"
         }
       }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
     }
   }
 }

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -7,12 +7,14 @@
   ],
   "properties": {
     "lead_organisations": {
+      "description": "DEPRECATED: this field is being replaced by the `emphasised_organisations` field in the details hash.",
       "$ref": "#/definitions/guid_list"
     },
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },
     "supporting_organisations": {
+      "description": "DEPRECATED: this field will be removed.",
       "$ref": "#/definitions/guid_list"
     },
     "world_locations": {

--- a/formats/detailed_guide/publisher/details.json
+++ b/formats/detailed_guide/publisher/details.json
@@ -68,6 +68,13 @@
     "political": {
       "$ref": "#/definitions/political"
     },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
     "withdrawn_notice": {
       "$ref": "#/definitions/withdrawn_notice"
     },

--- a/formats/publication/publisher/links.json
+++ b/formats/publication/publisher/links.json
@@ -10,6 +10,7 @@
       "$ref": "#/definitions/guid_list"
     },
     "supporting_organisations": {
+      "description": "DEPRECATED: this field is being removed.",
       "$ref": "#/definitions/guid_list"
     },
     "ministers": {


### PR DESCRIPTION
Currently, there are three types of organisations stored in the publishing-api database:

- lead organisations
- organisations
- supporting organisations
Where: organisations = lead organisations + supporting organisations

GOV.UK publishing apps do not send to the publishing-api the same organisation types consistently. We are going to modify all applications to send at least the organisations content ids in the links hash and the "emphasised_organisations" in the details hash. 
Frontend applications will then decide what and how to display the organisations by reading the details and links hashes of a piece of content. 

The `emphasised_organisations` in details hash will allow frontend applications to decide the order in which to display organisations. (emphasised_organisations will go first)

ticket: https://trello.com/c/us3MI1n9/602-fix-organisation-tagging
related to: https://github.com/alphagov/whitehall/pull/2585

Future steps:
- remove lead and supporting organisations from the schemas