### PR TITLE
Add content store servers to deploy.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,7 @@
 for server in $(govuk_node_list -c backend); do
   rsync -r dist/* deploy@$server:/data/apps/publishing-api/shared/govuk-content-schemas/
 done
+
+for server in $(govuk_node_list -c content_store); do
+  rsync -r dist/* deploy@$server:/data/apps/content-store/shared/govuk-content-schemas/
+done


### PR DESCRIPTION
This is needed so content store can validate its
output against the frontend schemas.