### PR TITLE
Restrict usage of deprecated `lead_organisations`, remove `supporting_organisations`

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -79,9 +79,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -82,9 +82,6 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
-        "supporting_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -95,10 +95,6 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
-        "supporting_organisations": {
-          "description": "DEPRECATED: this field will be removed.",
-          "$ref": "#/definitions/guid_list"
-        },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -92,10 +92,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -13,10 +13,6 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
-        "supporting_organisations": {
-          "description": "DEPRECATED: this field will be removed.",
-          "$ref": "#/definitions/guid_list"
-        },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -10,10 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -40,10 +40,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -94,9 +94,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -227,10 +227,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -29,10 +29,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -100,9 +100,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -116,10 +116,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -101,9 +101,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -124,10 +124,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -37,10 +37,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -101,10 +101,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -100,9 +100,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -69,10 +69,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -37,10 +37,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -50,10 +50,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -54,10 +54,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -38,10 +38,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -97,9 +97,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -41,10 +41,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -32,10 +32,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -43,10 +43,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -100,9 +100,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -190,10 +190,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -145,10 +145,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -135,10 +135,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -95,9 +95,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -52,10 +52,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -30,10 +30,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -103,9 +103,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -77,10 +77,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -42,10 +42,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -97,9 +97,6 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -131,10 +131,6 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -32,10 +32,6 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -97,9 +97,6 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -84,10 +84,6 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -32,10 +32,6 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -90,9 +90,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -113,10 +113,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -89,6 +89,9 @@
         "working_groups": {
           "$ref": "#/definitions/frontend_links"
         },
+        "lead_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -108,9 +111,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "lead_organisations": {
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -148,6 +148,10 @@
         "working_groups": {
           "$ref": "#/definitions/guid_list"
         },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
         "related": {
           "$ref": "#/definitions/guid_list"
         },
@@ -171,10 +175,6 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -20,6 +20,10 @@
         "working_groups": {
           "$ref": "#/definitions/guid_list"
         },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
         "related": {
           "$ref": "#/definitions/guid_list"
         },
@@ -43,10 +47,6 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -109,9 +109,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -82,9 +82,6 @@
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
         },
-        "supporting_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "ministers": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -82,10 +82,6 @@
         "document_collections": {
           "$ref": "#/definitions/guid_list"
         },
-        "supporting_organisations": {
-          "description": "DEPRECATED: this field is being removed.",
-          "$ref": "#/definitions/guid_list"
-        },
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -114,10 +114,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -13,10 +13,6 @@
         "document_collections": {
           "$ref": "#/definitions/guid_list"
         },
-        "supporting_organisations": {
-          "description": "DEPRECATED: this field is being removed.",
-          "$ref": "#/definitions/guid_list"
-        },
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -45,10 +45,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -94,9 +94,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -76,10 +76,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -30,10 +30,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -97,9 +97,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -81,10 +81,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -34,10 +34,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -56,10 +56,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -98,9 +98,6 @@
         "topics": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -73,10 +73,6 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -34,10 +34,6 @@
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -39,10 +39,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -33,10 +33,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -97,9 +97,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -79,10 +79,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -34,10 +34,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -94,9 +94,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -42,10 +42,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -29,10 +29,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -94,9 +94,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -119,10 +119,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -29,10 +29,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -94,9 +94,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -88,10 +88,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -29,10 +29,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -53,10 +53,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -91,9 +91,6 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "lead_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -35,10 +35,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -26,10 +26,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/formats/base_links.json
+++ b/formats/base_links.json
@@ -19,10 +19,6 @@
       "description": "All organisations linked to this content item. This should include lead organisations.",
       "$ref": "#/definitions/guid_list"
     },
