### PR TITLE
Fixes for frontend validation

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -126,6 +130,9 @@
         "case_study"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -179,7 +186,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -422,6 +422,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -538,6 +542,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -375,6 +375,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -487,6 +491,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "coming_soon"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -342,6 +342,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -458,6 +462,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -307,6 +307,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -419,6 +423,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -117,6 +121,9 @@
         "contact"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -170,7 +177,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -529,6 +529,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -645,6 +649,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -491,6 +491,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -603,6 +607,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -123,6 +127,9 @@
         "detailed_guide"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -176,7 +183,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -418,6 +418,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -534,6 +538,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -374,6 +374,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -486,6 +490,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -124,6 +128,9 @@
         "document_collection"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -177,7 +184,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -426,6 +426,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -542,6 +546,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -380,6 +380,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -492,6 +496,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "email_alert_signup"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -403,6 +403,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -519,6 +523,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -368,6 +368,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -480,6 +484,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -123,6 +127,9 @@
         "fatality_notice"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -176,7 +183,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -371,6 +371,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -487,6 +491,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -325,6 +325,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -437,6 +441,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "financial_release"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -352,6 +352,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -468,6 +472,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -317,6 +317,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -429,6 +433,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "financial_releases_campaign"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -356,6 +356,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -472,6 +476,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -321,6 +321,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -433,6 +437,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "financial_releases_geoblocker"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -340,6 +340,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -456,6 +460,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -305,6 +305,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -417,6 +421,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -120,6 +124,9 @@
         "financial_releases_index"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -173,7 +180,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -343,6 +343,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -459,6 +463,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -302,6 +302,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -414,6 +418,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "financial_releases_success"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -345,6 +345,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -461,6 +465,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -310,6 +310,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -422,6 +426,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -120,6 +124,9 @@
         "finder"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -173,7 +180,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -492,6 +492,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -608,6 +612,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -448,6 +448,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -560,6 +564,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "hmrc_manual"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -447,6 +447,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -563,6 +567,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -412,6 +412,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -524,6 +528,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "hmrc_manual_section"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -437,6 +437,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -553,6 +557,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -402,6 +402,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -514,6 +518,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -118,6 +122,9 @@
         "html_publication"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -171,7 +178,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -354,6 +354,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -470,6 +474,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -315,6 +315,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -427,6 +431,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -126,6 +130,9 @@
         "mainstream_browse_page"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -179,7 +186,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -379,6 +379,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -495,6 +499,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -328,6 +328,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -440,6 +444,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -117,6 +121,9 @@
         "manual"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -170,7 +177,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -433,6 +433,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -549,6 +553,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -392,6 +392,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -504,6 +508,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -117,6 +121,9 @@
         "manual_section"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -170,7 +177,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -386,6 +386,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -502,6 +506,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -345,6 +345,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -457,6 +461,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -38,6 +38,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -112,6 +116,9 @@
       "pattern": "^(placeholder|placeholder_.+)$",
       "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -165,7 +172,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -414,6 +414,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -529,6 +533,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -379,6 +379,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -490,6 +494,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -133,6 +137,9 @@
         "policy"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -186,7 +193,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -479,6 +479,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -595,6 +599,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -421,6 +421,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -533,6 +537,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -129,6 +133,9 @@
         "publication"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -182,7 +189,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -412,6 +412,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -528,6 +532,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -362,6 +362,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -474,6 +478,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -117,6 +121,9 @@
         "service_manual_guide"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -170,7 +177,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -383,6 +383,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -499,6 +503,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -344,6 +344,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -456,6 +460,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -120,6 +124,9 @@
         "service_manual_topic"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -173,7 +180,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -383,6 +383,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -499,6 +503,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -340,6 +340,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -452,6 +456,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -131,6 +135,9 @@
         "specialist_document"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -184,7 +191,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -1310,6 +1310,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -1443,6 +1447,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1275,6 +1275,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -1387,6 +1391,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -118,6 +122,9 @@
         "statistics_announcement"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -171,7 +178,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -371,6 +371,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -487,6 +491,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -332,6 +332,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -444,6 +448,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "take_part"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -341,6 +341,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -457,6 +461,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -306,6 +306,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -418,6 +422,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "taxon"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -335,6 +335,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -451,6 +455,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -300,6 +300,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -412,6 +416,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -120,6 +124,9 @@
         "topic"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -173,7 +180,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -381,6 +381,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -497,6 +501,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -338,6 +338,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -450,6 +454,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -117,6 +121,9 @@
         "topical_event_about_page"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -170,7 +177,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -344,6 +344,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -460,6 +464,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -306,6 +306,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -418,6 +422,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -117,6 +121,9 @@
         "travel_advice"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -170,7 +177,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -421,6 +421,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -537,6 +541,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -383,6 +383,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -495,6 +499,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -117,6 +121,9 @@
         "travel_advice_index"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -170,7 +177,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -390,6 +390,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -506,6 +510,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -352,6 +352,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -464,6 +468,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "unpublishing"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -355,6 +355,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -471,6 +475,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -320,6 +320,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -432,6 +436,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },
@@ -114,6 +118,9 @@
         "working_group"
       ]
     },
+    "expanded_links": {
+      "type": "object"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -167,7 +174,7 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "parent": {
                 "$ref": "#/definitions/guid_list"

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -337,6 +337,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -453,6 +457,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -302,6 +302,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "publishing_app": {
           "type": "string"
         },
@@ -414,6 +418,10 @@
           ]
         },
         "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
           "type": "string",
           "format": "date-time"
         },

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -46,7 +46,7 @@
       },
       "links": {
         "type": "object",
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "parent": {
             "$ref": "#/definitions/guid_list"

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -31,6 +31,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "publishing_app": {
       "type": "string"
     },

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -63,6 +63,7 @@ private
 
     properties = properties.merge(
       'links' => frontend_links,
+      'expanded_links' => { "type" => "object" },
       'updated_at' => updated_at,
       'base_path' => { '$ref' => '#/definitions/absolute_path' }
     )


### PR DESCRIPTION
### Add `first_published_at` for all formats.  …

This is now optional for all formats at publish
and guaranteed for all formats in frontend (once
republished).

### Allow non-parent links in nested links.  …

This is too restrictive, in reality all link types
are expanded.

We should look into whether this a good long term
solution while tidying up the upcoming validation
errors as most of these schemas will not validate
against the current content store output.

### Add a simple definition for expanded links to all formats.  …

These are provided by publishing API and presented
to the frontends.  We should look into whether
this needs to be a more fully-fledged definition.

https://trello.com/c/qegWyQTI/725-content-store-validation-against-front-end-schemas