### PR TITLE
Remove service manual guide summary

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -202,9 +202,9 @@
         "body"
       ],
       "properties": {
-        "summary": {
-          "type": "string",
-          "description": "A single line short summary that does not contain formatting."
+        "show_description": {
+          "type": "boolean",
+          "description": "Display the description on the page if true. This is needed for the service standard points."
         },
         "body": {
           "type": "string"

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -10,9 +10,9 @@
         "body"
       ],
       "properties": {
-        "summary": {
-          "type": "string",
-          "description": "A single line short summary that does not contain formatting."
+        "show_description": {
+          "type": "boolean",
+          "description": "Display the description on the page if true. This is needed for the service standard points."
         },
         "body": {
           "type": "string"

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -10,9 +10,9 @@
         "body"
       ],
       "properties": {
-        "summary": {
-          "type": "string",
-          "description": "A single line short summary that does not contain formatting."
+        "show_description": {
+          "type": "boolean",
+          "description": "Display the description on the page if true. This is needed for the service standard points."
         },
         "body": {
           "type": "string"

--- a/formats/service_manual_guide/frontend/examples/point_page.json
+++ b/formats/service_manual_guide/frontend/examples/point_page.json
@@ -4,13 +4,13 @@
   "format": "service_manual_guide",
   "locale": "en",
   "base_path": "/service-standard/service-standard/understand-user-needs",
-  "description": "Understand user needs.",
+  "description": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
   "title": "1. Understand user needs",
   "updated_at": "2015-10-12T08:54:30+00:00",
   "schema_name": "service_manual_guide",
   "document_type": "service_manual_guide",
   "details": {
-    "summary": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
+    "show_description": true,
     "body": "<h2>Why it's in the standard</h2>\n<p>You need to know the people who use your service (your users) and what they want to do (their user needs) if you want to build a service that works for them.</p>\n",
     "header_links": [
       {

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -6,9 +6,9 @@
     "body"
   ],
   "properties": {
-    "summary": {
-      "type": "string",
-      "description": "A single line short summary that does not contain formatting."
+    "show_description": {
+      "type": "boolean",
+      "description": "Display the description on the page if true. This is needed for the service standard points."
     },
     "body": {
       "type": "string"

--- a/formats/service_manual_guide/publisher_v2/examples/point_page.json
+++ b/formats/service_manual_guide/publisher_v2/examples/point_page.json
@@ -5,14 +5,14 @@
   "format": "service_manual_guide",
   "locale": "en",
   "details" : {
-    "summary": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
+    "show_description": true,
     "body": "<h2>Why it's in the standard</h2>\n<p>You need to know the people who use your service (your users) and what they want to do (their user needs) if you want to build a service that works for them.</p>\n",
     "header_links" : [
       { "title" : "Why it's in the standard", "href" : "#why-its-in-the-standard" }
     ]
   },
   "base_path" : "/service-standard/service-standard/understand-user-needs",
-  "description" : "Understand user needs.",
+  "description" : "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
   "title" : "1. Understand user needs",
   "routes": [
     {


### PR DESCRIPTION
We can use the same text for the meta description and the point text.

Because we need to optionally display the description, either for the normal guide page or the point page, the boolean show_description will be used to turn it off and on.