### PR TITLE
Add finder_email_signup_schema

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -1,0 +1,525 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "format",
+    "title",
+    "details",
+    "locale",
+    "content_id",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "format": {
+      "type": "string",
+      "enum": [
+        "finder_email_signup"
+      ]
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "related",
+        "organisations"
+      ],
+      "properties": {
+        "related": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "alpha_taxons": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder_email_signup"
+      ]
+    },
+    "expanded_links": {
+      "type": "object"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "links": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "parent": {
+                "$ref": "#/definitions/guid_list"
+              }
+            }
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "email_signup_choice",
+        "email_filter_by",
+        "subscription_list_title_prefix"
+      ],
+      "properties": {
+        "beta": {
+          "type": "boolean"
+        },
+        "email_signup_choice": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "key",
+              "radio_button_name",
+              "topic_name",
+              "prechecked"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "radio_button_name": {
+                "type": "string"
+              },
+              "topic_name": {
+                "type": "string"
+              },
+              "prechecked": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "email_filter_by": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subscription_list_title_prefix": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "plural": {
+                  "type": "string"
+                },
+                "singular": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -1,0 +1,630 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "email_signup_choice",
+        "email_filter_by",
+        "subscription_list_title_prefix"
+      ],
+      "properties": {
+        "beta": {
+          "type": "boolean"
+        },
+        "email_signup_choice": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "key",
+              "radio_button_name",
+              "topic_name",
+              "prechecked"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "radio_button_name": {
+                "type": "string"
+              },
+              "topic_name": {
+                "type": "string"
+              },
+              "prechecked": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "email_filter_by": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subscription_list_title_prefix": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "plural": {
+                  "type": "string"
+                },
+                "singular": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "related",
+        "organisations"
+      ],
+      "properties": {
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "alpha_taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "These are for collecting content related to a particular government policy.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "finder_email_signup"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        },
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "last_edited_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time when the content recieved a major or minor update."
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        }
+      },
+      "required": [
+        "format",
+        "title",
+        "details",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "content_id",
+        "update_type"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "schema_name": {
+          "type": "string",
+          "enum": [
+            "finder_email_signup"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        },
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "last_edited_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time when the content recieved a major or minor update."
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        }
+      },
+      "required": [
+        "document_type",
+        "schema_name",
+        "title",
+        "details",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "content_id",
+        "update_type"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "previous_version": {
+      "type": "string"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "related",
+        "organisations"
+      ],
+      "properties": {
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "alpha_taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "These are for collecting content related to a particular government policy.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    }
+  }
+}

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -1,0 +1,580 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "email_signup_choice",
+        "email_filter_by",
+        "subscription_list_title_prefix"
+      ],
+      "properties": {
+        "beta": {
+          "type": "boolean"
+        },
+        "email_signup_choice": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "key",
+              "radio_button_name",
+              "topic_name",
+              "prechecked"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "radio_button_name": {
+                "type": "string"
+              },
+              "topic_name": {
+                "type": "string"
+              },
+              "prechecked": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "email_filter_by": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subscription_list_title_prefix": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "plural": {
+                  "type": "string"
+                },
+                "singular": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "finder_email_signup"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        },
+        "last_edited_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time when the content recieved a major or minor update."
+        },
+        "previous_version": {
+          "type": "string"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        }
+      },
+      "required": [
+        "format",
+        "title",
+        "details",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "base_path"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "schema_name": {
+          "type": "string",
+          "enum": [
+            "finder_email_signup"
+          ]
+        },
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "public_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publishing_app": {
+          "type": "string"
+        },
+        "rendering_app": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "need_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/route"
+          }
+        },
+        "redirects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/redirect_route"
+          }
+        },
+        "access_limited": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "users"
+          ],
+          "properties": {
+            "users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "phase": {
+          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+          "type": "string",
+          "enum": [
+            "alpha",
+            "beta",
+            "live"
+          ]
+        },
+        "details": {
+          "$ref": "#/definitions/details"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        },
+        "last_edited_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time when the content recieved a major or minor update."
+        },
+        "previous_version": {
+          "type": "string"
+        },
+        "update_type": {
+          "enum": [
+            "major",
+            "minor",
+            "republish"
+          ]
+        }
+      },
+      "required": [
+        "document_type",
+        "schema_name",
+        "title",
+        "details",
+        "publishing_app",
+        "rendering_app",
+        "locale",
+        "routes",
+        "base_path"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
+++ b/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
@@ -1,0 +1,193 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/cma-cases/email-signup",
+  "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+  "document_type": "finder_email_signup",
+  "expanded_links": {
+    "related": [
+      {
+        "analytics_identifier": null,
+        "api_url": "https://www.gov.uk/api/content/cma-cases",
+        "base_path": "/cma-cases",
+        "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+        "description": "Find reports and updates on current and historical CMA investigations",
+        "locale": "en",
+        "public_updated_at": "2016-06-13T14:30:40.000Z",
+        "title": "Competition and Markets Authority cases",
+        "web_url": "https://www.gov.uk/cma-cases",
+        "expanded_links": { }
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "D550",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
+        "base_path": "/government/organisations/competition-and-markets-authority",
+        "content_id": "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+        "description": null,
+        "locale": "en",
+        "public_updated_at": "2015-03-10T16:23:14.000Z",
+        "title": "Competition and Markets Authority",
+        "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority",
+        "expanded_links": { }
+      }
+    ],
+    "available_translations": [
+      {
+        "analytics_identifier": null,
+        "api_url": "https://www.gov.uk/api/content/cma-cases/email-signup",
+        "base_path": "/cma-cases/email-signup",
+        "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+        "description": "You'll get an email each time a case is updated or a new case is published.",
+        "locale": "en",
+        "public_updated_at": "2016-06-13T14:30:40.000Z",
+        "title": "Competition and Markets Authority cases",
+        "web_url": "https://www.gov.uk/cma-cases/email-signup"
+      }
+    ]
+  },
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "format": "finder_email_signup",
+  "locale": "en",
+  "need_ids": [ ],
+  "phase": "live",
+  "public_updated_at": "2016-06-13T14:30:40.000+00:00",
+  "publishing_app": "specialist-publisher",
+  "rendering_app": "finder-frontend",
+  "schema_name": "finder_email_signup",
+  "title": "Competition and Markets Authority cases",
+  "updated_at": "2016-06-13T14:31:32.260Z",
+  "withdrawn_notice": { },
+  "links": {
+    "related": [
+      {
+        "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+        "title": "Competition and Markets Authority cases",
+        "base_path": "/cma-cases",
+        "description": "Find reports and updates on current and historical CMA investigations",
+        "api_url": "https://www.gov.uk/api/content/cma-cases",
+        "web_url": "https://www.gov.uk/cma-cases",
+        "locale": "en",
+        "public_updated_at": "2016-06-13T14:30:40.000+00:00",
+        "schema_name": "finder",
+        "document_type": "finder",
+        "analytics_identifier": null,
+        "links": {
+          "topics": [
+            "fd11e3b0-76bc-4197-b652-a030b57915be",
+            "7aa3ec0c-683e-44ba-aa3f-cc9655651b9b",
+            "1433d403-333f-4d81-b83a-c5358412fd1b",
+            "65a89136-2117-41aa-ba96-35feb9d821f5",
+            "4a6f14ad-baa1-4b15-8026-8282913ef693"
+          ],
+          "email_alert_signup": [
+            "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a"
+          ],
+          "organisations": [
+            "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+          ]
+        }
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+        "title": "Competition and Markets Authority",
+        "base_path": "/government/organisations/competition-and-markets-authority",
+        "description": null,
+        "api_url": "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
+        "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority",
+        "locale": "en",
+        "public_updated_at": "2015-03-10T16:23:14.000+00:00",
+        "schema_name": "placeholder_organisation",
+        "document_type": "placeholder_organisation",
+        "analytics_identifier": "D550",
+        "links": { },
+        "details": {
+          "brand": "department-for-business-innovation-skills",
+          "logo": {
+            "formatted_title": "Competition and <br/>Markets Authority",
+            "crest": null
+          }
+        }
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+        "title": "Competition and Markets Authority cases",
+        "base_path": "/cma-cases/email-signup",
+        "description": "You'll get an email each time a case is updated or a new case is published.",
+        "api_url": "https://www.gov.uk/api/content/cma-cases/email-signup",
+        "web_url": "https://www.gov.uk/cma-cases/email-signup",
+        "locale": "en",
+        "public_updated_at": "2016-06-13T14:30:40.000+00:00",
+        "schema_name": "finder_email_signup",
+        "document_type": "finder_email_signup",
+        "analytics_identifier": null,
+        "links": {
+          "related": [
+            "fef4ac7c-024a-4943-9f19-e85a8369a1f3"
+          ],
+          "organisations": [
+            "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+          ]
+        }
+      }
+    ]
+  },
+  "description": "You'll get an email each time a case is updated or a new case is published.",
+  "details": {
+    "beta": false,
+    "email_signup_choice": [
+      {
+        "key": "ca98-and-civil-cartels",
+        "radio_button_name": "CA98 and civil cartels",
+        "topic_name": "CA98 and civil cartels",
+        "prechecked": false
+      },
+      {
+        "key": "criminal-cartels",
+        "radio_button_name": "Criminal cartels",
+        "topic_name": "criminal cartels",
+        "prechecked": false
+      },
+      {
+        "key": "markets",
+        "radio_button_name": "Markets",
+        "topic_name": "markets",
+        "prechecked": false
+      },
+      {
+        "key": "mergers",
+        "radio_button_name": "Mergers",
+        "topic_name": "mergers",
+        "prechecked": false
+      },
+      {
+        "key": "consumer-enforcement",
+        "radio_button_name": "Consumer enforcement",
+        "topic_name": "consumer enforcement",
+        "prechecked": false
+      },
+      {
+        "key": "regulatory-references-and-appeals",
+        "radio_button_name": "Regulatory references and appeals",
+        "topic_name": "regulatory references and appeals",
+        "prechecked": false
+      },
+      {
+        "key": "review-of-orders-and-undertakings",
+        "radio_button_name": "Reviews of orders and undertakings",
+        "topic_name": "reviews of orders and undertakings",
+        "prechecked": false
+      }
+    ],
+    "email_filter_by": "case_type",
+    "subscription_list_title_prefix": {
+      "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
+      "plural": "Competition and Markets Authority (CMA) cases with the following case types: "
+    }
+  }
+
+}

--- a/formats/finder_email_signup/frontend/examples/raib-report-email-signup.json
+++ b/formats/finder_email_signup/frontend/examples/raib-report-email-signup.json
@@ -1,0 +1,168 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/raib-reports/email-signup",
+  "content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
+  "document_type": "finder_email_signup",
+  "expanded_links": {
+    "related": [
+      {
+        "analytics_identifier": null,
+        "api_url": "https://www.gov.uk/api/content/raib-reports",
+        "base_path": "/raib-reports",
+        "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
+        "description": "Find reports of RAIB investigations into rail accidents and incidents",
+        "locale": "en",
+        "public_updated_at": "2016-06-13T14:30:40.000Z",
+        "title": "Rail Accident Investigation Branch reports",
+        "web_url": "https://www.gov.uk/raib-reports",
+        "expanded_links": { }
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "OT249",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/rail-accident-investigation-branch",
+        "base_path": "/government/organisations/rail-accident-investigation-branch",
+        "content_id": "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
+        "description": null,
+        "locale": "en",
+        "public_updated_at": "2015-04-01T09:33:41.000Z",
+        "title": "Rail Accident Investigation Branch",
+        "web_url": "https://www.gov.uk/government/organisations/rail-accident-investigation-branch",
+        "expanded_links": { }
+      }
+    ],
+    "available_translations": [
+      {
+        "analytics_identifier": null,
+        "api_url": "https://www.gov.uk/api/content/raib-reports/email-signup",
+        "base_path": "/raib-reports/email-signup",
+        "content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
+        "description": "You'll get an email each time a report is updated or a new report is published.",
+        "locale": "en",
+        "public_updated_at": "2016-06-13T14:30:40.000Z",
+        "title": "Rail Accident Investigation Branch reports",
+        "web_url": "https://www.gov.uk/raib-reports/email-signup"
+      }
+    ]
+  },
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "format": "finder_email_signup",
+  "locale": "en",
+  "need_ids": [ ],
+  "phase": "live",
+  "public_updated_at": "2016-06-13T14:30:40.000+00:00",
+  "publishing_app": "specialist-publisher",
+  "rendering_app": "finder-frontend",
+  "schema_name": "finder_email_signup",
+  "title": "Rail Accident Investigation Branch reports",
+  "updated_at": "2016-06-13T14:31:34.931Z",
+  "withdrawn_notice": { },
+  "links": {
+    "related": [
+      {
+        "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
+        "title": "Rail Accident Investigation Branch reports",
+        "base_path": "/raib-reports",
+        "description": "Find reports of RAIB investigations into rail accidents and incidents",
+        "api_url": "https://www.gov.uk/api/content/raib-reports",
+        "web_url": "https://www.gov.uk/raib-reports",
+        "locale": "en",
+        "public_updated_at": "2016-06-13T14:30:40.000+00:00",
+        "schema_name": "finder",
+        "document_type": "finder",
+        "analytics_identifier": null,
+        "links": {
+          "email_alert_signup": [
+            "db81c7e8-b1b6-4c29-992a-1289f1b63073"
+          ],
+          "organisations": [
+            "013872d8-8bbb-4e80-9b79-45c7c5cf9177"
+          ]
+        }
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
+        "title": "Rail Accident Investigation Branch",
+        "base_path": "/government/organisations/rail-accident-investigation-branch",
+        "description": null,
+        "api_url": "https://www.gov.uk/api/content/government/organisations/rail-accident-investigation-branch",
+        "web_url": "https://www.gov.uk/government/organisations/rail-accident-investigation-branch",
+        "locale": "en",
+        "public_updated_at": "2015-04-01T09:33:41.000+00:00",
+        "schema_name": "placeholder",
+        "document_type": "organisation",
+        "analytics_identifier": "OT249",
+        "links": { },
+        "details": {
+          "brand": "department-for-transport",
+          "logo": {
+            "formatted_title": "Rail Accident<br/>Investigation Branch",
+            "crest": null
+          }
+        }
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
+        "title": "Rail Accident Investigation Branch reports",
+        "base_path": "/raib-reports/email-signup",
+        "description": "You'll get an email each time a report is updated or a new report is published.",
+        "api_url": "https://www.gov.uk/api/content/raib-reports/email-signup",
+        "web_url": "https://www.gov.uk/raib-reports/email-signup",
+        "locale": "en",
+        "public_updated_at": "2016-06-13T14:30:40.000+00:00",
+        "schema_name": "finder_email_signup",
+        "document_type": "finder_email_signup",
+        "analytics_identifier": null,
+        "links": {
+          "related": [
+            "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd"
+          ],
+          "organisations": [
+            "013872d8-8bbb-4e80-9b79-45c7c5cf9177"
+          ]
+        }
+      }
+    ]
+  },
+  "description": "You'll get an email each time a report is updated or a new report is published.",
+  "details": {
+    "beta": false,
+    "email_signup_choice": [
+      {
+        "key": "heavy-rail",
+        "radio_button_name": "Heavy rail",
+        "topic_name": "heavy rail",
+        "prechecked": false
+      },
+      {
+        "key": "light-rail",
+        "radio_button_name": "Light rail",
+        "topic_name": "light rail",
+        "prechecked": false
+      },
+      {
+        "key": "metros",
+        "radio_button_name": "Metros",
+        "topic_name": "metros",
+        "prechecked": false
+      },
+      {
+        "key": "heritage-railways",
+        "radio_button_name": "Heritage railways",
+        "topic_name": "heritage railways",
+        "prechecked": false
+      }
+    ],
+    "email_filter_by": "railway_type",
+    "subscription_list_title_prefix": {
+      "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",
+      "plural": "Rail Accident Investigation Branch (RAIB) reports with the following railway types: "
+    }
+  }
+
+}

--- a/formats/finder_email_signup/publisher/details.json
+++ b/formats/finder_email_signup/publisher/details.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "email_signup_choice",
+    "email_filter_by",
+    "subscription_list_title_prefix"
+  ],
+  "properties": {
+    "beta": {
+      "type": "boolean"
+    },
+    "email_signup_choice": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "radio_button_name",
+          "topic_name",
+          "prechecked"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "radio_button_name": {
+            "type": "string"
+          },
+          "topic_name": {
+            "type": "string"
+          },
+          "prechecked": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "email_filter_by": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "subscription_list_title_prefix": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "plural": {
+              "type": "string"
+            },
+            "singular": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/formats/finder_email_signup/publisher/links.json
+++ b/formats/finder_email_signup/publisher/links.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "related",
+    "organisations"
+  ],
+  "properties": {
+    "related": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "organisations": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}

