### PR TITLE
Make lead_organisations optional

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -76,9 +76,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "lead_organisations": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -91,9 +91,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -9,9 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -76,9 +76,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "document_collections": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -90,9 +90,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "document_collections": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -9,9 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "document_collections": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -76,9 +76,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "document_collections": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -78,9 +78,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "document_collections": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -9,9 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "lead_organisations"
-      ],
       "properties": {
         "document_collections": {
           "$ref": "#/definitions/guid_list"

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "lead_organisations"
-  ],
   "properties": {
     "lead_organisations": {
       "description": "DEPRECATED: this field is being replaced by the `emphasised_organisations` field in the details hash.",

--- a/formats/detailed_guide/publisher/links.json
+++ b/formats/detailed_guide/publisher/links.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "lead_organisations"
-  ],
   "properties": {
     "document_collections": {
       "$ref": "#/definitions/guid_list"

--- a/formats/publication/publisher/links.json
+++ b/formats/publication/publisher/links.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "lead_organisations"
-  ],
   "properties": {
     "document_collections": {
       "$ref": "#/definitions/guid_list"


### PR DESCRIPTION
We're getting rid of lead and supporting organisations.
This commit is to make sure that they're optional in our schemas.

Another piece of work to completely get rid of them will come as soon as publishing applications will have been updated to stop publishing those types of organisation.

ticket: https://trello.com/c/us3MI1n9/602-fix-organisation-tagging