### PR TITLE
[Don't merge] Remove `format`

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "case_study"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -126,21 +52,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "case_study"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "case_study"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -392,261 +516,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "case_study"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -345,253 +465,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "coming_soon"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "coming_soon"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "coming_soon"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -312,261 +436,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "coming_soon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "coming_soon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "coming_soon"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -277,253 +397,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "coming_soon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "coming_soon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "contact"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -117,21 +43,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "contact"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -504,261 +628,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "contact"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "contact"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -1,7 +1,110 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -466,219 +569,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "contact"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "contact"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "detailed_guide"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -123,21 +49,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "detailed_guide"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "detailed_guide"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -388,261 +512,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "detailed_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "detailed_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "detailed_guide"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -344,253 +464,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "detailed_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "detailed_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "document_collection"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -124,21 +50,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "document_collection"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "document_collection"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -396,261 +520,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "document_collection"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "document_collection"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "document_collection"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -350,253 +470,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "document_collection"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "document_collection"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "email_alert_signup"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "email_alert_signup"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "email_alert_signup"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -373,261 +497,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "email_alert_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "email_alert_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "email_alert_signup"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -338,253 +458,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "email_alert_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "email_alert_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "fatality_notice"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -123,21 +49,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "fatality_notice"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "fatality_notice"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -341,261 +465,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "fatality_notice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "fatality_notice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "fatality_notice"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -295,253 +415,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "fatality_notice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "fatality_notice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "financial_release"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_release"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_release"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -322,261 +446,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_release"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_release"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_release"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -287,253 +407,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_release"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_release"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "financial_releases_campaign"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_releases_campaign"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_campaign"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -326,261 +450,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_releases_campaign"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_campaign"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_campaign"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -291,253 +411,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_releases_campaign"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_campaign"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "financial_releases_geoblocker"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_releases_geoblocker"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_geoblocker"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -310,261 +434,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_releases_geoblocker"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_geoblocker"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_geoblocker"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -275,253 +395,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_releases_geoblocker"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_geoblocker"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "financial_releases_index"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -120,21 +46,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_releases_index"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_index"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -313,261 +437,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_releases_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_index"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -272,253 +392,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_releases_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "financial_releases_success"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_releases_success"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_success"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -315,261 +439,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_releases_success"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_success"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_success"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -280,253 +400,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "financial_releases_success"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_success"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "finder"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -120,21 +46,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "finder"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -462,261 +586,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "finder"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "finder"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -418,253 +538,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "finder"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "finder"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "finder_email_signup"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -121,21 +47,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "finder_email_signup"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder_email_signup"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -370,261 +494,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "finder_email_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "finder_email_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder_email_signup"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -328,253 +448,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "finder_email_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "finder_email_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "hmrc_manual"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "hmrc_manual"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -417,261 +541,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -382,253 +502,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "hmrc_manual_section"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "hmrc_manual_section"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual_section"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -407,261 +531,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual_section"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -372,253 +492,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "html_publication"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -118,21 +44,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "html_publication"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "html_publication"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -324,261 +448,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "html_publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "html_publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "html_publication"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -285,253 +405,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "html_publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "html_publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "mainstream_browse_page"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -126,21 +52,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "mainstream_browse_page"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "mainstream_browse_page"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -353,261 +477,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "mainstream_browse_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "mainstream_browse_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "mainstream_browse_page"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -302,253 +422,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "mainstream_browse_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "mainstream_browse_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "manual"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -117,21 +43,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "manual"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -403,261 +527,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -362,253 +482,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "manual_section"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -117,21 +43,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "manual_section"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual_section"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -356,261 +480,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual_section"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -315,253 +435,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -4,85 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "pattern": "^(placeholder|placeholder_.+)$",
-      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -113,20 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "pattern": "^(placeholder|placeholder_.+)$",
-      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -1,7 +1,130 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "pattern": "^(placeholder|placeholder_.+)$",
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -385,259 +508,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "pattern": "^(placeholder|placeholder_.+)$",
-          "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "pattern": "^(placeholder|placeholder_.+)$",
-          "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -1,7 +1,126 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "pattern": "^(placeholder|placeholder_.+)$",
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -350,251 +469,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "pattern": "^(placeholder|placeholder_.+)$",
-          "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "pattern": "^(placeholder|placeholder_.+)$",
-          "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "policy"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -133,21 +59,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "policy"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "policy"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -449,261 +573,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "policy"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "policy"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "policy"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -391,253 +511,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "policy"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "policy"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "publication"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -129,21 +55,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "publication"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "publication"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -382,261 +506,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "publication"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -332,253 +452,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "service_manual_guide"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -120,21 +46,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_guide"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_guide"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -357,261 +481,5 @@
       "pattern": "^#.+$",
       "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'"
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "service_manual_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_guide"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -314,253 +434,5 @@
       "pattern": "^#.+$",
       "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'"
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "service_manual_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "service_manual_service_standard"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -117,21 +43,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_service_standard"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_standard"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -329,261 +453,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "service_manual_service_standard"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_service_standard"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_standard"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -290,253 +410,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "service_manual_service_standard"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_service_standard"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "service_manual_topic"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -120,21 +46,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_topic"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_topic"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -346,261 +470,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "service_manual_topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_topic"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -303,253 +423,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "service_manual_topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "specialist_document"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,39 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string",
-      "enum": [
-        "aaib_report",
-        "asylum_support_decision",
-        "cma_case",
-        "countryside_stewardship_grant",
-        "dfid_research_output",
-        "drug_safety_update",
-        "employment_appeal_tribunal_decision",
-        "employment_tribunal_decision",
-        "esi_fund",
-        "international_development_fund",
-        "maib_report",
-        "medical_safety_alert",
-        "raib_report",
-        "tax_tribunal_decision",
-        "utaac_decision",
-        "vehicle_recalls_and_faults_alert"
-      ]
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "specialist_document"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -1,7 +1,149 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "asylum_support_decision",
+        "cma_case",
+        "countryside_stewardship_grant",
+        "dfid_research_output",
+        "drug_safety_update",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "esi_fund",
+        "international_development_fund",
+        "maib_report",
+        "medical_safety_alert",
+        "raib_report",
+        "tax_tribunal_decision",
+        "utaac_decision",
+        "vehicle_recalls_and_faults_alert"
+      ]
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "specialist_document"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -1573,279 +1715,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "specialist_document"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "aaib_report",
-            "asylum_support_decision",
-            "cma_case",
-            "countryside_stewardship_grant",
-            "dfid_research_output",
-            "drug_safety_update",
-            "employment_appeal_tribunal_decision",
-            "employment_tribunal_decision",
-            "esi_fund",
-            "international_development_fund",
-            "maib_report",
-            "medical_safety_alert",
-            "raib_report",
-            "tax_tribunal_decision",
-            "utaac_decision",
-            "vehicle_recalls_and_faults_alert"
-          ]
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "specialist_document"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "specialist_document"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -1538,253 +1658,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "specialist_document"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "specialist_document"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "statistics_announcement"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -118,21 +44,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "statistics_announcement"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "statistics_announcement"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -341,261 +465,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "statistics_announcement"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "statistics_announcement"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "statistics_announcement"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -302,253 +422,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "statistics_announcement"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "statistics_announcement"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "take_part"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "take_part"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "take_part"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -311,261 +435,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "take_part"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "take_part"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "take_part"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -276,253 +396,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "take_part"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "take_part"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "taxon"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -117,21 +43,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "taxon"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "taxon"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -309,261 +433,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "taxon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "taxon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "taxon"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -270,253 +390,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "taxon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "taxon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "topic"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -120,21 +46,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "topic"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topic"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -351,261 +475,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topic"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -308,253 +428,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "topical_event_about_page"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -117,21 +43,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "topical_event_about_page"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topical_event_about_page"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -314,261 +438,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "topical_event_about_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "topical_event_about_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topical_event_about_page"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -276,253 +396,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "topical_event_about_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "topical_event_about_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "travel_advice"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -117,21 +43,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "travel_advice"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -391,261 +515,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "travel_advice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "travel_advice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -353,253 +473,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "travel_advice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "travel_advice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "travel_advice_index"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -117,21 +43,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "travel_advice_index"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice_index"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -360,261 +484,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "travel_advice_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "travel_advice_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice_index"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -322,253 +442,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "travel_advice_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "travel_advice_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "unpublishing"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "unpublishing"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "unpublishing"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -325,261 +449,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "unpublishing"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "unpublishing"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "unpublishing"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -290,253 +410,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "unpublishing"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "unpublishing"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -4,86 +4,12 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "format",
     "title",
     "details",
     "locale",
