### PR TITLE
Add top & second level browse pages to details hash

### DIFF
--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -204,6 +204,14 @@
           "type": "string",
           "description": "An internal name for admin interfaces. Includes parent."
         },
+        "top_level_browse_pages": {
+          "description": "All top-level browse pages",
+          "$ref": "#/definitions/guid_list"
+        },
+        "second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page",
+          "$ref": "#/definitions/guid_list"
+        },
         "second_level_ordering": {
           "enum": [
             "alphabetical",

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -11,6 +11,14 @@
           "type": "string",
           "description": "An internal name for admin interfaces. Includes parent."
         },
+        "top_level_browse_pages": {
+          "description": "All top-level browse pages",
+          "$ref": "#/definitions/guid_list"
+        },
+        "second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page",
+          "$ref": "#/definitions/guid_list"
+        },
         "second_level_ordering": {
           "enum": [
             "alphabetical",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -11,6 +11,14 @@
           "type": "string",
           "description": "An internal name for admin interfaces. Includes parent."
         },
+        "top_level_browse_pages": {
+          "description": "All top-level browse pages",
+          "$ref": "#/definitions/guid_list"
+        },
+        "second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page",
+          "$ref": "#/definitions/guid_list"
+        },
         "second_level_ordering": {
           "enum": [
             "alphabetical",

--- a/formats/mainstream_browse_page/publisher/details.json
+++ b/formats/mainstream_browse_page/publisher/details.json
@@ -7,6 +7,14 @@
       "type": "string",
       "description": "An internal name for admin interfaces. Includes parent."
     },
+    "top_level_browse_pages": {
+      "description": "All top-level browse pages",
+      "$ref": "#/definitions/guid_list"
+    },
+    "second_level_browse_pages": {
+      "description": "All 2nd level browse pages under active_top_level_browse_page",
+      "$ref": "#/definitions/guid_list"
+    },
     "second_level_ordering": {
       "enum": [ "alphabetical", "curated" ]
     },


### PR DESCRIPTION
We are adding top level and second level browse pages into the details hash because we need them to be able to be ordered when the content is curated in collections publisher.

In the past we made a decision of not preserving the order for links, which can be found here: https://gov-uk.atlassian.net/wiki/display/FS/RFC+36%3A+Stop+preserving+order+for+links

One of the key reasons for this decision was to make sure presentation concerns don't get put in the links hash. That's why we are using details instead: neither of these fields are needed to describe how the browse pages link together (we have active_top_level for that).

There will be following commits to remove these two fields from the links hash once we have fixed the frontend apps.

Trello:
https://trello.com/c/KZJigx96/676-ordering-of-browse-pages-no-longer-respected

@davidslv & @MatMoore