### PR TITLE
Only allow unique content_ids in links

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -330,6 +330,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -196,6 +196,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -116,6 +116,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -138,6 +138,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -244,6 +244,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -109,6 +109,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -70,6 +70,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -431,6 +431,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -296,6 +296,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -100,6 +100,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -254,6 +254,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -323,6 +323,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -188,6 +188,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -109,6 +109,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -137,6 +137,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -305,6 +305,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -170,6 +170,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -131,6 +131,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -254,6 +254,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -119,6 +119,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -80,6 +80,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -258,6 +258,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -123,6 +123,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -84,6 +84,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -242,6 +242,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -107,6 +107,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -68,6 +68,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -245,6 +245,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -110,6 +110,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -103,6 +103,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -65,6 +65,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -247,6 +247,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -112,6 +112,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -73,6 +73,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -391,6 +391,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -259,6 +259,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -106,6 +106,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -211,6 +211,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -349,6 +349,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -214,6 +214,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -175,6 +175,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -339,6 +339,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -204,6 +204,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -165,6 +165,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -256,6 +256,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -121,6 +121,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -101,6 +101,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -78,6 +78,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -277,6 +277,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -146,6 +146,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -113,6 +113,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -91,6 +91,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -332,6 +332,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -200,6 +200,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -103,6 +103,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -155,6 +155,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -285,6 +285,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -153,6 +153,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -103,6 +103,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -108,6 +108,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -311,6 +311,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -178,6 +178,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -139,6 +139,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -374,6 +374,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -242,6 +242,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -116,6 +116,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -184,6 +184,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -320,6 +320,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -186,6 +186,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -119,6 +119,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -125,6 +125,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -303,6 +303,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -169,6 +169,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -101,6 +101,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -126,6 +126,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -283,6 +283,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -150,6 +150,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -105,6 +105,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -103,6 +103,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -277,6 +277,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -125,6 +125,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -86,6 +86,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -273,6 +273,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -138,6 +138,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -101,6 +101,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -95,6 +95,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -243,6 +243,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -108,6 +108,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -69,6 +69,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -237,6 +237,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -102,6 +102,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -63,6 +63,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -281,6 +281,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -148,6 +148,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -105,6 +105,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -101,6 +101,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -246,6 +246,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -111,6 +111,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -100,6 +100,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -69,6 +69,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -323,6 +323,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -188,6 +188,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -100,6 +100,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -146,6 +146,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -292,6 +292,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -157,6 +157,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -100,6 +100,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -115,6 +115,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -257,6 +257,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -122,6 +122,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -83,6 +83,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -239,6 +239,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -104,6 +104,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -97,6 +97,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -65,6 +65,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -47,6 +47,7 @@
     },
     "guid_list": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/guid"
       }


### PR DESCRIPTION
publishing-api now silently discards duplicates (alphagov/publishing-api#303). This should be reflected in the content-schemas.

/cc @boffbowsh 