### PR TITLE
Add more documentation on deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In the future, there may be a third:
 * [Suggested workflows](docs/suggested-workflows.md)
 * [Why do contract testing?](docs/why-contract-testing.md)
 * [Running your frontend against the examples (content-store not needed)](docs/running-frontend-against-examples.md)
+* [Deployment](docs/deployment.md)
 
 ## Background
 

--- a/docs/adding-a-new-format.md
+++ b/docs/adding-a-new-format.md
@@ -40,7 +40,3 @@ using the rake task in content-store:
 
 If there are examples which are invalid, you may want to change your publisher
 and republish the documents.
-
-## Deploying your changes
-
-Deploy your changes with the [Deploy GOVUK Content Schemas](https://deploy.publishing.service.gov.uk/job/Deploy_GOVUK_Content_Schemas/) Jenkins job.  This makes your changes available to the publishing API for validation and dependency resolution.

--- a/docs/changing-a-format.md
+++ b/docs/changing-a-format.md
@@ -15,4 +15,4 @@ The steps would be:
 4. create a new branch and commit and push your changes
    - this will run a branch build of govuk-content-schemas. This includes running the contract tests for each application which relies on the schemas. You'll get immediate feedback about whether publishing applications generate content items compatible with the new schema.
 5. once the tests pass, someone will merge your pull request and the new schemas will be available to use
-6. Deploy your changes with the [Deploy GOVUK Content Schemas](https://deploy.publishing.service.gov.uk/job/Deploy_GOVUK_Content_Schemas/) Jenkins job.  This makes your changes available to the publishing API for validation and dependency resolution.
+6. Deploy your changes (see [`docs/deployment.md`](docs/deployment.md) for details).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,8 @@
+# Deployment
+
+Deploy your changes with the [Deploy GOVUK Content Schemas](https://deploy.publishing.service.gov.uk/job/Deploy_GOVUK_Content_Schemas/) Jenkins job.  This makes your changes available to the publishing API for validation and dependency resolution.
+
+Currently the validation done by the Publishing API just reports validation failures, and should not effect the operation of the service. As such, deployments can be done as soon as changes are available to deploy.
+
+Deployment is done by the `deploy.sh` script, which will copy the files in
+`dist` on to the relevant servers.


### PR DESCRIPTION
Move the information in to one file, and explicitly state that deployments can
be done as soon as changes are available to deploy.

Trello: https://trello.com/c/0ybQOynQ/733-process-for-deploying-schemas-to-production