-    "lead_organisations": {
-      "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-      "$ref": "#/definitions/guid_list"
-    },
     "parent": {
       "description": "The parent content item.",
       "$ref": "#/definitions/guid_list",

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -40,16 +40,6 @@
     }
   },
   "links": {
-    "lead_organisations": [
-      {
-        "content_id": "dbeaa22b-fb0c-49b0-b44e-0ca6cb52b381",
-        "title": "Department for Work and Pensions",
-        "base_path": "/government/organisations/department-for-work-pensions",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-pensions",
-        "web_url": "https://www.gov.uk/government/organisations/department-for-work-pensions",
-        "locale": "en"
-      }
-    ],
     "organisations": [
       {
         "content_id": "dbeaa22b-fb0c-49b0-b44e-0ca6cb52b381",

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -60,7 +60,6 @@
         "locale": "en"
       }
     ],
-    "supporting_organisations": [],
     "world_locations": [],
     "worldwide_organisations": [],
     "available_translations": [

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -21,17 +21,6 @@
   },
   "format": "case_study",
   "links": {
-    "lead_organisations": [
-      {
-        "content_id": "8b19c238-54e3-4e27-b0d7-60f8e2a677c9",
-        "title": "Department for International Development",
-        "base_path": "/government/organisations/department-for-international-development",
-        "api_url": "https://www.gov.uk/api/organisations/department-for-international-development",
-        "web_url": "https://www.gov.uk/government/organisations/department-for-international-development",
-        "locale": "en",
-        "analytics_identifier": "L2"
-      }
-    ],
     "organisations": [
       {
         "content_id": "8b19c238-54e3-4e27-b0d7-60f8e2a677c9",

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -33,7 +33,6 @@
       }
     ],
     "related_policies": [],
-    "supporting_organisations": [],
     "world_locations": [
       {
         "content_id": "456af51f-5fd3-4855-8a33-52cb32ff9985",

--- a/formats/case_study/frontend/examples/translated.json
+++ b/formats/case_study/frontend/examples/translated.json
@@ -63,16 +63,6 @@
         "web_url": "https://www.gov.uk/government/organisations/uk-trade-investment"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "8449fbe1-bffe-46cf-a141-07df52c530b7",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/uk-trade-investment",
-        "base_path": "/government/organisations/uk-trade-investment",
-        "locale": "en",
-        "title": "UK Trade & Investment",
-        "web_url": "https://www.gov.uk/government/organisations/uk-trade-investment"
-      }
-    ],
     "supporting_organisations": [
       {
         "content_id": "4e5d0f10-65cb-4036-8a18-123240e3698a",

--- a/formats/case_study/frontend/examples/translated.json
+++ b/formats/case_study/frontend/examples/translated.json
@@ -63,16 +63,6 @@
         "web_url": "https://www.gov.uk/government/organisations/uk-trade-investment"
       }
     ],
-    "supporting_organisations": [
-      {
-        "content_id": "4e5d0f10-65cb-4036-8a18-123240e3698a",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/foreign-commonwealth-office",
-        "base_path": "/government/organisations/foreign-commonwealth-office",
-        "locale": "en",
-        "title": "Foreign & Commonwealth Office",
-        "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office"
-      }
-    ],
     "world_locations": [
       {
         "content_id": "1a47d8eb-36e8-4a9e-8a05-ca33184c2f86",

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -6,10 +6,6 @@
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },
-    "supporting_organisations": {
-      "description": "DEPRECATED: this field will be removed.",
-      "$ref": "#/definitions/guid_list"
-    },
     "world_locations": {
       "$ref": "#/definitions/guid_list"
     },

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -3,10 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "lead_organisations": {
-      "description": "DEPRECATED: this field is being replaced by the `emphasised_organisations` field in the details hash.",
-      "$ref": "#/definitions/guid_list"
-    },
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },

--- a/formats/case_study/publisher_v2/examples/case_study_links.json
+++ b/formats/case_study/publisher_v2/examples/case_study_links.json
@@ -4,7 +4,6 @@
       "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
     ],
     "related_policies": [],
-    "supporting_organisations": [],
     "world_locations": [
       "456af51f-5fd3-4855-8a33-52cb32ff9985"
     ],

--- a/formats/case_study/publisher_v2/examples/case_study_links.json
+++ b/formats/case_study/publisher_v2/examples/case_study_links.json
@@ -3,9 +3,6 @@
     "organisations": [
       "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
     ],
-    "lead_organisations": [
-      "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
-    ],
     "related_policies": [],
     "supporting_organisations": [],
     "world_locations": [

--- a/formats/detailed_guide/frontend/examples/detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/detailed_guide.json
@@ -51,17 +51,6 @@
         "analytics_identifier": "D25"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
-        "title": "HM Revenue & Customs",
-        "base_path": "/government/organisations/hm-revenue-customs",
-        "api_url": "https://www.gov.uk/api/organisations/hm-revenue-customs",
-        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
-        "locale": "en",
-        "analytics_identifier": "D25"
-      }
-    ],
     "policy_areas": [
       {
         "content_id": "8034be95-4ac2-4fff-93c5-e7514ed9504a",

--- a/formats/detailed_guide/frontend/examples/national_applicability_alternative_url_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/national_applicability_alternative_url_detailed_guide.json
@@ -61,17 +61,6 @@
         "analytics_identifier": "OT1051"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "49e09fa7-f65b-49d6-b4ab-0ca82a548e93",
-        "title": "British Cattle Movement Service",
-        "base_path": "/government/organisations/british-cattle-movement-service",
-        "api_url": "https://www.gov.uk/api/organisations/british-cattle-movement-service",
-        "web_url": "https://www.gov.uk/government/organisations/british-cattle-movement-service",
-        "locale": "en",
-        "analytics_identifier": "OT1051"
-      }
-    ],
     "parent": []
   }
 }

