### PR TITLE
Rename service manual links topics

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -86,6 +86,9 @@
         "content_owners": {
           "$ref": "#/definitions/frontend_links"
         },
+        "service_manual_topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -60,6 +60,10 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
+        "service_manual_topics": {
+          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -14,6 +14,10 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
+        "service_manual_topics": {
+          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide.json
@@ -13,20 +13,47 @@
     ]
   },
   "links": {
-    "content_owners": [{
-      "content_id": "e5f09422-bf55-417c-b520-8a42cb409814",
-      "title": "Agile delivery community",
-      "base_path": "/service-manual/communities/agile-delivery-community",
-      "description": "Agile delivery community takes care of...",
-      "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
-      "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
-      "locale": "en",
-      "analytics_identifier": null
-    }]
+    "content_owners": [
+      {
+        "content_id": "e5f09422-bf55-417c-b520-8a42cb409814",
+        "title": "Agile delivery community",
+        "base_path": "/service-manual/communities/agile-delivery-community",
+        "description": "Agile delivery community takes care of...",
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
+        "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
+        "locale": "en",
+        "analytics_identifier": null
+      }
+    ],
+    "service_manual_topics": [
+      {
+        "content_id": "370e00b2-3c79-4816-aaa9-1a7059e6155d",
+        "title": "Agile",
+        "base_path": "/service-manual/agile",
+        "description": "",
+        "api_url": "https://content-store.gov.uk/content/service-manual/agile",
+        "web_url": "https://www.gov.uk/service-manual/agile",
+        "locale": "en",
+        "schema_name": "service_manual_topic",
+        "document_type": "service_manual_topic",
+        "analytics_identifier": null,
+        "links": {
+          "linked_items": [
+            "fb81a47b-7c8f-4280-b6c7-b6fa25822222"
+          ],
+          "content_owners": [
+            "e50286e4-2d79-44aa-bcf4-f024e5e17061"
+          ],
+          "organisations": [
+            "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+          ]
+        }
+      }
+    ]
   },
-  "base_path": "/service-manual/agile",
+  "base_path": "/service-manual/agile/agile-delivery",
   "description": "What agile is, why it works and how to do it",
-  "title": "Agile",
+  "title": "Agile Delivery",
   "updated_at": "2015-10-12T08:54:30+00:00",
   "schema_name": "service_manual_guide",
   "document_type": "service_manual_guide"

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
@@ -12,7 +12,34 @@
       }
     ]
   },
-  "base_path": "/service-manual/agile-community",
+  "links": {
+    "service_manual_topics": [
+      {
+        "content_id": "370e00b2-3c79-4816-aaa9-1a7059e6155d",
+        "title": "Communities",
+        "base_path": "/service-manual/communities",
+        "description": "",
+        "api_url": "https://content-store.gov.uk/content/service-manual/communities",
+        "web_url": "https://www.gov.uk/service-manual/communities",
+        "locale": "en",
+        "schema_name": "service_manual_topic",
+        "document_type": "service_manual_topic",
+        "analytics_identifier": null,
+        "links": {
+          "linked_items": [
+            "fb81a47b-7c8f-4280-b6c7-b6fa25822222"
+          ],
+          "content_owners": [
+            "e50286e4-2d79-44aa-bcf4-f024e5e17061"
+          ],
+          "organisations": [
+            "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+          ]
+        }
+      }
+    ]
+  },
+  "base_path": "/service-manual/communities/agile-community",
   "description": "The agile community",
   "title": "Agile Community",
   "updated_at": "2015-10-12T08:54:30+00:00",

--- a/formats/service_manual_guide/frontend/examples/with_change_history.json
+++ b/formats/service_manual_guide/frontend/examples/with_change_history.json
@@ -25,20 +25,47 @@
     ]
   },
   "links": {
-    "content_owners": [{
-      "content_id": "e5f09422-bf55-417c-b520-8a42cb409814",
-      "title": "Agile delivery community",
-      "base_path": "/service-manual/communities/agile-delivery-community",
-      "description": "Agile delivery community takes care of...",
-      "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
-      "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
-      "locale": "en",
-      "analytics_identifier": null
-    }]
+    "content_owners": [
+      {
+        "content_id": "e5f09422-bf55-417c-b520-8a42cb409814",
+        "title": "Agile delivery community",
+        "base_path": "/service-manual/communities/agile-delivery-community",
+        "description": "Agile delivery community takes care of...",
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
+        "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
+        "locale": "en",
+        "analytics_identifier": null
+      }
+    ],
+    "service_manual_topics": [
+      {
+        "content_id": "370e00b2-3c79-4816-aaa9-1a7059e6155d",
+        "title": "Agile",
+        "base_path": "/service-manual/agile",
+        "description": "",
+        "api_url": "https://content-store.gov.uk/content/service-manual/agile",
+        "web_url": "https://www.gov.uk/service-manual/agile",
+        "locale": "en",
+        "schema_name": "service_manual_topic",
+        "document_type": "service_manual_topic",
+        "analytics_identifier": null,
+        "links": {
+          "linked_items": [
+            "2b81a47b-7c8f-4280-b6c7-b6fa25822222"
+          ],
+          "content_owners": [
+            "e50286e4-2d79-44aa-bcf4-f024e5e17061"
+          ],
+          "organisations": [
+            "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+          ]
+        }
+      }
+    ]
   },
-  "base_path": "/service-manual/with-change-history",
+  "base_path": "/service-manual/agile/with-change-history",
   "description": "This guide has some change history",
-  "title": "Agile",
+  "title": "With Change History",
   "updated_at": "2015-10-12T08:54:30+00:00",
   "schema_name": "service_manual_guide",
   "document_type": "service_manual_guide"

--- a/formats/service_manual_guide/publisher/links.json
+++ b/formats/service_manual_guide/publisher/links.json
@@ -6,6 +6,10 @@
     "content_owners": {
       "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
       "$ref": "#/definitions/guid_list"
+    },
+    "service_manual_topics": {
+    	"description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
+    	"$ref": "#/definitions/guid_list"
     }
   }
 }

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide_links.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide_links.json
@@ -1,5 +1,6 @@
 {
   "links": {
-    "content_owners": ["f6eef5ca-be55-41b2-98be-f72b3e649b84"]
+    "content_owners": ["f6eef5ca-be55-41b2-98be-f72b3e649b84"],
+    "service_manual_topics": ["cd02b82d-c706-435c-a2fc-2dcabd168ef4"]
   }
 }


### PR DESCRIPTION
'topics' is already a reserved field and is being renamed to 'service_manual_topics'.