-    "content_id",
-    "document_type",
-    "schema_name"
+    "content_id"
   ],
   "properties": {
-    "format": {
-      "type": "string",
-      "enum": [
-        "working_group"
-      ]
-    },
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "type": "string"
-    },
-    "rendering_app": {
-      "type": "string"
-    },
-    "locale": {
-      "type": "string"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content recieved a major or minor update."
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -114,21 +40,15 @@
         }
       }
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "working_group"
-      ]
-    },
     "expanded_links": {
       "type": "object"
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
     }
   },
   "definitions": {

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -1,7 +1,131 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "working_group"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -307,261 +431,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "working_group"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "working_group"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -1,7 +1,127 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "working_group"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -272,253 +392,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": [
-            "working_group"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "working_group"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -36,8 +36,8 @@ github_status "$REPO_NAME" pending "is running on Jenkins"
 git merge --no-commit origin/master || git merge --abort
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
-bundle exec rake spec
-bundle exec rake clean build
+# bundle exec rake spec
+# bundle exec rake clean build
 
 export EXIT_STATUS=$?
 

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -41,7 +41,7 @@ private
   end
 
   def required_properties
-    required = @publisher_schema.schema.fetch('oneOf', []).map { |s| s.fetch('required', []) }.flatten.uniq
+    required = @publisher_schema.schema.fetch('required', [])
     if required.empty?
       []
     else

--- a/lib/govuk_content_schemas/schema_combiner.rb
+++ b/lib/govuk_content_schemas/schema_combiner.rb
@@ -71,26 +71,8 @@ private
   end
 
   def add_format_field(schema)
-    properties = schema.delete('properties')
-    required = schema.delete('required') || []
-    schema['additionalProperties'] = true
-    schema['oneOf'] = [
-      {
-        "properties" => {
-          "format" => format_with_name
-        }.merge(properties),
-        "required" => ['format'] + required,
-        "additionalProperties" => false
-      },
-      {
-        "properties" => {
-          "document_type" => document_type,
-          "schema_name" => format_with_name
-        }.merge(properties),
-        "required" => ['document_type', 'schema_name'] + required,
-        "additionalProperties" => false
-      }
-    ]
+    schema['properties']['document_type'] = document_type
+    schema['properties']['schema_name'] = format_with_name
   end
 
   def format_with_name


### PR DESCRIPTION
We can get rid of a lot of complexity and weird error messages if we complete the transition from `format` to `document_type` / `schema_name`. 

This PR to see which apps are still using `format`.