--- a/formats/detailed_guide/frontend/examples/national_applicability_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/national_applicability_detailed_guide.json
@@ -49,17 +49,6 @@
     }
   },
   "links": {
-    "lead_organisations": [
-      {
-        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
-        "title": "Department for Communities and Local Government",
-        "base_path": "/government/organisations/department-for-communities-and-local-government",
-        "api_url": "https://www.gov.uk/api/organisations/department-for-communities-and-local-government",
-        "web_url": "https://www.gov.uk/government/organisations/department-for-communities-and-local-government",
-        "locale": "en",
-        "analytics_identifier": "D4"
-      }
-    ],
     "organisations": [
       {
         "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",

--- a/formats/detailed_guide/frontend/examples/political_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/political_detailed_guide.json
@@ -37,17 +37,6 @@
         "analytics_identifier": "D11"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "d65d4203-01f5-4920-a3b1-f614bfd8e83e",
-        "title": "Department of Energy & Climate Change",
-        "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
-        "api_url": "https://www.gov.uk/api/organisations/department-of-energy-climate-change",
-        "web_url": "https://www.gov.uk/government/organisations/department-of-energy-climate-change",
-        "locale": "en",
-        "analytics_identifier": "D11"
-      }
-    ],
     "parent": [
       {
         "content_id": "0d59f5e7-a230-4bac-b02c-624a59a34dab",

--- a/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
@@ -59,17 +59,6 @@
         "locale": "en"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "9adfc4ed-9f6c-4976-a6d8-18d34356367c",
-        "title": "Foreign & Commonwealth Office",
-        "base_path": "/government/organisations/foreign-commonwealth-office",
-        "api_url": "https://www.gov.uk/api/organisations/foreign-commonwealth-office",
-        "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
-        "locale": "en",
-        "analytics_identifier": "D13"
-      }
-    ],
     "organisations": [
       {
         "content_id": "9adfc4ed-9f6c-4976-a6d8-18d34356367c",

--- a/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
@@ -54,17 +54,6 @@
         "locale": "en",
         "analytics_identifier": "D7"
       }
-    ],
-    "lead_organisations": [
-      {
-        "content_id": "de4e9dc6-cca4-43af-a594-682023b84d6c",
-        "title": "Department for Environment, Food & Rural Affairs",
-        "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
-        "api_url": "https://www.gov.uk/api/organisations/department-for-environment-food-rural-affairs",
-        "web_url": "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",
-        "locale": "en",
-        "analytics_identifier": "D7"
-      }
     ]
   }
 }

