### PR TITLE
Remove unused fields for service manual guide

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -198,18 +198,6 @@
         "body": {
           "type": "string"
         },
-        "content_owner": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "withdrawn_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -210,18 +210,6 @@
             }
           }
         },
-        "related_discussion": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "header_links": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -17,18 +17,6 @@
         "body": {
           "type": "string"
         },
-        "content_owner": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "withdrawn_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -29,18 +29,6 @@
             }
           }
         },
-        "related_discussion": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "header_links": {
           "type": "array",
           "items": {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -17,18 +17,6 @@
         "body": {
           "type": "string"
         },
-        "content_owner": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "withdrawn_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -29,18 +29,6 @@
             }
           }
         },
-        "related_discussion": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "href": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
         "header_links": {
           "type": "array",
           "items": {

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide.json
@@ -5,10 +5,6 @@
   "locale": "en",
   "details": {
     "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "related_discussion": {
-      "title": "Design community on hackpad",
-      "href": "https://designpatterns.hackpad.com/"
-    },
     "header_links": [
       {
         "title": "What is it, why it works and how to do it",

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
@@ -5,10 +5,6 @@
   "locale": "en",
   "details": {
     "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "related_discussion": {
-      "title": "Design community on hackpad",
-      "href": "https://designpatterns.hackpad.com/"
-    },
     "header_links": [
       {
         "title": "What is it, why it works and how to do it",

--- a/formats/service_manual_guide/frontend/examples/with_change_history.json
+++ b/formats/service_manual_guide/frontend/examples/with_change_history.json
@@ -5,10 +5,6 @@
   "locale": "en",
   "details": {
     "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "related_discussion": {
-      "title": "Design community on hackpad",
-      "href": "https://designpatterns.hackpad.com/"
-    },
     "header_links": [
       {
         "title": "What is it, why it works and how to do it",

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -25,18 +25,6 @@
         }
       }
     },
-    "related_discussion": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "href": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
     "header_links": {
       "type": "array",
       "items": {

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -13,18 +13,6 @@
     "body": {
       "type": "string"
     },
-    "content_owner": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "href": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
     "withdrawn_notice": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
@@ -6,10 +6,6 @@
   "locale": "en",
   "details" : {
     "body" : "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "related_discussion" : {
-      "title" : "Design community on hackpad",
-      "href" : "https://designpatterns.hackpad.com/"
-    },
     "header_links" : [
       { "title" : "What is it, why it works and how to do it", "href" : "#what-is-it-why-it-works-and-how-to-do-it" }
     ]
@@ -23,5 +19,4 @@
       "type": "exact"
     }
   ]
-
 }

--- a/formats/service_manual_guide/publisher_v2/examples/with_change_history.json
+++ b/formats/service_manual_guide/publisher_v2/examples/with_change_history.json
@@ -6,10 +6,6 @@
   "locale": "en",
   "details" : {
     "body" : "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "related_discussion" : {
-      "title" : "Design community on hackpad",
-      "href" : "https://designpatterns.hackpad.com/"
-    },
     "header_links" : [
       { "title" : "What is it, why it works and how to do it", "href" : "#what-is-it-why-it-works-and-how-to-do-it" }
     ],


### PR DESCRIPTION
Removes `related_discussion` which is no longer used and `content_owner` which has been moved to the links.

Related frontend PR: https://github.com/alphagov/service-manual-frontend/pull/20