### PR TITLE
Make public_updated_at an optional field for all formats

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -513,7 +513,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -634,7 +633,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -455,7 +455,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -572,7 +571,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -429,7 +429,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -550,7 +549,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -387,7 +387,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -504,7 +503,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -616,7 +616,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -737,7 +736,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -571,7 +571,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -688,7 +687,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -505,7 +505,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -626,7 +625,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -454,7 +454,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -571,7 +570,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -513,7 +513,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -634,7 +633,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -460,7 +460,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -577,7 +576,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -490,7 +490,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -611,7 +610,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -448,7 +448,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -565,7 +564,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -458,7 +458,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -579,7 +578,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -405,7 +405,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -522,7 +521,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -439,7 +439,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -560,7 +559,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -397,7 +397,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -514,7 +513,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -443,7 +443,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -564,7 +563,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -401,7 +401,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -518,7 +517,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -427,7 +427,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -548,7 +547,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -385,7 +385,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -502,7 +501,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -430,7 +430,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -551,7 +550,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -382,7 +382,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -499,7 +498,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -432,7 +432,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -553,7 +552,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -390,7 +390,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -507,7 +506,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -579,7 +579,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -700,7 +699,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -528,7 +528,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -645,7 +644,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -534,7 +534,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -655,7 +654,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -492,7 +492,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -609,7 +608,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -524,7 +524,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -645,7 +644,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -482,7 +482,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -599,7 +598,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -441,7 +441,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -562,7 +561,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -395,7 +395,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -512,7 +511,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -466,7 +466,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -587,7 +586,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -408,7 +408,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -525,7 +524,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -520,7 +520,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -641,7 +640,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -472,7 +472,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -589,7 +588,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -473,7 +473,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -594,7 +593,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -425,7 +425,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -542,7 +541,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -501,7 +501,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -621,7 +620,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -459,7 +459,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -575,7 +574,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -562,7 +562,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -683,7 +682,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -501,7 +501,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -618,7 +617,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -503,7 +503,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -624,7 +623,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -442,7 +442,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -559,7 +558,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -470,7 +470,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -591,7 +590,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -424,7 +424,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -541,7 +540,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -470,7 +470,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -591,7 +590,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -420,7 +420,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -537,7 +536,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -1397,7 +1397,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -1535,7 +1534,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1355,7 +1355,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -1472,7 +1471,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -458,7 +458,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -579,7 +578,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -412,7 +412,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -529,7 +528,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -428,7 +428,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -549,7 +548,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -386,7 +386,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -503,7 +502,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -422,7 +422,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -543,7 +542,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -380,7 +380,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -497,7 +496,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -468,7 +468,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -589,7 +588,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -418,7 +418,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -535,7 +534,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -431,7 +431,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -552,7 +551,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -386,7 +386,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -503,7 +502,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -508,7 +508,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -629,7 +628,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -463,7 +463,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -580,7 +579,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -477,7 +477,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -598,7 +597,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -432,7 +432,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -549,7 +548,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -442,7 +442,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -563,7 +562,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -400,7 +400,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -517,7 +516,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -8,7 +8,6 @@
     "title",
     "details",
     "locale",
-    "public_updated_at",
     "content_id",
     "document_type",
     "schema_name"

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -424,7 +424,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],
@@ -545,7 +544,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "content_id",
         "update_type"
       ],

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -382,7 +382,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false
@@ -499,7 +498,6 @@
         "rendering_app",
         "locale",
         "routes",
-        "public_updated_at",
         "base_path"
       ],
       "additionalProperties": false

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -8,8 +8,7 @@
     "publishing_app",
     "rendering_app",
     "locale",
-    "routes",
-    "public_updated_at"
+    "routes"
   ],
   "properties": {
     "base_path": {


### PR DESCRIPTION
If the public_updated_at field is not provided when content
is submitted to the publishing api then it will default it
to Time.now for major updates and raise an error for minor
updates. We should never publish something for the first
time with a minor update so this field is always present.

Because this piece of workflow is now a part of the
publishing api it means our publishing apps should no
longer be required to send this field and they can
optionally leave it out and still pass their schema tests.

This field can still be sent (optionally) if the
publishing app wishes to set a custom public_updated_at.
This is a requirement for some of our publishing apps,
e.g. Whitehall.