### PR TITLE
Adapt contacts to whitehall model

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,16 @@ In the future, there may be a third:
 
 The 'publisher' [`schema.json`](dist/formats/case_study/publisher/schema.json) is built from three parts:
 
-  - [`metadata.json`](formats/metadata.json): the top level set of fields. These are the **same for every content
-    format**.
+  - [`metadata.json`](formats/metadata.json): the top level set of fields. These are **common to most content
+    formats**.
 
   - [version metadata eg. `v2_metadata.json`](formats/v2_metadata.json): Fields specific to the publisher version.
     Either [`v1_metadata.json`](formats/v1_metadata.json) or [`v2_metadata.json`](formats/v2_metadata.json)
+
+  - [format specific metadata eg. `formats/contact/publisher_v2/metadata.json`](formats/contact/publisher_v2/metadata.json):
+    Exceptional formats which do not conform to common, v1 or v2 metadata definitions may define their own
+    format specific metadata.
+    An example of this is pathless content such as Whitehall contacts.
 
   - [`definitions.json`](formats/definitions.json) Common definitions used across schemas.
 

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -191,8 +191,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "title",
-        "description"
+        "title"
       ],
       "properties": {
         "slug": {
@@ -257,6 +256,12 @@
               "type": "null"
             }
           ]
+        },
+        "contact_type": {
+          "type": "string"
+        },
+        "feature_on_homepage": {
+          "type": "boolean"
         },
         "email_addresses": {
           "type": "array",

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -7,8 +7,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "title",
-        "description"
+        "title"
       ],
       "properties": {
         "slug": {
@@ -73,6 +72,12 @@
               "type": "null"
             }
           ]
+        },
+        "contact_type": {
+          "type": "string"
+        },
+        "feature_on_homepage": {
+          "type": "boolean"
         },
         "email_addresses": {
           "type": "array",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -7,8 +7,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "title",
-        "description"
+        "title"
       ],
       "properties": {
         "slug": {
@@ -73,6 +72,12 @@
               "type": "null"
             }
           ]
+        },
+        "contact_type": {
+          "type": "string"
+        },
+        "feature_on_homepage": {
+          "type": "boolean"
         },
         "email_addresses": {
           "type": "array",
@@ -555,16 +560,6 @@
         },
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -573,9 +568,7 @@
         "details",
         "publishing_app",
         "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
+        "locale"
       ],
       "additionalProperties": false
     },
@@ -674,16 +667,6 @@
         },
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
         }
       },
       "required": [
@@ -693,9 +676,7 @@
         "details",
         "publishing_app",
         "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
+        "locale"
       ],
       "additionalProperties": false
     }

--- a/formats/contact/publisher/details.json
+++ b/formats/contact/publisher/details.json
@@ -3,8 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "title",
-    "description"
+    "title"
   ],
   "properties": {
     "slug": {
@@ -66,6 +65,12 @@
           "type": "null"
         }
       ]
+    },
+    "contact_type": {
+      "type": "string"
+    },
+    "feature_on_homepage": {
+      "type": "boolean"
     },
     "email_addresses": {
       "type": "array",

--- a/formats/contact/publisher_v2/examples/whitehall-contact.json
+++ b/formats/contact/publisher_v2/examples/whitehall-contact.json
@@ -1,0 +1,26 @@
+{
+  "locale": "en",
+  "schema_name": "contact",
+  "document_type": "contact",
+  "title": "Government Digital Service",
+  "details": {
+    "title": "Government Digital Service",
+    "description": "Government Digital Service",
+    "contact_type": "general",
+    "feature_on_homepage": true,
+    "post_addresses": [
+      {
+        "title": "Aviation House",
+        "street_address": "Aviation House\n125 Kingsway",
+        "locality": "London",
+        "postal_code": "WC2B 6NH",
+        "world_location": "United Kingdom"
+      }
+    ],
+    "phone_numbers": [],
+    "email_addresses": []
+  },
+  "publishing_app": "whitehall",
+  "rendering_app": "government-frontend",
+  "phase": "live"
+}

--- a/formats/contact/publisher_v2/metadata.json
+++ b/formats/contact/publisher_v2/metadata.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref" : "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [ "users" ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [ "alpha", "beta", "live" ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    }
+  },
+  "definitions": {}
+}

--- a/lib/tasks/combine_schemas.rake
+++ b/lib/tasks/combine_schemas.rake
@@ -27,7 +27,8 @@ end
 
 def sources_for_v2_details(filename)
   Rake::FileList.new(
-    "formats/{definitions,metadata,v2_metadata}.json",
+    "formats/definitions.json",
+    metadata_sources(filename),
     filename.pathmap("%{^dist/,}p").pathmap("%{_v2,}d/details.json")
   )
 end
@@ -37,6 +38,16 @@ def sources_for_v2_links(filename)
     "formats/{definitions,links_metadata,base_links}.json",
     filename.pathmap("%{^dist/,}p").pathmap("%{_v2,}d/links.json")
   ).select { |f| File.exist?(f) }
+end
+
+def metadata_sources(filename)
+  format_metadata = filename.pathmap("%{^dist/,}d/metadata.json")
+
+  if File.exist?(format_metadata)
+    format_metadata
+  else
+    "formats/{definitions,metadata,v2_metadata}.json"
+  end
 end
 
 def sources_for_frontend_schema(filename)


### PR DESCRIPTION
https://trello.com/c/JxKRVn6c/731-export-whitehall-contacts-to-publishing-api-medium

Whitehall contacts are pretty similar to those from the contacts app, a couple of fields are needed to accommodate Whitehall contacts data.
The significant change here is to allow formats to provide custom metadata, this feels a bit strange as metadata should be common across all formats, however the publishing API allows pathless content for specific formats and I've attempted to provide a mechanism for this here. Perhaps there's a better solution?
The description field is no a longer required field, [this is enforced by the contacts-admin application](https://github.com/alphagov/contacts-admin/blob/master/app/models/contact.rb#L28) as it's not necessary for Whitehall.