### PR TITLE
Add `emphasised_organisations` example

### DIFF
--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -96,7 +96,7 @@
       ],
       "properties": {
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -14,7 +14,7 @@
       ],
       "properties": {
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -41,7 +41,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -228,7 +228,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -30,7 +30,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -120,7 +120,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -39,7 +39,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -102,7 +102,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -51,7 +51,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -55,7 +55,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -39,7 +39,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -42,7 +42,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -33,7 +33,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -44,7 +44,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -191,7 +191,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -36,7 +36,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -146,7 +146,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -136,7 +136,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -53,7 +53,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -31,7 +31,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -78,7 +78,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -43,7 +43,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -132,7 +132,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -33,7 +33,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -85,7 +85,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -33,7 +33,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -110,7 +110,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -174,7 +174,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -46,7 +46,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -225,6 +225,13 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
         "tags": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -118,7 +118,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -30,6 +30,13 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
         "tags": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -49,7 +49,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -30,6 +30,13 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
         "tags": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -101,7 +101,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -31,7 +31,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -82,7 +82,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -35,7 +35,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -57,7 +57,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -74,7 +74,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -35,7 +35,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -40,7 +40,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -34,7 +34,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -80,7 +80,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -35,7 +35,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -43,7 +43,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -30,7 +30,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -120,7 +120,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -30,7 +30,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -89,7 +89,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -30,7 +30,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -54,7 +54,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -36,7 +36,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -27,7 +27,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {
-          "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/formats/base_links.json
+++ b/formats/base_links.json
@@ -20,7 +20,7 @@
       "$ref": "#/definitions/guid_list"
     },
     "lead_organisations": {
-      "description": "A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+      "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
       "$ref": "#/definitions/guid_list"
     },
     "parent": {

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -29,6 +29,7 @@
       "alt_text": "Terence",
       "caption": null
     },
+    "emphasised_organisations": ["dbeaa22b-fb0c-49b0-b44e-0ca6cb52b381"],
     "withdrawn_notice": {
       "explanation": "<div class=\"govspeak\"><p>We’ve withdrawn this case study and published newer <a href=\"https://www.gov.uk/government/collections/work-programme-real-life-stories\">Work Programme real life stories</a>.</p></div>",
       "withdrawn_at": "2014-08-22T10:29:02+01:00"
@@ -36,6 +37,16 @@
   },
   "links": {
     "lead_organisations": [
+      {
+        "content_id": "dbeaa22b-fb0c-49b0-b44e-0ca6cb52b381",
+        "title": "Department for Work and Pensions",
+        "base_path": "/government/organisations/department-for-work-pensions",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-pensions",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-work-pensions",
+        "locale": "en"
+      }
+    ],
+    "organisations": [
       {
         "content_id": "dbeaa22b-fb0c-49b0-b44e-0ca6cb52b381",
         "title": "Department for Work and Pensions",

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -16,11 +16,23 @@
       "topics": [],
       "policies": []
     },
-    "format_display_type": "case_study"
+    "format_display_type": "case_study",
+    "emphasised_organisations": ["8b19c238-54e3-4e27-b0d7-60f8e2a677c9"]
   },
   "format": "case_study",
   "links": {
     "lead_organisations": [
+      {
+        "content_id": "8b19c238-54e3-4e27-b0d7-60f8e2a677c9",
+        "title": "Department for International Development",
+        "base_path": "/government/organisations/department-for-international-development",
+        "api_url": "https://www.gov.uk/api/organisations/department-for-international-development",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-international-development",
+        "locale": "en",
+        "analytics_identifier": "L2"
+      }
+    ],
+    "organisations": [
       {
         "content_id": "8b19c238-54e3-4e27-b0d7-60f8e2a677c9",
         "title": "Department for International Development",

--- a/formats/case_study/frontend/examples/translated.json
+++ b/formats/case_study/frontend/examples/translated.json
@@ -18,6 +18,7 @@
       "caption": "UKTI Spain",
       "url": "https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/image_data/file/7633/s300_foto_UKTI-1.jpg"
     },
+    "emphasised_organisations": ["8449fbe1-bffe-46cf-a141-07df52c530b7"],
     "tags": {
       "browse_pages": [],
       "topics": [],
@@ -50,6 +51,16 @@
         "locale": "ar",
         "title": "البحرين - تحديث دراسة حالة دولة",
         "web_url": "https://www.gov.uk/government/case-studies/doing-business-in-spain.ar"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "8449fbe1-bffe-46cf-a141-07df52c530b7",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/uk-trade-investment",
+        "base_path": "/government/organisations/uk-trade-investment",
+        "locale": "en",
+        "title": "UK Trade & Investment",
+        "web_url": "https://www.gov.uk/government/organisations/uk-trade-investment"
       }
     ],
     "lead_organisations": [

--- a/formats/case_study/publisher_v2/examples/case_study_links.json
+++ b/formats/case_study/publisher_v2/examples/case_study_links.json
@@ -1,5 +1,8 @@
 {
   "links": {
+    "organisations": [
+      "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
+    ],
     "lead_organisations": [
       "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
     ],

--- a/formats/detailed_guide/frontend/examples/detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/detailed_guide.json
@@ -36,9 +36,21 @@
       "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
       "current": false
     },
+    "emphasised_organisations": ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"],
     "political": false
   },
   "links": {
+    "organisations": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue & Customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "api_url": "https://www.gov.uk/api/organisations/hm-revenue-customs",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
+        "locale": "en",
+        "analytics_identifier": "D25"
+      }
+    ],
     "lead_organisations": [
       {
         "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",

--- a/formats/detailed_guide/frontend/examples/national_applicability_alternative_url_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/national_applicability_alternative_url_detailed_guide.json
@@ -21,6 +21,7 @@
       "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
       "current": false
     },
+    "emphasised_organisations": ["49e09fa7-f65b-49d6-b4ab-0ca82a548e93"],
     "change_history": [
       {
         "public_timestamp": "2014-05-06T13:03:41+01:00",
@@ -49,6 +50,17 @@
     }
   },
   "links": {
+    "organisations": [
+      {
+        "content_id": "49e09fa7-f65b-49d6-b4ab-0ca82a548e93",
+        "title": "British Cattle Movement Service",
+        "base_path": "/government/organisations/british-cattle-movement-service",
+        "api_url": "https://www.gov.uk/api/organisations/british-cattle-movement-service",
+        "web_url": "https://www.gov.uk/government/organisations/british-cattle-movement-service",
+        "locale": "en",
+        "analytics_identifier": "OT1051"
+      }
+    ],
     "lead_organisations": [
       {
         "content_id": "49e09fa7-f65b-49d6-b4ab-0ca82a548e93",

--- a/formats/detailed_guide/frontend/examples/national_applicability_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/national_applicability_detailed_guide.json
@@ -28,6 +28,7 @@
       }
     ],
     "political": false,
+    "emphasised_organisations": ["2e7868a8-38f5-4ff6-b62f-9a15d1c22d28"],
     "national_applicability": {
       "england": {
         "label": "England",
@@ -49,6 +50,17 @@
   },
   "links": {
     "lead_organisations": [
+      {
+        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "title": "Department for Communities and Local Government",
+        "base_path": "/government/organisations/department-for-communities-and-local-government",
+        "api_url": "https://www.gov.uk/api/organisations/department-for-communities-and-local-government",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-communities-and-local-government",
+        "locale": "en",
+        "analytics_identifier": "D4"
+      }
+    ],
+    "organisations": [
       {
         "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
         "title": "Department for Communities and Local Government",

--- a/formats/detailed_guide/frontend/examples/political_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/political_detailed_guide.json
@@ -22,9 +22,21 @@
       "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
       "current": false
     },
-    "political": true
+    "political": true,
+    "emphasised_organisations": ["d65d4203-01f5-4920-a3b1-f614bfd8e83e"]
   },
   "links": {
+    "organisations": [
+      {
+        "content_id": "d65d4203-01f5-4920-a3b1-f614bfd8e83e",
+        "title": "Department of Energy & Climate Change",
+        "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
+        "api_url": "https://www.gov.uk/api/organisations/department-of-energy-climate-change",
+        "web_url": "https://www.gov.uk/government/organisations/department-of-energy-climate-change",
+        "locale": "en",
+        "analytics_identifier": "D11"
+      }
+    ],
     "lead_organisations": [
       {
         "content_id": "d65d4203-01f5-4920-a3b1-f614bfd8e83e",

--- a/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
@@ -35,6 +35,7 @@
       "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
       "current": false
     },
+    "emphasised_organisations": ["9adfc4ed-9f6c-4976-a6d8-18d34356367c"],
     "political": false
   },
   "links": {
@@ -59,6 +60,17 @@
       }
     ],
     "lead_organisations": [
+      {
+        "content_id": "9adfc4ed-9f6c-4976-a6d8-18d34356367c",
+        "title": "Foreign & Commonwealth Office",
+        "base_path": "/government/organisations/foreign-commonwealth-office",
+        "api_url": "https://www.gov.uk/api/organisations/foreign-commonwealth-office",
+        "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
+        "locale": "en",
+        "analytics_identifier": "D13"
+      }
+    ],
+    "organisations": [
       {
         "content_id": "9adfc4ed-9f6c-4976-a6d8-18d34356367c",
         "title": "Foreign & Commonwealth Office",

--- a/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
@@ -33,12 +33,24 @@
       "current": false
     },
     "political": false,
+    "emphasised_organisations": ["de4e9dc6-cca4-43af-a594-682023b84d6c"],
     "withdrawn_notice": {
       "explanation": "<div class=\"govspeak\"><p>This information has been archived as it is now out of date. For current information please go to <a rel=\"external\" href=\"http://www.hse.gov.uk/reach/\">http://www.hse.gov.uk/reach/</a></p></div>",
       "withdrawn_at": "2015-01-28T13:05:30Z"
     }
   },
   "links": {
+    "organisations": [
+      {
+        "content_id": "de4e9dc6-cca4-43af-a594-682023b84d6c",
+        "title": "Department for Environment, Food & Rural Affairs",
+        "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
+        "api_url": "https://www.gov.uk/api/organisations/department-for-environment-food-rural-affairs",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",
+        "locale": "en",
+        "analytics_identifier": "D7"
+      }
+    ],
     "lead_organisations": [
       {
         "content_id": "de4e9dc6-cca4-43af-a594-682023b84d6c",

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -21,6 +21,7 @@
     "signup_link": "",
     "summary": "The government believes that the current benefits system is too complex, and there are insufficient incentives to encourage people on benefits to start paid work or increase their hours.",
     "show_summaries": false,
+    "emphasised_organisations": ["a4759607-4fd8-4cf0-9d56-af9d14a71162"],
     "facets": [
       {
         "key": "is_historic",

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -20,6 +20,7 @@
     "signup_link": "",
     "summary": "Universal Credit brings together 6 benefits for people who are out of work or on a low income into a single payment. It's being introduced in stages, starting in October 2013. By the end of 2017 it's expected to be available across England and Wales.",
     "show_summaries": false,
+    "emphasised_organisations": ["9417d532-a080-4856-9a0f-08b1d9d78c98"],
     "facets": [
       {
         "key": "is_historic",

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -20,6 +20,7 @@
     "signup_link": "",
     "summary": "While day-to-day policing and justice functions are devolved to the Northern Ireland Executive, the UK government retains responsibility for national security issues in Northern Ireland.",
     "show_summaries": false,
+    "emphasised_organisations": ["8927158f-e4b2-4361-b55d-02de7599b220"],
     "facets": [
       {
         "key": "is_historic",

--- a/formats/publication/frontend/examples/political_publication.json
+++ b/formats/publication/frontend/examples/political_publication.json
@@ -25,6 +25,7 @@
         "note": "First published."
       }
     ],
+    "emphasised_organisations": ["d65d4203-01f5-4920-a3b1-f614bfd8e83e"],
     "tags": {
       "browse_pages": [],
       "policies": [],
@@ -39,6 +40,17 @@
   },
   "links": {
     "lead_organisations": [
+      {
+        "content_id": "d65d4203-01f5-4920-a3b1-f614bfd8e83e",
+        "title": "Department of Energy & Climate Change",
+        "base_path": "/government/organisations/department-of-energy-climate-change",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-of-energy-climate-change",
+        "web_url": "https://www.gov.uk/government/organisations/department-of-energy-climate-change",
+        "locale": "en",
+        "analytics_identifier": "D11"
+      }
+    ],
+    "organisations": [
       {
         "content_id": "d65d4203-01f5-4920-a3b1-f614bfd8e83e",
         "title": "Department of Energy & Climate Change",

--- a/formats/publication/frontend/examples/publication.json
+++ b/formats/publication/frontend/examples/publication.json
@@ -25,10 +25,22 @@
       "slug": "2015-conservative-government",
       "current": true
     },
-    "political": false
+    "political": false,
+    "emphasised_organisations": ["16628142-57b2-4611-bc03-5912785acee3"]
   },
   "links": {
     "lead_organisations": [
+      {
+        "content_id": "16628142-57b2-4611-bc03-5912785acee3",
+        "title": "Environment Agency",
+        "base_path": "/government/organisations/environment-agency",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/environment-agency",
+        "web_url": "https://www.gov.uk/government/organisations/environment-agency",
+        "locale": "en",
+        "analytics_identifier": "EA199"
+      }
+    ],
+    "organisations": [
       {
         "content_id": "16628142-57b2-4611-bc03-5912785acee3",
         "title": "Environment Agency",

--- a/formats/publication/frontend/examples/statistics_publication.json
+++ b/formats/publication/frontend/examples/statistics_publication.json
@@ -25,6 +25,7 @@
       "current": false
     },
     "political": false,
+    "emphasised_organisations": ["2e7868a8-38f5-4ff6-b62f-9a15d1c22d28"],
     "national_applicability": {
       "england": {
         "label": "England",
@@ -48,6 +49,17 @@
     }
   },
   "links": {
+    "organisations": [
+      {
+        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "title": "Department for Communities and Local Government",
+        "base_path": "/government/organisations/department-for-communities-and-local-government",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-communities-and-local-government",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-communities-and-local-government",
+        "locale": "en",
+        "analytics_identifier": "D4"
+      }
+    ],
     "lead_organisations": [
       {
         "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",

--- a/formats/publication/frontend/examples/withdrawn_publication.json
+++ b/formats/publication/frontend/examples/withdrawn_publication.json
@@ -35,12 +35,24 @@
       "current": false
     },
     "political": false,
+    "emphasised_organisations": ["de4e9dc6-cca4-43af-a594-682023b84d6c"],
     "withdrawn_notice": {
       "explanation": "<div class=\"govspeak\"><p>This information is now out of date. For our current guidance please read <a href=\"https://www.gov.uk/government/collections/guidance-for-keepers-of-sheep-goats-and-pigs\">guidance for keepers of sheep, goats and pigs</a>.</p></div>",
       "withdrawn_at": "2015-01-13T13:05:30Z"
     }
   },
   "links": {
+    "organisations": [
+      {
+        "content_id": "de4e9dc6-cca4-43af-a594-682023b84d6c",
+        "title": "Department for Environment, Food & Rural Affairs",
+        "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-environment-food-rural-affairs",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",
+        "locale": "en",
+        "analytics_identifier": "D7"
+      }
+    ],
     "lead_organisations": [
       {
         "content_id": "de4e9dc6-cca4-43af-a594-682023b84d6c",

--- a/formats/publication/publisher/details.json
+++ b/formats/publication/publisher/details.json
@@ -26,6 +26,13 @@
     "change_history": {
       "$ref": "#/definitions/change_history"
     },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
     "tags": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
This example is needed to get government-frontend tested with the new way of specifying emphasised organisations.

Related: https://github.com/alphagov/govuk-content-schemas/pull/306

Trello: https://trello.com/c/us3MI1n9/602-fix-organisation-tagging