### PR TITLE
Add second_level_ordering to MainsteamBrowsePage

### DIFF
--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -215,6 +215,10 @@
             "curated"
           ]
         },
+        "ordered_second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
+          "$ref": "#/definitions/guid_list"
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -17,6 +17,10 @@
             "curated"
           ]
         },
+        "ordered_second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
+          "$ref": "#/definitions/guid_list"
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -17,6 +17,10 @@
             "curated"
           ]
         },
+        "ordered_second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
+          "$ref": "#/definitions/guid_list"
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/formats/mainstream_browse_page/frontend/examples/top_level_page.json
+++ b/formats/mainstream_browse_page/frontend/examples/top_level_page.json
@@ -3,7 +3,12 @@
   "base_path": "/browse/benefits",
   "description": "Includes tax credits, eligibility and appeals",
   "details": {
-    "second_level_ordering": "alphabetical"
+    "second_level_ordering": "alphabetical",
+    "ordered_second_level_browse_pages": [
+      "f91583d0-be95-4dc8-8268-c2551ff8628a",
+      "c7d40a39-bda7-42c3-9287-2c080d10a2a9",
+      "9592c019-1792-430d-88df-df9f560a2d08"
+    ]
   },
   "format": "mainstream_browse_page",
   "links": {

--- a/formats/mainstream_browse_page/frontend/examples/top_level_page_with_child_pages_in_curated_order.json
+++ b/formats/mainstream_browse_page/frontend/examples/top_level_page_with_child_pages_in_curated_order.json
@@ -3,7 +3,12 @@
   "base_path": "/browse/visas-immigration",
   "description": "Visas, settlement, asylum and sponsorship",
   "details": {
-    "second_level_ordering": "curated"
+    "second_level_ordering": "curated",
+    "ordered_second_level_browse_pages": [
+      "0529f318-e05a-4798-9e77-a901eedfdb37",
+      "8e9576ca-8bbe-450f-9eb9-14bea6f93534",
+      "ce9f6198-f7d1-4625-9ae7-9611ffc9caa7"
+    ]
   },
   "format": "mainstream_browse_page",
   "links": {

--- a/formats/mainstream_browse_page/publisher/details.json
+++ b/formats/mainstream_browse_page/publisher/details.json
@@ -10,6 +10,10 @@
     "second_level_ordering": {
       "enum": [ "alphabetical", "curated" ]
     },
+    "ordered_second_level_browse_pages": {
+      "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
+      "$ref": "#/definitions/guid_list"
+    },
     "groups": {
       "type": "array",
       "items": {


### PR DESCRIPTION
content-store does not retain the order of the items that are sent in the links
hash, therefore in order to allow custom 2nd level browse pages ordering we
have to read the links order from the details hash.

paired on it with @rubenarakelyan 