--- a/formats/policy/frontend/examples/minimal_policy_area.json
+++ b/formats/policy/frontend/examples/minimal_policy_area.json
@@ -19,7 +19,6 @@
   },
   "links": {
     "organisations": [],
-    "lead_organisations": [],
     "people": [],
     "working_groups": [],
     "related": [],

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -68,16 +68,6 @@
         "locale": "en"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "a4759607-4fd8-4cf0-9d56-af9d14a71162",
-        "title": "Department for Work and Pensions",
-        "base_path": "/government/organisations/department-for-work-and-pensions",
-        "api_url": "https://www.gov.uk/api/organisations/department-for-work-and-pensions",
-        "web_url": "https://www.gov.uk/government/organisations/department-for-work-and-pensions",
-        "locale": "en"
-      }
-    ],
     "people": [],
     "working_groups": [],
     "related": [],

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -67,16 +67,6 @@
         "locale": "en"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "9417d532-a080-4856-9a0f-08b1d9d78c98",
-        "title": "Department for Work and Pensions",
-        "base_path": "/government/organisations/department-for-work-and-pensions",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-and-pensions",
-        "web_url": "https://www.gov.uk/government/organisations/department-for-work-and-pensions",
-        "locale": "en"
-      }
-    ],
     "people": [
       {
         "content_id": "295ce3e3-a68b-4952-8f13-72ea62f5c16b",

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -61,16 +61,6 @@
         "locale": "en"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "8927158f-e4b2-4361-b55d-02de7599b220",
-        "title": "Northern Ireland Office",
-        "base_path": "/government/organisations/northern-ireland-office",
-        "api_url": "https://www.gov.uk/api/organisations/northern-ireland-office",
-        "web_url": "https://www.gov.uk/government/organisations/northern-ireland-office",
-        "locale": "en"
-      }
-    ],
     "people": [
       {
         "content_id": "70dc1901-2d36-4c3d-98ee-e1d5587a5ba9",

--- a/formats/policy/publisher/links.json
+++ b/formats/policy/publisher/links.json
@@ -13,6 +13,10 @@
     "working_groups": {
       "$ref": "#/definitions/guid_list"
     },
+    "lead_organisations": {
+      "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+      "$ref": "#/definitions/guid_list"
+    },
     "related": {
       "$ref": "#/definitions/guid_list"
     },

--- a/formats/policy/publisher_v2/examples/policy_links.json
+++ b/formats/policy/publisher_v2/examples/policy_links.json
@@ -3,9 +3,6 @@
     "organisations":[
       "a4759607-4fd8-4cf0-9d56-af9d14a71162"
     ],
-    "lead_organisations":[
-      "a4759607-4fd8-4cf0-9d56-af9d14a71162"
-    ],
     "people": [],
     "working_groups": [],
     "related":[],

--- a/formats/publication/frontend/examples/political_publication.json
+++ b/formats/publication/frontend/examples/political_publication.json
@@ -39,17 +39,6 @@
     "political": true
   },
   "links": {
-    "lead_organisations": [
-      {
-        "content_id": "d65d4203-01f5-4920-a3b1-f614bfd8e83e",
-        "title": "Department of Energy & Climate Change",
-        "base_path": "/government/organisations/department-of-energy-climate-change",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/department-of-energy-climate-change",
-        "web_url": "https://www.gov.uk/government/organisations/department-of-energy-climate-change",
-        "locale": "en",
-        "analytics_identifier": "D11"
-      }
-    ],
     "organisations": [
       {
         "content_id": "d65d4203-01f5-4920-a3b1-f614bfd8e83e",

--- a/formats/publication/frontend/examples/publication.json
+++ b/formats/publication/frontend/examples/publication.json
@@ -29,17 +29,6 @@
     "emphasised_organisations": ["16628142-57b2-4611-bc03-5912785acee3"]
   },
   "links": {
-    "lead_organisations": [
-      {
-        "content_id": "16628142-57b2-4611-bc03-5912785acee3",
-        "title": "Environment Agency",
-        "base_path": "/government/organisations/environment-agency",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/environment-agency",
-        "web_url": "https://www.gov.uk/government/organisations/environment-agency",
-        "locale": "en",
-        "analytics_identifier": "EA199"
-      }
-    ],
     "organisations": [
       {
         "content_id": "16628142-57b2-4611-bc03-5912785acee3",

--- a/formats/publication/frontend/examples/statistics_publication.json
+++ b/formats/publication/frontend/examples/statistics_publication.json
@@ -60,17 +60,6 @@
         "analytics_identifier": "D4"
       }
     ],
-    "lead_organisations": [
-      {
-        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
-        "title": "Department for Communities and Local Government",
-        "base_path": "/government/organisations/department-for-communities-and-local-government",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-communities-and-local-government",
-        "web_url": "https://www.gov.uk/government/organisations/department-for-communities-and-local-government",
-        "locale": "en",
-        "analytics_identifier": "D4"
-      }
-    ],
     "document_collections": [
       {
         "content_id": "5eb622a8-7631-11e4-a3cb-005056011aef",

--- a/formats/publication/frontend/examples/withdrawn_publication.json
+++ b/formats/publication/frontend/examples/withdrawn_publication.json
@@ -56,17 +56,6 @@
         "locale": "en",
         "analytics_identifier": "D7"
       }
-    ],
-    "lead_organisations": [
-      {
-        "content_id": "de4e9dc6-cca4-43af-a594-682023b84d6c",
-        "title": "Department for Environment, Food & Rural Affairs",
-        "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-environment-food-rural-affairs",
-        "web_url": "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",
-        "locale": "en",
-        "analytics_identifier": "D7"
-      }
     ]
   },
   "schema_name": "publication",

--- a/formats/publication/publisher/links.json
+++ b/formats/publication/publisher/links.json
@@ -6,10 +6,6 @@
     "document_collections": {
       "$ref": "#/definitions/guid_list"
     },
-    "supporting_organisations": {
-      "description": "DEPRECATED: this field is being removed.",
-      "$ref": "#/definitions/guid_list"
-    },
     "ministers": {
       "$ref": "#/definitions/guid_list"
     },

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
     }
   }
 
-  let(:link_names) { ["lead_organisations"] }
+  let(:link_names) { ["organisations"] }
 
   let(:required_properties) {
     %w{

--- a/spec/lib/schema_combiner_spec.rb
+++ b/spec/lib/schema_combiner_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
   context "combining a metadata schema and a links schema" do
     let(:links_schema) {
       build_schema('links.json',
-        properties: build_string_properties('lead_organisations'),
+        properties: build_string_properties('organisations'),
         definitions: build_string_properties('guid_list')
       )
     }
@@ -180,7 +180,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
 
     it 'embeds the remaining content of the links schema as the links property definition' do
       remaining_content_of_links_schema = links_schema.schema.reject { |k, v| %w{$schema definitions}.include?(k) }
-      expect(combined.schema['definitions']['links']['properties'].keys).to eq(['lead_organisations', 'mainstream_browse_pages'])
+      expect(combined.schema['definitions']['links']['properties'].keys).to eq(['organisations', 'mainstream_browse_pages'])
     end
 
     it 'merges the definitions from the links schema into the combined schemas definitions' do
@@ -205,7 +205,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
     }
 
     let(:links_schema) {
-      build_schema('links.json', properties: build_string_properties('lead_organisations'))
+      build_schema('links.json', properties: build_string_properties('organisations'))
     }
 
     let(:definitions) {
@@ -254,7 +254,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
     }
 
     let(:links_schema) {
-      build_schema('links.json', properties: build_string_properties('lead_organisations', 'mainstream_browse_pages'))
+      build_schema('links.json', properties: build_string_properties('organisations', 'mainstream_browse_pages'))
     }
 
     let(:definitions) {
@@ -285,7 +285,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
     it 'embeds the merged links schemas as the links property' do
       remaining_content_of_links_schema = links_schema.schema.reject { |k, v| %w{$schema definitions}.include?(k) }
       expect(combined.schema['properties']['links']['properties'].keys).to match_array(
-        ['lead_organisations', 'mainstream_browse_pages', 'organisations', 'parent'])
+        ['organisations', 'mainstream_browse_pages', 'parent'])
     end
 
     it 'merges the definitions from the definitions schema into the combined schemas definitions' do


### PR DESCRIPTION
`lead_organisations` is deprecated and should not be used anymore. This PR makes sure that it's only allowed in the Policy format, where were currently removing it.