--- a/formats/finder_email_signup/publisher_v2/examples/finder_email_signup.json
+++ b/formats/finder_email_signup/publisher_v2/examples/finder_email_signup.json
@@ -1,0 +1,70 @@
+{
+  "base_path": "/cma-cases/email-signup",
+  "description": "You'll get an email each time a case is updated or a new case is published.",
+  "document_type": "finder_email_signup",
+  "schema_name": "finder_email_signup",
+  "locale": "en",
+  "public_updated_at": "2016-04-26T11:19:42.000+00:00",
+  "publishing_app": "specialist-publisher",
+  "rendering_app": "finder-frontend",
+  "title": "Competition and Markets Authority cases",
+  "update_type": "minor",
+  "routes": [
+    {
+      "path": "/cma-cases/email-signup",
+      "type": "exact"
+    }
+  ],
+  "details": {
+    "beta": false,
+    "email_filter_by": "case_type",
+    "subscription_list_title_prefix": {
+      "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
+      "singular": "Competition and Markets Authority (CMA) cases with the following case type: "
+    },
+    "email_signup_choice": [
+      {
+        "key": "ca98-and-civil-cartels",
+        "prechecked": false,
+        "radio_button_name": "CA98 and civil cartels",
+        "topic_name": "CA98 and civil cartels"
+      },
+      {
+        "key": "criminal-cartels",
+        "prechecked": false,
+        "radio_button_name": "Criminal cartels",
+        "topic_name": "criminal cartels"
+      },
+      {
+        "key": "markets",
+        "prechecked": false,
+        "radio_button_name": "Markets",
+        "topic_name": "markets"
+      },
+      {
+        "key": "mergers",
+        "prechecked": false,
+        "radio_button_name": "Mergers",
+        "topic_name": "mergers"
+      },
+      {
+        "key": "consumer-enforcement",
+        "prechecked": false,
+        "radio_button_name": "Consumer enforcement",
+        "topic_name": "consumer enforcement"
+      },
+      {
+        "key": "regulatory-references-and-appeals",
+        "prechecked": false,
+        "radio_button_name": "Regulatory references and appeals",
+        "topic_name": "regulatory references and appeals"
+      },
+      {
+        "key": "review-of-orders-and-undertakings",
+        "prechecked": false,
+        "radio_button_name": "Reviews of orders and undertakings",
+        "topic_name": "reviews of orders and undertakings"
+      }
+    ]
+  }
+}

--- a/formats/finder_email_signup/publisher_v2/examples/finder_email_signup_links.json
+++ b/formats/finder_email_signup/publisher_v2/examples/finder_email_signup_links.json
@@ -1,0 +1,10 @@
+{
+  "links": {
+    "organisations": [
+      "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
+    ],
+    "related": [
+      "fef4ac7c-024a-4943-9f19-e85a8369a1f3"
+    ]
+  }
+}


### PR DESCRIPTION
We've retroactively added a schema for finder_email_signup,
which are published via a rake task on specialist-publisher
[Trello Card](https://trello.com/c/HnpJ2PQf/147-create-missing-schema-for-finder-email-signup-medium)
