### PR TITLE
Add document_collection schema

### DIFF
--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -1,0 +1,539 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "title",
+    "details",
+    "locale",
+    "public_updated_at",
+    "content_id",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "format": {
+      "type": "string",
+      "enum": [
+        "document_collection"
+      ]
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "documents",
+        "organisations"
+      ],
+      "properties": {
+        "documents": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "alpha_taxons": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "document_collection"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "links": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "parent": {
+                "$ref": "#/definitions/guid_list"
+              }
+            }
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "first_public_at",
+        "collection_groups",
+        "government",
+        "political"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "collection_groups": {
+          "description": "The ordered list of collection groups",
+          "type": "array",
+          "items": {
+            "description": "Collection group",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "documents"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "body": {
+                "type": "string"
+              },
+              "documents": {
+                "description": "An ordered list of documents in this collection group",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/guid"
+                }
+              }
+            }
+          }
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -1,0 +1,638 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "first_public_at",
+        "collection_groups",
+        "government",
+        "political"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "collection_groups": {
+          "description": "The ordered list of collection groups",
+          "type": "array",
+          "items": {
+            "description": "Collection group",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "documents"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "body": {
+                "type": "string"
+              },
+              "documents": {
+                "description": "An ordered list of documents in this collection group",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/guid"
+                }
+              }
+            }
+          }
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "documents",
+        "organisations"
+      ],
+      "properties": {
+        "documents": {
+          "description": "An unordered list of all documents in this collection",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "alpha_taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "These are for collecting content related to a particular government policy.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "document_collection"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        }
+      },
+      "required": [
+        "format",
+        "title",
+        "details",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "public_updated_at",
+        "content_id",
+        "update_type"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "schema_name": {
+          "type": "string",
+          "enum": [
+            "document_collection"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        }
+      },
+      "required": [
+        "document_type",
+        "schema_name",
+        "title",
+        "details",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "public_updated_at",
+        "content_id",
+        "update_type"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -1,0 +1,319 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "previous_version": {
+      "type": "string"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "documents",
+        "organisations"
+      ],
+      "properties": {
+        "documents": {
+          "description": "An unordered list of all documents in this collection",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "alpha_taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "These are for collecting content related to a particular government policy.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -1,0 +1,580 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "first_public_at",
+        "collection_groups",
+        "government",
+        "political"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "collection_groups": {
+          "description": "The ordered list of collection groups",
+          "type": "array",
+          "items": {
+            "description": "Collection group",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "documents"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "body": {
+                "type": "string"
+              },
+              "documents": {
+                "description": "An ordered list of documents in this collection group",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/guid"
+                }
+              }
+            }
+          }
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "document_collection"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "previous_version": {
+          "type": "string"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        }
+      },
+      "required": [
+        "format",
+        "title",
+        "details",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "public_updated_at",
+        "base_path"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "schema_name": {
+          "type": "string",
+          "enum": [
+            "document_collection"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "previous_version": {
+          "type": "string"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        }
+      },
+      "required": [
+        "document_type",
+        "schema_name",
+        "title",
+        "details",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "public_updated_at",
+        "base_path"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/formats/document_collection/frontend/examples/document_collection.json
+++ b/formats/document_collection/frontend/examples/document_collection.json
@@ -1,0 +1,207 @@
+{
+  "content_id": "5eb731c7-7631-11e4-a3cb-005056011aef",
+  "base_path": "/government/collections/national-driving-and-riding-standards",
+  "description": "The standards set out what it takes to be a safe and responsible driver and rider and provide training to drivers and riders.",
+  "public_updated_at": "2016-02-29T09:24:10.000+00:00",
+  "title": "National standards for driving and riding",
+  "updated_at": "2016-05-17T11:27:14.152Z",
+  "schema_name": "document_collection",
+  "document_type": "document_collection",
+  "format": "document_collection",
+  "locale": "en",
+  "details": {
+    "collection_groups": [
+      {
+        "title": "Car and light van",
+        "body": "<div class=\"govspeak\">\n<p>The standard sets out what you must be able to do and what you must know and understand to be a safe and responsible car and light van driver. The syllabus sets out a way of teaching people that knowledge and those skills.</p>\n</div>",
+        "documents": [
+          "5e5dc1ab-7631-11e4-a3cb-005056011aef",
+          "5e5dc201-7631-11e4-a3cb-005056011aef",
+          "5e5dd324-7631-11e4-a3cb-005056011aef"
+        ]
+      },
+      {
+        "title": "Moped and motorcycle",
+        "body": "<div class=\"govspeak\">\n<p>The standard sets out what you must be able to do and what you must know and understand to be a safe and responsible car and light van driver. The syllabus sets out a way of teaching people that knowledge and those skills.</p>\n</div>",
+        "documents": [
+          "5e5dc29b-7631-11e4-a3cb-005056011aef",
+          "5e5ddbe8-7631-11e4-a3cb-005056011aef"
+        ]
+      },
+      {
+        "title": "Lorry",
+        "body": "<div class=\"govspeak\">\n<p>The standard sets out what you must be able to do and what you must know and understand to be a safe and responsible lorry driver.</p>\n</div>",
+        "documents": [
+          "5e5ddb9c-7631-11e4-a3cb-005056011aef"
+        ]
+      },
+      {
+        "title": "Bus and coach",
+        "body": "<div class=\"govspeak\">\n<p>The standard sets out what you must be able to do and what you must know and understand to be a safe and responsible bus and coach driver.</p>\n</div>",
+        "documents": [
+          "5e5ddaac-7631-11e4-a3cb-005056011aef"
+        ]
+      },
+      {
+        "title": "Driver and rider trainer",
+        "body": "<div class=\"govspeak\">\n<p>The standard sets out what you must be able to do and what you must know and understand to provide training to drivers and riders.</p>\n</div>",
+        "documents": [
+          "5e5ddcc9-7631-11e4-a3cb-005056011aef"
+        ]
+      },
+      {
+        "title": "Developed driving competence",
+        "body": "<div class=\"govspeak\">\n<p>The standard sets out what you must be able to do and what you must know and understand to show developed driving competence.</p>\n</div>",
+        "documents": [
+          "5e5dc159-7631-11e4-a3cb-005056011aef"
+        ]
+      }
+    ],
+    "first_public_at": "2016-02-29T09:24:10.000+00:00",
+    "tags": {
+      "browse_pages": [],
+      "topics": [],
+      "policies": []
+    },
+    "government": {
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "current": false
+    },
+    "emphasised_organisations": ["d39237a5-678b-4bb5-a372-eb2cb036933d"],
+    "political": false
+  },
+  "links": {
+    "documents": [
+      {
+        "content_id": "5e5dd324-7631-11e4-a3cb-005056011aef",
+        "title": "Car and light van driver competence framework",
+        "base_path": "/government/publications/car-and-light-van-driver-competence-framework",
+        "description": "The research, statistics and professional opinions which form the basis of the 'National standard for driving cars and light vans'.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/car-and-light-van-driver-competence-framework",
+        "web_url": "https://www.gov.uk/government/publications/car-and-light-van-driver-competence-framework",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5e5ddbe8-7631-11e4-a3cb-005056011aef",
+        "title": "Moped and motorcycle rider competence framework",
+        "base_path": "/government/publications/competence-framework-for-moped-and-motorcycle-riders",
+        "description": "The research, statistics and professional opinions which form the basis of the 'National standard for riding mopeds and motorcycles'.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/competence-framework-for-moped-and-motorcycle-riders",
+        "web_url": "https://www.gov.uk/government/publications/competence-framework-for-moped-and-motorcycle-riders",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5e5dc201-7631-11e4-a3cb-005056011aef",
+        "title": "Car and light van driving syllabus",
+        "base_path": "/government/publications/car-and-small-van-driving-syllabus",
+        "description": "A way of teaching people the skills, knowledge and understanding they need to be a safe and responsible driver.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/car-and-small-van-driving-syllabus",
+        "web_url": "https://www.gov.uk/government/publications/car-and-small-van-driving-syllabus",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5e5dc159-7631-11e4-a3cb-005056011aef",
+        "title": "National standard for developed driving competence",
+        "base_path": "/government/publications/national-standard-for-developed-driving-competence",
+        "description": "What you must be able to do and what you must know and understand to show developed driving competence.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/national-standard-for-developed-driving-competence",
+        "web_url": "https://www.gov.uk/government/publications/national-standard-for-developed-driving-competence",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5e5ddcc9-7631-11e4-a3cb-005056011aef",
+        "title": "National standard for driver and rider training",
+        "base_path": "/government/publications/national-standard-for-driver-and-rider-training",
+        "description": "What you must be able to do and what you must know and understand to provide training to drivers and riders.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/national-standard-for-driver-and-rider-training",
+        "web_url": "https://www.gov.uk/government/publications/national-standard-for-driver-and-rider-training",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5e5ddaac-7631-11e4-a3cb-005056011aef",
+        "title": "National standard for driving buses and coaches",
+        "base_path": "/government/publications/national-standard-for-driving-buses-and-coaches",
+        "description": "What you must be able to do and what you must know and understand to be a safe and responsible bus or coach driver.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/national-standard-for-driving-buses-and-coaches",
+        "web_url": "https://www.gov.uk/government/publications/national-standard-for-driving-buses-and-coaches",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5e5ddb9c-7631-11e4-a3cb-005056011aef",
+        "title": "National standard for driving lorries",
+        "base_path": "/government/publications/national-standard-for-driving-lorries",
+        "description": "What you must be able to do and what you must know and understand to be a safe and responsible lorry driver.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/national-standard-for-driving-lorries",
+        "web_url": "https://www.gov.uk/government/publications/national-standard-for-driving-lorries",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5e5dc29b-7631-11e4-a3cb-005056011aef",
+        "title": "National standard for riding mopeds and motorcycles",
+        "base_path": "/government/publications/national-standard-for-riding-mopeds-and-motorcycles",
+        "description": "What you must be able to do and what you must know and understand to be a safe and responsible moped or motorcycle rider.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/national-standard-for-riding-mopeds-and-motorcycles",
+        "web_url": "https://www.gov.uk/government/publications/national-standard-for-riding-mopeds-and-motorcycles",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5e5dc1ab-7631-11e4-a3cb-005056011aef",
+        "title": "National standard for driving cars and light vans",
+        "base_path": "/government/publications/national-standard-for-driving-cars-and-light-vans",
+        "description": "What you must be able to do and what you must know and understand to be a safe and responsible car driver.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/national-standard-for-driving-cars-and-light-vans",
+        "web_url": "https://www.gov.uk/government/publications/national-standard-for-driving-cars-and-light-vans",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "d39237a5-678b-4bb5-a372-eb2cb036933d",
+        "title": "Driver and Vehicle Standards Agency",
+        "base_path": "/government/organisations/driver-and-vehicle-standards-agency",
+        "api_url": "https://www.gov.uk/api/organisations/driver-and-vehicle-standards-agency",
+        "web_url": "https://www.gov.uk/government/organisations/driver-and-vehicle-standards-agency",
+        "locale": "en",
+        "analytics_identifier": "EA570"
+      }
+    ],
+    "policy_areas": [
+      {
+        "content_id": "8034be95-4ac2-4fff-93c5-e7514ed9504a",
+        "title": "Tax and revenue",
+        "base_path": "/government/topics/tax-and-revenue",
+        "api_url": "https://www.gov.uk/api/content/government/world/topics/tax-and-revenue",
+        "web_url": "https://www.gov.uk/government/world/topics/tax-and-revenue",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/document_collection/frontend/examples/document_collection.json
+++ b/formats/document_collection/frontend/examples/document_collection.json
@@ -68,8 +68,12 @@
       "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
       "current": false
     },
+    "political": true,
     "emphasised_organisations": ["d39237a5-678b-4bb5-a372-eb2cb036933d"],
-    "political": false
+    "withdrawn_notice": {
+      "explanation": "<div class=\"govspeak\"><p>This information is now out of date.</p></div>",
+      "withdrawn_at": "2016-03-01T13:05:30Z"
+    }
   },
   "links": {
     "documents": [

--- a/formats/document_collection/frontend/examples/document_collection_with_body.json
+++ b/formats/document_collection/frontend/examples/document_collection_with_body.json
@@ -1,0 +1,136 @@
+{
+  "content_id": "5eb851bc-7631-11e4-a3cb-005056011aef",
+  "base_path": "/government/collections/financial-sanctions-regime-specific-consolidated-lists-and-releases",
+  "description": "This document series contains details of all regimes currently subject to financial sanctions.",
+  "public_updated_at": "2016-02-08T17:36:26.000+00:00",
+  "title": "Financial sanctions: Regime-specific lists and releases",
+  "updated_at": "2016-05-17T12:21:21.185Z",
+  "schema_name": "document_collection",
+  "document_type": "document_collection",
+  "format": "document_collection",
+  "locale": "en",
+  "details": {
+    "body": "<div class=\"govspeak\"><p>Each regime page provides a current list of asset freeze targets designated by the United Nations (UN), European Union and United Kingdom, under legislation relating to current financial sanctions regimes.</p>\n\n<h2 id=\"consolidated-list\">Consolidated list</h2>\n\n<p>The <a rel=\"external\" href=\"https://www.gov.uk/government/publications/financial-sanctions-consolidated-list-of-targets\">current consolidated list of asset freeze targets</a> designated by the United Nations, European Union and United Kingdom, under legislation relating to current financial sanctions regimes, is also available.</p>\n\n<h3 id=\"subscribing-to-financial-sanctions-mailing-list\">Subscribing to financial sanctions mailing list</h3>\n\n<p><a rel=\"external\" href=\"http://engage.hm-treasury.gov.uk/fin-sanc-subscribe/\">Subscribe to our free e-mail alerts</a> for information on updates to the Treasury’s consolidated list of targets of financial sanctions in effect in the UK.</p>\n\n<p>Enquiries relating to asset freezing or other financial sanctions should be submitted to HM Treasury either by email to <a href=\"mailto:financialsanctions@hmtreasury.gsi.gov.uk\">financialsanctions@hmtreasury.gsi.gov.uk</a> or by post to Financial Sanctions, HM Treasury, 1 Horse Guards Road, London SW1A 2HQ.</p>\n\n<h3 id=\"further-information\">Further information</h3>\n\n<p>For further information on financial sanctions see the <a href=\"https://www.gov.uk/sanctions-embargoes-and-restrictions\">guide to sanctions, embargoes and restrictions.</a></p>\n</div>",
+    "collection_groups": [
+      {
+        "title": "Documents",
+        "documents": [
+          "841f225a-80b2-44d5-ba13-a36c7a82b859",
+          "5e2fd762-7631-11e4-a3cb-005056011aef",
+          "5e2fd5e9-7631-11e4-a3cb-005056011aef"
+        ]
+      }
+    ],
+    "first_public_at": "2013-10-11T17:12:00+01:00",
+    "change_history": [
+      {
+        "public_timestamp": "2016-02-08T17:36:26+00:00",
+        "note": "Liberia removed - Council Regulation (EC) No 872/2004 imposing financial sanctions against Liberia has been repealed with effect from 6 October 2015."
+      },
+      {
+        "public_timestamp": "2016-01-22T12:36:47+00:00",
+        "note": "Updated to add - Financial Sanctions, UK freezing orders"
+      },
+      {
+        "public_timestamp": "2014-12-23T10:17:01+00:00",
+        "note": "Updated to include Yemen in collection"
+      },
+      {
+        "public_timestamp": "2014-07-15T16:24:28+01:00",
+        "note": "Updated to reflect latest HM Treasury notices, 15/07/14 Sudan (Reg 747/2014) and 15/07/14 South Sudan (Reg 748/2014)"
+      },
+      {
+        "public_timestamp": "2014-03-18T12:36:37+00:00",
+        "note": "added 'Financial sanctions, Ukraine (Sovereignty and Territorial Integrity)' to collection"
+      },
+      {
+        "public_timestamp": "2014-03-12T15:33:27+00:00",
+        "note": "added Central African Republic"
+      },
+      {
+        "public_timestamp": "2014-02-21T16:59:49+00:00",
+        "note": "added publication 'Financial sanctions, Ukraine'"
+      },
+      {
+        "public_timestamp": "2013-10-11T17:12:00+01:00",
+        "note": "First published."
+      }
+    ],
+    "tags": {
+      "browse_pages": [],
+      "topics": [],
+      "policies": []
+    },
+    "government": {
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "current": false
+    },
+    "political": false,
+    "emphasised_organisations": ["1994e0e4-bd19-4966-bbd7-f293d6e90a6b"]
+  },
+  "links": {
+    "documents": [
+      {
+        "content_id": "5e2fd5e9-7631-11e4-a3cb-005056011aef",
+        "title": "Financial sanctions, Somalia",
+        "base_path": "/government/publications/financial-sanctions-somalia",
+        "description": "Somalia is currently subject to financial sanctions. This document contains the current list of designated persons.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/financial-sanctions-somalia",
+        "web_url": "https://www.gov.uk/government/publications/financial-sanctions-somalia",
+        "locale": "en",
+        "document_type": "guidance"
+      },
+      {
+        "content_id": "5e2fd762-7631-11e4-a3cb-005056011aef",
+        "title": "Current list of designated persons, terrorism and terrorist financing",
+        "base_path": "/government/publications/current-list-of-designated-persons-terrorism-and-terrorist-financing",
+        "description": "This document provides a current list of designated persons currently subject to financial sanctions for believed involvement in terrorist activity.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/current-list-of-designated-persons-terrorism-and-terrorist-financing",
+        "web_url": "https://www.gov.uk/government/publications/current-list-of-designated-persons-terrorism-and-terrorist-financing",
+        "locale": "en",
+        "document_type": "guidance"
+      },
+      {
+        "content_id": "841f225a-80b2-44d5-ba13-a36c7a82b859",
+        "title": "Financial Sanctions, UK freezing orders",
+        "base_path": "/government/publications/financial-sanctions-uk-freezing-orders",
+        "description": "Somalia is currently subject to financial sanctions. This document contains the current list of designated persons.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/financial-sanctions-uk-freezing-orders",
+        "web_url": "https://www.gov.uk/government/publications/financial-sanctions-uk-freezing-orders",
+        "locale": "en",
+        "document_type": "guidance"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "1994e0e4-bd19-4966-bbd7-f293d6e90a6b",
+        "title": "HM Treasury",
+        "base_path": "/government/organisations/hm-treasury",
+        "api_url": "https://www.gov.uk/api/organisations/hm-treasury",
+        "web_url": "https://www.gov.uk/government/organisations/hm-treasury",
+        "locale": "en",
+        "analytics_identifier": "D15"
+      },
+      {
+        "content_id": "e82999a0-79f0-4c77-a8f1-39135e7a123c",
+        "title": "Office of Financial Sanctions Implementation",
+        "base_path": "/government/organisations/office-of-financial-sanctions-implementation",
+        "api_url": "https://www.gov.uk/api/organisations/office-of-financial-sanctions-implementation",
+        "web_url": "https://www.gov.uk/government/organisations/office-of-financial-sanctions-implementation",
+        "locale": "en",
+        "analytics_identifier": "OT1187"
+      }
+    ],
+    "policy_areas": [
+      {
+        "content_id": "8034be95-4ac2-4fff-93c5-e7514ed9504a",
+        "title": "Tax and revenue",
+        "base_path": "/government/topics/tax-and-revenue",
+        "api_url": "https://www.gov.uk/api/content/government/world/topics/tax-and-revenue",
+        "web_url": "https://www.gov.uk/government/world/topics/tax-and-revenue",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/document_collection/publisher/details.json
+++ b/formats/document_collection/publisher/details.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "first_public_at",
+    "collection_groups",
+    "government",
+    "political"
+  ],
+  "properties": {
+    "body": {
+      "type": "string"
+    },
+    "collection_groups": {
+      "description": "The ordered list of collection groups",
+      "type": "array",
+      "items": {
+        "description": "Collection group",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "documents"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "documents": {
+            "description": "An ordered list of documents in this collection group",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/guid"
+            }
+          }
+        }
+      }
+    },
+    "first_public_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "tags": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "government": {
+      "$ref": "#/definitions/government"
+    },
+    "political": {
+      "$ref": "#/definitions/political"
+    },
+    "change_history": {
+      "$ref": "#/definitions/change_history"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    }
+  }
+}

--- a/formats/document_collection/publisher/links.json
+++ b/formats/document_collection/publisher/links.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "documents",
+    "organisations"
+  ],
+  "properties": {
+    "documents": {
+      "description": "An unordered list of all documents in this collection",
+      "$ref": "#/definitions/guid_list"
+    },
+    "topical_events": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}

--- a/formats/publication/frontend/examples/political_publication.json
+++ b/formats/publication/frontend/examples/political_publication.json
@@ -71,16 +71,6 @@
         "locale": "en"
       }
     ],
-    "document_collections": [
-      {
-        "content_id": "5eb67fbf-7631-11e4-a3cb-005056011aef",
-        "title": "Climate Change Agreements guidance",
-        "base_path": "/government/collections/climate-change-agreements-guidance",
-        "api_url": "https://www.gov.uk/api/content/government/collections/climate-change-agreements-guidance",
-        "web_url": "https://www.gov.uk/government/collections/climate-change-agreements-guidance",
-        "locale": "en"
-      }
-    ],
     "policies": [
       {
         "content_id": "5d2b69f0-7631-11e4-a3cb-005056011aef",


### PR DESCRIPTION
Details:
* Body is optional for collections
* First public at is required like other editioned content
* A document collection must have an ordered list of groups
  * Each group must have a title and an ordered list of documents, the group may have some body copy
* Collections can be political
* Collections can be withdrawn
* Include tags – these are not really used except for emails, see #292 for why they weren't removed from other formats

Links:
* Add documents GUID list, make this a required field
* Whitehall marks "policy areas" as being required in the editor, but content schemas say this is "largely deprecated", so it has been intentionally left out. (Policy areas are included by base links)
* Add topical events
* Lead organisations are also required, we've changed the pattern for organisations to "organisations" in links and emphasised organisations in details – there isn't a pattern yet for which bits must be required
to match current behaviour.

Include examples based on:
https://www.gov.uk/government/collections/national-driving-and-riding-standards
https://www.gov.uk/government/collections/financial-sanctions-regime-specific-consolidated-lists-and-releases

https://trello.com/c/PMeMQb5E/410-11-document-collection-migration-mvp-content-schema-examples-and-front-end-work