### PR TITLE
Allow document_type & schema_name for gone

### DIFF
--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "format",
     "publishing_app",
     "routes"
   ],
@@ -15,6 +14,13 @@
       "$ref": "#/definitions/guid"
     },
     "format": {
+      "description": "DEPRECATED. This field will be removed by Tijmen.",
+      "enum": [ "gone" ]
+    },
+    "document_type": {
+      "enum": [ "gone" ]
+    },
+    "schema_name": {
       "enum": [ "gone" ]
     },
     "publishing_app": {

--- a/dist/formats/redirect/publisher/schema.json
+++ b/dist/formats/redirect/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "format",
     "publishing_app",
     "redirects",
     "base_path",
@@ -17,6 +16,13 @@
       "$ref": "#/definitions/guid"
     },
     "format": {
+      "description": "DEPRECATED: This field will be removed by Tijmen.",
+      "enum": [ "redirect" ]
+    },
+    "document_type": {
+      "enum": [ "redirect" ]
+    },
+    "schema_name": {
       "enum": [ "redirect" ]
     },
     "publishing_app": {

--- a/formats/gone/publisher_v2/schema.json
+++ b/formats/gone/publisher_v2/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "format",
     "publishing_app",
     "routes"
   ],
@@ -15,6 +14,13 @@
       "$ref": "#/definitions/guid"
     },
     "format": {
+      "description": "DEPRECATED. This field will be removed by Tijmen.",
+      "enum": [ "gone" ]
+    },
+    "document_type": {
+      "enum": [ "gone" ]
+    },
+    "schema_name": {
       "enum": [ "gone" ]
     },
     "publishing_app": {

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "format",
     "publishing_app",
     "redirects",
     "base_path",
@@ -17,6 +16,13 @@
       "$ref": "#/definitions/guid"
     },
     "format": {
+      "description": "DEPRECATED: This field will be removed by Tijmen.",
+      "enum": [ "redirect" ]
+    },
+    "document_type": {
+      "enum": [ "redirect" ]
+    },
+    "schema_name": {
       "enum": [ "redirect" ]
     },
     "publishing_app": {


### PR DESCRIPTION
There are a couple of apps still sending `format` to the publishing-api. We've created PRs for these to send `document_type` and `schema_name` but these can't be merged until those attributes are allowed everywhere.

After those PRs are merged `format` will be removed here, and `document_type` & `schema_name` will become required.

Part of: https://github.com/alphagov/govuk-content-schemas/pull/348