### PR TITLE
Add toplevel withdrawn notice to document collection example

### DIFF
--- a/formats/document_collection/frontend/examples/document_collection.json
+++ b/formats/document_collection/frontend/examples/document_collection.json
@@ -9,6 +9,10 @@
   "document_type": "document_collection",
   "format": "document_collection",
   "locale": "en",
+  "withdrawn_notice": {
+    "explanation": "<div class=\"govspeak\"><p>This information is now out of date.</p></div>",
+    "withdrawn_at": "2016-03-01T13:05:30Z"
+  },
   "details": {
     "collection_groups": [
       {


### PR DESCRIPTION
Any format can be withdrawn and the withdrawn_notice is now a top level property. It's duplicated in the details hash for now to continue to support frontend expectations but it should also be present in examples metadata.