### PR TITLE
Use document_type & schema_name in examples

### DIFF
--- a/formats/case_study/publisher_v2/examples/case_study.json
+++ b/formats/case_study/publisher_v2/examples/case_study.json
@@ -3,7 +3,6 @@
   "base_path": "/government/case-studies/get-britain-building-carlisle-park",
   "title": "Get Britain Building: Carlisle Park",
   "description": "Nearly 400 homes are set to be built on the site of a former tar distillery thanks to Gleeson Homes and HCA investment.",
-  "format": "case_study",
   "public_updated_at": "2012-12-17T15:45:44.000+00:00",
   "details": {
     "change_note": null,
@@ -30,6 +29,10 @@
   ],
   "publishing_app": "whitehall",
   "rendering_app": "government-frontend",
-  "need_ids": [],
-  "phase": "live"
+  "need_ids": [
+
+  ],
+  "phase": "live",
+  "document_type": "case_study",
+  "schema_name": "case_study"
 }

--- a/formats/coming_soon/publisher_v2/examples/coming_soon.json
+++ b/formats/coming_soon/publisher_v2/examples/coming_soon.json
@@ -3,16 +3,17 @@
   "details": {
     "publish_time": "2014-12-17T09:30:00+00:00"
   },
-  "format": "coming_soon",
   "locale": "en",
   "title": "Coming soon",
   "publishing_app": "whitehall",
   "rendering_app": "government-frontend",
-   "routes": [
+  "routes": [
     {
       "path": "/government/case-studies/a-random-title-for-a-random-document",
       "type": "exact"
     }
   ],
-  "public_updated_at": "2014-12-15T12:31:00+00:00"
+  "public_updated_at": "2014-12-15T12:31:00+00:00",
+  "document_type": "coming_soon",
+  "schema_name": "coming_soon"
 }

--- a/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
@@ -27,9 +27,15 @@
       }
     ],
     "tags": {
-      "browse_pages": [],
-      "topics": [],
-      "policies": []
+      "browse_pages": [
+
+      ],
+      "topics": [
+
+      ],
+      "policies": [
+
+      ]
     },
     "government": {
       "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
@@ -37,7 +43,9 @@
       "current": false
     },
     "political": false,
-    "emphasised_organisations": ["de4e9dc6-cca4-43af-a594-682023b84d6c"],
+    "emphasised_organisations": [
+      "de4e9dc6-cca4-43af-a594-682023b84d6c"
+    ],
     "withdrawn_notice": {
       "explanation": "<div class=\"govspeak\"><p>This information has been archived as it is now out of date. For current information please go to <a rel=\"external\" href=\"http://www.hse.gov.uk/reach/\">http://www.hse.gov.uk/reach/</a></p></div>",
       "withdrawn_at": "2015-01-28T13:05:30Z"

--- a/formats/email_alert_signup/publisher_v2/examples/email_alert_signup.json
+++ b/formats/email_alert_signup/publisher_v2/examples/email_alert_signup.json
@@ -2,8 +2,9 @@
   "base_path": "/government/policies/employment/email-signup",
   "title": "Employment",
   "description": "",
-  "format": "email_alert_signup",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "locale": "en",
   "public_updated_at": "2015-04-14T10:56:00.000+00:00",
   "publishing_app": "whitehall",
@@ -31,5 +32,7 @@
       "path": "/government/policies/employment/email-signup",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "email_alert_signup",
+  "schema_name": "email_alert_signup"
 }

--- a/formats/financial_release/publisher_v2/examples/financial_release.json
+++ b/formats/financial_release/publisher_v2/examples/financial_release.json
@@ -2,7 +2,6 @@
   "base_path": "/lloyds-share-offer",
   "title": "Financial Release",
   "description": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,quis nostrud exercitation",
-  "format": "financial_release",
   "locale": "en",
   "public_updated_at": "2015-12-01T00:00:00.000Z",
   "publishing_app": "share-sale-publisher",
@@ -24,7 +23,7 @@
       "alt_text": "lloyds-logo",
       "url": "pressrelease.jpg"
     },
-    "body":  [
+    "body": [
       {
         "content_type": "text/govspeak",
         "content": "Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensibus theophrastus consectetuer.\n\nVis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensibus theophrastus consectetuer.\n\nSumo solum quaestio has cu. Eu oblique euismod deleniti eum, congue necessitatibus ne sit.\n\nNo eum mutat soleat definiebas, ut argumentum efficiantur delicatissimi ius. At feugait adversarium vel. At cum mutat numquam graecis. Sit appareat adolescens constituto eu, te eleifend postulant theophrastus eam.\n\nIf you would like to receive email updates for daily ice cream flavours, send us a hand written note.\n\nSumo solum quaestio has cu. Eu oblique euismod deleniti eum, congue necessitatibus ne sit.\n\nVel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne. This can be found at [www.gov.uk/financial-release-campaign](/financial-release-campaign)."
@@ -51,7 +50,10 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
-}
+  "redirects": [
 
+  ],
+  "update_type": "major",
+  "document_type": "financial_release",
+  "schema_name": "financial_release"
+}

--- a/formats/financial_releases_campaign/publisher_v2/examples/financial_releases_campaign.json
+++ b/formats/financial_releases_campaign/publisher_v2/examples/financial_releases_campaign.json
@@ -4,7 +4,6 @@
   "description": "Campaign page for financial press releases",
   "locale": "en",
   "public_updated_at": "2015-12-07T11:22:21.000Z",
-  "format": "financial_releases_campaign",
   "publishing_app": "share-sale-publisher",
   "rendering_app": "email-campaign-frontend",
   "phase": "live",
@@ -23,7 +22,7 @@
         "content": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum <a href=\"/lloydsshares\">www.gov.uk/lloydsshares</a>.</p>\n"
       }
     ],
-    "body":  [
+    "body": [
       {
         "content_type": "text/govspeak",
         "content": "Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensibus theophrastus consectetuer.\nSumo solum quaestio has cu. Eu oblique euismod deleniti eum, congue necessitatibus ne sit.\nNo eum mutat soleat definiebas, ut argumentum efficiantur delicatissimi ius. At feugait adversarium vel. At cum mutat numquam graecis. Sit appareat adolescens constituto eu, te eleifend postulant theophrastus eam\nIf you would like to receive email updates for daily ice cream flavours, send us a hand written note.\nVel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne.If you like yoga [click here](/lloydsfactsheet)."
@@ -74,6 +73,10 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
+  "redirects": [
+
+  ],
+  "update_type": "major",
+  "document_type": "financial_releases_campaign",
+  "schema_name": "financial_releases_campaign"
 }

--- a/formats/financial_releases_geoblocker/publisher_v2/examples/financial_releases_campaign_geoblocker.json
+++ b/formats/financial_releases_geoblocker/publisher_v2/examples/financial_releases_campaign_geoblocker.json
@@ -2,7 +2,6 @@
   "base_path": "/lloydsshares/location",
   "title": "Financial Releases geoblocker",
   "description": "The government will be making shares in Lloyds Banking Group available for sale to the general public.",
-  "format": "financial_releases_geoblocker",
   "locale": "en",
   "public_updated_at": "2015-12-01T00:00:00.000Z",
   "publishing_app": "share-sale-publisher",
@@ -18,7 +17,10 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
-}
+  "redirects": [
 
+  ],
+  "update_type": "major",
+  "document_type": "financial_releases_geoblocker",
+  "schema_name": "financial_releases_geoblocker"
+}

--- a/formats/financial_releases_index/publisher_v2/examples/financial_releases_index.json
+++ b/formats/financial_releases_index/publisher_v2/examples/financial_releases_index.json
@@ -4,7 +4,6 @@
   "description": "Index page for listing financial press releases",
   "locale": "en",
   "public_updated_at": "2015-12-02T17:11:23+01:00",
-  "format": "financial_releases_index",
   "publishing_app": "share-sale-publisher",
   "rendering_app": "email-campaign-frontend",
   "phase": "live",
@@ -20,6 +19,10 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
+  "redirects": [
+
+  ],
+  "update_type": "major",
+  "document_type": "financial_releases_index",
+  "schema_name": "financial_releases_index"
 }

--- a/formats/financial_releases_success/publisher_v2/examples/financial_releases_success.json
+++ b/formats/financial_releases_success/publisher_v2/examples/financial_releases_success.json
@@ -3,7 +3,6 @@
   "locale": "en",
   "public_updated_at": "2015-12-07T11:22:21.000Z",
   "title": "dummy title content for success page",
-  "format": "financial_releases_success",
   "publishing_app": "share-sale-publisher",
   "rendering_app": "email-campaign-frontend",
   "phase": "live",
@@ -18,6 +17,10 @@
       "type": "exact"
     }
   ],
-  "redirects": [],
-  "update_type": "major"
+  "redirects": [
+
+  ],
+  "update_type": "major",
+  "document_type": "financial_releases_success",
+  "schema_name": "financial_releases_success"
 }

--- a/formats/finder/publisher_v2/examples/finder.json
+++ b/formats/finder/publisher_v2/examples/finder.json
@@ -2,8 +2,9 @@
   "base_path": "/cma-cases",
   "title": "Competition and Markets Authority cases",
   "description": "",
-  "format": "finder",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "locale": "en",
   "public_updated_at": "2015-04-30T10:41:26.000+00:00",
   "publishing_app": "specialist-publisher",
@@ -337,5 +338,7 @@
       "path": "/cma-cases",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "finder",
+  "schema_name": "finder"
 }

--- a/formats/gone/publisher/examples/gone.json
+++ b/formats/gone/publisher/examples/gone.json
@@ -1,5 +1,4 @@
 {
-  "format": "gone",
   "publishing_app": "collections-publisher",
   "content_id": "4c5eed70-2fbb-4d39-94f2-de83bc2879a5",
   "update_type": "major",
@@ -8,5 +7,7 @@
       "path": "/some-gone-route",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "gone",
+  "schema_name": "gone"
 }

--- a/formats/gone/publisher_v2/examples/gone.json
+++ b/formats/gone/publisher_v2/examples/gone.json
@@ -1,10 +1,11 @@
 {
-  "format": "gone",
   "publishing_app": "collections-publisher",
   "routes": [
     {
       "path": "/some-gone-route",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "gone",
+  "schema_name": "gone"
 }

--- a/formats/hmrc_manual/publisher_v2/examples/hmrc_manual.json
+++ b/formats/hmrc_manual/publisher_v2/examples/hmrc_manual.json
@@ -2,8 +2,9 @@
   "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies",
   "title": "VAT Government and Public Bodies",
   "description": "Guidance on VAT as it applies to local authorities and other government and public bodies.",
-  "format": "hmrc_manual",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "locale": "en",
   "public_updated_at": "2015-02-11T13:45:00.000+00:00",
   "publishing_app": "hmrc-manuals-api",
@@ -123,5 +124,7 @@
       "path": "/hmrc-internal-manuals/vat-government-and-public-bodies",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "hmrc_manual",
+  "schema_name": "hmrc_manual"
 }

--- a/formats/hmrc_manual_section/publisher_v2/examples/hmrc_manual_section.json
+++ b/formats/hmrc_manual_section/publisher_v2/examples/hmrc_manual_section.json
@@ -2,17 +2,19 @@
   "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
   "title": "Introduction: contents",
   "description": "",
-  "format": "hmrc_manual_section",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "locale": "en",
-  "public_updated_at": "2015-02-10T14:52:10.000+00:00",
   "public_updated_at": "2015-02-11T13:45:00.000+00:00",
   "publishing_app": "hmrc-manuals-api",
   "rendering_app": "manuals-frontend",
   "details": {
     "body": "\n",
     "section_id": "VATGPB1000",
-    "breadcrumbs": [],
+    "breadcrumbs": [
+
+    ],
     "child_section_groups": [
       {
         "child_sections": [
@@ -66,11 +68,12 @@
       }
     ]
   },
- "routes": [
+  "routes": [
     {
       "path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb1000",
       "type": "exact"
     }
-  ]
-
+  ],
+  "document_type": "hmrc_manual_section",
+  "schema_name": "hmrc_manual_section"
 }

--- a/formats/mainstream_browse_page/publisher_v2/examples/mainstream_browse_page.json
+++ b/formats/mainstream_browse_page/publisher_v2/examples/mainstream_browse_page.json
@@ -1,10 +1,12 @@
 {
   "base_path": "/browse",
   "description": "Almost everything on GOV.UK.",
-  "details": {},
-  "format": "mainstream_browse_page",
+  "details": {
+  },
   "locale": "en",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "public_updated_at": "2015-04-20T15:46:10.000+00:00",
   "publishing_app": "collections-publisher",
   "rendering_app": "collections",
@@ -14,6 +16,7 @@
       "path": "/browse",
       "type": "exact"
     }
-  ]
-
+  ],
+  "document_type": "mainstream_browse_page",
+  "schema_name": "mainstream_browse_page"
 }

--- a/formats/manual/publisher_v2/examples/manual.json
+++ b/formats/manual/publisher_v2/examples/manual.json
@@ -2,14 +2,15 @@
   "base_path": "/guidance/content-design",
   "title": "Content design: planning, writing and managing content",
   "description": "Planning and managing digital content to meet the needs the public has of government.",
-  "format": "manual",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "locale": "en",
   "public_updated_at": "2015-04-27T12:54:27.000+00:00",
   "publishing_app": "specialist-publisher",
   "rendering_app": "manuals-frontend",
   "details": {
-    "body":  [
+    "body": [
       {
         "content_type": "text/govspeak",
         "content": "Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensibus theophrastus consectetuer.\nSumo solum quaestio has cu. Eu oblique euismod deleniti eum, congue necessitatibus ne sit.\nNo eum mutat soleat definiebas, ut argumentum efficiantur delicatissimi ius. At feugait adversarium vel. At cum mutat numquam graecis. Sit appareat adolescens constituto eu, te eleifend postulant theophrastus eam\nIf you would like to receive email updates for daily ice cream flavours, send us a hand written note.\nVel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne.If you like yoga [click here](/lloydsfactsheet)."
@@ -80,5 +81,7 @@
       "path": "/guidance/content-design",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "manual",
+  "schema_name": "manual"
 }

--- a/formats/manual_section/publisher_v2/examples/manual_section.json
+++ b/formats/manual_section/publisher_v2/examples/manual_section.json
@@ -2,14 +2,15 @@
   "base_path": "/guidance/content-design/what-is-content-design",
   "title": "What is content design?",
   "description": "Introduction to content design.",
-  "format": "manual_section",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "locale": "en",
   "public_updated_at": "2015-04-24T10:26:26.000+00:00",
   "publishing_app": "hmrc-manuals-api",
   "rendering_app": "manuals-frontend",
   "details": {
-    "body":[
+    "body": [
       {
         "content_type": "text/govspeak",
         "content": "## Designing content, not creating copy\n\nGood content design allows people to do or find out what they need to from government simply and quickly using the most appropriate content format available. It is based on research into GOV.UK user behaviour, analytics and feedback.\n\nGovernment has a tendency to publish content that is more focused on what it wants to say than what the user needs to know. This makes content difficult to understand and act on.\n\nThis can result in frustrated users (citizens, businesspeople and even government experts) who can’t find the information they need or complete the tasks they come to GOV.UK for. We can avoid this on GOV.UK by basing what we publish on research into user behaviour and what users actually need.\n\n## Content design always starts with user needs\n\nWhen we talk about content design we mean taking a user need and presenting it on GOV.UK in the best way possible.\n\nA user need is something that a user will need to do or find out from government and can include:\n\n* finding out who a [new minister](/government/ministers) is\n* working out whether they’re eligible to [claim a benefit](/browse/benefits)\n* registering to [vote online](/register-to-vote)\n* checking the [Trade Tariff](/trade-tariff) for the taxes due on goods they import\n* confirming that a client’s prospective merger is permitted under the current [Competition and Markets Authority guidance]\n(/government/collections/cma-mergers-guidance)\n\nThere are currently over 40 content formats and tools on GOV.UK, all developed in response to the specific needs of different types of users. There can sometimes be more than one way to present content and the decisions have to be made carefully.\n\nBefore publishing to GOV.UK, you need to know your users’ needs and design your content around them. For more detail on how to do this, read the section on [user needs](/guidance/content-design/user-needs).\n\n## Content strategy and design\n\nDepending on what your user needs are, you may need to:\n\n* reduce the amount of content you plan to publish\n* split one big piece of content into smaller pieces\n* change the format of the content\n* put some content in the Mainstream area of the site\n* remove content from the site\n* request a new GOV.UK tool or format to meet the needs of your users\n* publish your content elsewhere, like a blog, partner site or social media\n\nYou’ll need to consider all of this when [planning your content](/guidance/content-design/planning-content). You will also need to consider how long the content will stay on GOV.UK and what will happen to it after it’s out of date. If you need [content design advice](/guidance/contact-the-government-digital-service/request-a-thing#content-advice), you can contact GDS via the [internal support form](https://support.production.alphagov.co.uk).## Designing by writing great content\n\nWriting great content clearly, in plain English, and optimised for the web helps people understand and find the information they need quickly and easily. This guidance and the GOV.UK style guide are based on research about how people use the internet. They show how to [write great content](/guidance/content-design/writing-for-gov-uk).\n\nAs government, we must write so that GOV.UK is accessible to anybody who is interested enough to look. GOV.UK users have different reading abilities and check GOV.UK on a range of devices. Read [how to design accessible content](/guidance/content-design/planning-content#accessibity) on GOV.UK before you start.\n\n## Designing to avoid duplication\n\nContent design also involves making sure content can be easily found on a site with over 100,000 content items (as of 2014).\n\nDuplicate content produces poor search results, confuses the user and damages the credibility of GOV.UK as a brand. Users end up using offline channels, like calling a helpline, because they aren’t sure they have all the information or the right information.\n\n## Content maintenance\n\nGood content design practice ensures that content on GOV.UK stays accurate, relevant, current and optimised both for users and search engines. When content no longer meets users’ needs or is out of date, it needs to be archived or removed from the site. The [section on content maintenance](/guidance/content-design/content-maintenance) looks at how to maintain and review content.\n\n## Simpler, clearer, faster. Applying all of these content design principles mean we do the hard work for the user. But the reward is a site that is simpler, clearer and faster for both government and citizens.\n"
@@ -48,10 +49,12 @@
       }
     ]
   },
- "routes": [
+  "routes": [
     {
       "path": "/guidance/content-design/what-is-content-design",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "manual_section",
+  "schema_name": "manual_section"
 }

--- a/formats/policy/publisher_v2/examples/policy.json
+++ b/formats/policy/publisher_v2/examples/policy.json
@@ -2,8 +2,9 @@
   "base_path": "/government/policies/benefits-reform",
   "title": "Benefits Reform",
   "description": "",
-  "format": "policy",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "locale": "en",
   "public_updated_at": "2015-03-10T11:55:11.066+00:00",
   "publishing_app": "whitehall",
@@ -54,12 +55,14 @@
         "display_as_result_metadata": true,
         "filterable": false
       }
-   ]
- },
- "routes": [
-   {
-     "path": "/government/policies/benefits-reform",
-     "type": "exact"
-   }
- ]
+    ]
+  },
+  "routes": [
+    {
+      "path": "/government/policies/benefits-reform",
+      "type": "exact"
+    }
+  ],
+  "document_type": "policy",
+  "schema_name": "policy"
 }

--- a/formats/redirect/publisher/examples/redirect-with-replacement.json
+++ b/formats/redirect/publisher/examples/redirect-with-replacement.json
@@ -1,6 +1,5 @@
 {
   "content_id": "f779f980-403d-473b-80aa-f038a58c3107",
-  "format": "redirect",
   "base_path": "/406beacon",
   "publishing_app": "short-url-manager",
   "update_type": "minor",
@@ -10,5 +9,7 @@
       "type": "exact",
       "destination": "/maritime-safety-weather-and-navigation/register-406-mhz-beacons?query=answer#fragment"
     }
-  ]
+  ],
+  "document_type": "redirect",
+  "schema_name": "redirect"
 }

--- a/formats/redirect/publisher/examples/redirect.json
+++ b/formats/redirect/publisher/examples/redirect.json
@@ -1,6 +1,5 @@
 {
   "content_id": "f779f980-403d-473b-80aa-f038a58c3107",
-  "format": "redirect",
   "base_path": "/406beacon",
   "publishing_app": "short-url-manager",
   "update_type": "minor",
@@ -10,5 +9,7 @@
       "type": "exact",
       "destination": "/maritime-safety-weather-and-navigation/register-406-mhz-beacons?query=answer#fragment"
     }
-  ]
+  ],
+  "document_type": "redirect",
+  "schema_name": "redirect"
 }

--- a/formats/redirect/publisher_v2/examples/redirect-with-replacement.json
+++ b/formats/redirect/publisher_v2/examples/redirect-with-replacement.json
@@ -1,5 +1,4 @@
 {
-  "format": "redirect",
   "base_path": "/406beacon",
   "publishing_app": "short-url-manager",
   "public_updated_at": "2016-02-25T16:10:40Z",
@@ -9,5 +8,7 @@
       "type": "exact",
       "destination": "/maritime-safety-weather-and-navigation/register-406-mhz-beacons?query=answer#fragment"
     }
-  ]
+  ],
+  "document_type": "redirect",
+  "schema_name": "redirect"
 }

--- a/formats/redirect/publisher_v2/examples/redirect.json
+++ b/formats/redirect/publisher_v2/examples/redirect.json
@@ -1,5 +1,4 @@
 {
-  "format": "redirect",
   "base_path": "/406beacon",
   "publishing_app": "short-url-manager",
   "public_updated_at": "2016-02-25T16:10:40Z",
@@ -9,5 +8,7 @@
       "type": "exact",
       "destination": "/maritime-safety-weather-and-navigation/register-406-mhz-beacons?query=answer#fragment"
     }
-  ]
+  ],
+  "document_type": "redirect",
+  "schema_name": "redirect"
 }

--- a/formats/service_manual_guide/publisher_v2/examples/point_page.json
+++ b/formats/service_manual_guide/publisher_v2/examples/point_page.json
@@ -1,23 +1,27 @@
 {
   "publishing_app": "service-manual-publisher",
   "rendering_app": "government-frontend",
-  "public_updated_at" : "2015-10-09T08:17:10+00:00",
-  "format": "service_manual_guide",
+  "public_updated_at": "2015-10-09T08:17:10+00:00",
   "locale": "en",
-  "details" : {
+  "details": {
     "show_description": true,
     "body": "<h2>Why it's in the standard</h2>\n<p>You need to know the people who use your service (your users) and what they want to do (their user needs) if you want to build a service that works for them.</p>\n",
-    "header_links" : [
-      { "title" : "Why it's in the standard", "href" : "#why-its-in-the-standard" }
+    "header_links": [
+      {
+        "title": "Why it's in the standard",
+        "href": "#why-its-in-the-standard"
+      }
     ]
   },
-  "base_path" : "/service-standard/service-standard/understand-user-needs",
-  "description" : "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
-  "title" : "1. Understand user needs",
+  "base_path": "/service-standard/service-standard/understand-user-needs",
+  "description": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
+  "title": "1. Understand user needs",
   "routes": [
     {
       "path": "/service-standard/service-standard/understand-user-needs",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "service_manual_guide",
+  "schema_name": "service_manual_guide"
 }

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
@@ -1,22 +1,26 @@
 {
   "publishing_app": "service-manual-publisher",
   "rendering_app": "government-frontend",
-  "public_updated_at" : "2015-10-09T08:17:10+00:00",
-  "format": "service_manual_guide",
+  "public_updated_at": "2015-10-09T08:17:10+00:00",
   "locale": "en",
-  "details" : {
-    "body" : "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "header_links" : [
-      { "title" : "What is it, why it works and how to do it", "href" : "#what-is-it-why-it-works-and-how-to-do-it" }
+  "details": {
+    "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
+    "header_links": [
+      {
+        "title": "What is it, why it works and how to do it",
+        "href": "#what-is-it-why-it-works-and-how-to-do-it"
+      }
     ]
   },
-  "base_path" : "/service-manual/agile",
-  "description" : "What agile is, why it works and how to do it",
-  "title" : "Agile",
+  "base_path": "/service-manual/agile",
+  "description": "What agile is, why it works and how to do it",
+  "title": "Agile",
   "routes": [
     {
       "path": "/service-manual/agile",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "service_manual_guide",
+  "schema_name": "service_manual_guide"
 }

--- a/formats/service_manual_guide/publisher_v2/examples/with_change_history.json
+++ b/formats/service_manual_guide/publisher_v2/examples/with_change_history.json
@@ -1,13 +1,15 @@
 {
   "publishing_app": "service-manual-publisher",
   "rendering_app": "government-frontend",
-  "public_updated_at" : "2015-10-09T08:17:10+00:00",
-  "format": "service_manual_guide",
+  "public_updated_at": "2015-10-09T08:17:10+00:00",
   "locale": "en",
-  "details" : {
-    "body" : "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
-    "header_links" : [
-      { "title" : "What is it, why it works and how to do it", "href" : "#what-is-it-why-it-works-and-how-to-do-it" }
+  "details": {
+    "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",
+    "header_links": [
+      {
+        "title": "What is it, why it works and how to do it",
+        "href": "#what-is-it-why-it-works-and-how-to-do-it"
+      }
     ],
     "change_history": [
       {
@@ -17,13 +19,15 @@
       }
     ]
   },
-  "base_path" : "/service-manual/agile",
-  "description" : "What agile is, why it works and how to do it",
-  "title" : "Agile",
+  "base_path": "/service-manual/agile",
+  "description": "What agile is, why it works and how to do it",
+  "title": "Agile",
   "routes": [
     {
       "path": "/service-manual/agile",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "service_manual_guide",
+  "schema_name": "service_manual_guide"
 }

--- a/formats/service_manual_service_standard/publisher_v2/examples/service_manual_service_standard.json
+++ b/formats/service_manual_service_standard/publisher_v2/examples/service_manual_service_standard.json
@@ -1,14 +1,13 @@
 {
-  "publishing_app":"service-manual-publisher",
-  "rendering_app":"service-manual-frontend",
-  "format": "service_manual_service_standard",
+  "publishing_app": "service-manual-publisher",
+  "rendering_app": "service-manual-frontend",
   "locale": "en",
-  "update_type":"major",
+  "update_type": "major",
   "base_path": "/service-manual/service-standard",
-  "public_updated_at" : "2015-10-09T08:17:10+00:00",
+  "public_updated_at": "2015-10-09T08:17:10+00:00",
   "title": "Digital Service Standard",
-  "description":"Digital Service Standard",
-  "phase":"beta",
+  "description": "Digital Service Standard",
+  "phase": "beta",
   "routes": [
     {
       "path": "/service-manual/service-standard",
@@ -28,5 +27,7 @@
         "base_path": "/service-manual/service-standard/do-ongoing-user-research"
       }
     ]
-  }
+  },
+  "document_type": "service_manual_service_standard",
+  "schema_name": "service_manual_service_standard"
 }

--- a/formats/service_manual_topic/publisher_v2/examples/service_manual_topic.json
+++ b/formats/service_manual_topic/publisher_v2/examples/service_manual_topic.json
@@ -1,31 +1,32 @@
 {
-  "publishing_app":"service-manual-publisher",
-  "rendering_app":"government-frontend",
-  "format":"service_manual_topic",
-  "locale":"en",
-  "update_type":"minor",
-  "base_path":"/service-manual/technology",
-  "public_updated_at":"2016-02-11T15:42:55Z",
-  "title":"Technology",
-  "description":"A tech description.",
-  "phase":"beta",
+  "publishing_app": "service-manual-publisher",
+  "rendering_app": "government-frontend",
+  "locale": "en",
+  "update_type": "minor",
+  "base_path": "/service-manual/technology",
+  "public_updated_at": "2016-02-11T15:42:55Z",
+  "title": "Technology",
+  "description": "A tech description.",
+  "phase": "beta",
   "routes": [
     {
-      "type":"exact",
-      "path":"/service-manual/technology"
+      "type": "exact",
+      "path": "/service-manual/technology"
     }
   ],
   "details": {
     "visually_collapsed": true,
     "groups": [
       {
-        "name":"Security",
-        "description":"A security description.",
+        "name": "Security",
+        "description": "A security description.",
         "content_ids": [
           "f84918f1-de82-4a8e-a4c5-d65872307a4f",
           "1e8c2361-ad63-4513-b7c0-9888c0880092"
         ]
       }
     ]
-  }
+  },
+  "document_type": "service_manual_topic",
+  "schema_name": "service_manual_topic"
 }

--- a/formats/specialist_document/publisher_v2/examples/specialist_document.json
+++ b/formats/specialist_document/publisher_v2/examples/specialist_document.json
@@ -2,7 +2,6 @@
   "base_path": "/cma-cases/example-cma-case",
   "title": "Example CMA Case",
   "description": "This is the summary of an example CMA case",
-  "format": "specialist_document",
   "public_updated_at": "2015-02-11T13:45:00.000+00:00",
   "publishing_app": "specialist-publisher",
   "rendering_app": "specialist-frontend",
@@ -17,7 +16,8 @@
       {
         "content_type": "text/govspeak",
         "content": "## Header\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case\r\n\r\nThis is the long body of an example CMA case"
-      }],
+      }
+    ],
     "attachments": [
       {
         "content_id": "0aa1aa33-36b9-4677-a643-52b9034a1c32",
@@ -36,24 +36,32 @@
         "updated_at": "2015-02-13T13:45:00.000+00:00"
       }
     ],
-    "change_history": [],
+    "change_history": [
+
+    ],
     "metadata": {
       "bulk_published": false,
       "opened_date": "2014-01-01",
       "closed_date": "2015-02-02",
       "case_type": "ca98-and-civil-cartels",
       "case_state": "open",
-      "market_sector": ["energy"],
+      "market_sector": [
+        "energy"
+      ],
       "outcome_type": "ca98-commitment",
       "document_type": "cma_case"
     },
     "max_cache_time": 10
   },
- "routes": [
+  "routes": [
     {
       "path": "/cma-cases/example-cma-case",
       "type": "exact"
     }
   ],
-  "redirects": []
+  "redirects": [
+
+  ],
+  "document_type": "cma_case",
+  "schema_name": "specialist_document"
 }

--- a/formats/topic/publisher_v2/examples/topic.json
+++ b/formats/topic/publisher_v2/examples/topic.json
@@ -1,8 +1,8 @@
 {
   "base_path": "/topic/oil-and-gas",
   "description": "",
-  "details": {},
-  "format": "topic",
+  "details": {
+  },
   "publishing_app": "collections-publisher",
   "rendering_app": "collections",
   "routes": [
@@ -12,7 +12,11 @@
     }
   ],
   "locale": "en",
-  "need_ids": [],
+  "need_ids": [
+
+  ],
   "public_updated_at": "2015-04-20T15:46:10.000+00:00",
-  "title": "Oil and gas"
+  "title": "Oil and gas",
+  "document_type": "topic",
+  "schema_name": "topic"
 }

--- a/formats/travel_advice/publisher_v2/examples/travel_advice.json
+++ b/formats/travel_advice/publisher_v2/examples/travel_advice.json
@@ -20,7 +20,9 @@
     "updated_at": "2015-10-15T11:00:20+01:00",
     "reviewed_at": "2015-10-15T11:00:20+01:00",
     "change_description": "Latest Update - this advice has been reviewed and re-issued without amendment",
-    "alert_status": [],
+    "alert_status": [
+
+    ],
     "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
     "image": {
       "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg",
@@ -147,9 +149,10 @@
     "max_cache_time": 10,
     "publishing_request_id": "2546-1460985144476-19268198-3242"
   },
-  "format": "travel_advice",
   "locale": "en",
-  "need_ids": ["101191"],
+  "need_ids": [
+    "101191"
+  ],
   "public_updated_at": "2015-10-15T11:00:20+01:00",
   "publishing_app": "travel-advice-publisher",
   "rendering_app": "frontend",
@@ -158,5 +161,7 @@
       "path": "/foreign-travel-advice/albania",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "travel_advice",
+  "schema_name": "travel_advice"
 }

--- a/formats/travel_advice_index/frontend/examples/index.json
+++ b/formats/travel_advice_index/frontend/examples/index.json
@@ -12,7 +12,9 @@
         "updated_at": "2016-01-01T00:00:00+00:00",
         "public_updated_at": "2015-01-01T00:00:00+00:00",
         "change_description": "Latest update: Summary - on 26 October 2015 a serious earthquake struck causing casualties around the country and affecting communications networks; if someone you know is likely to have been involved and you're unable to contact them, contact the British Embassy in Kabul",
-        "synonyms": []
+        "synonyms": [
+
+        ]
       },
       {
         "name": "Austria",
@@ -20,7 +22,9 @@
         "updated_at": "2016-01-02T00:00:00+00:00",
         "public_updated_at": "2015-01-02T00:00:00+00:00",
         "change_description": "Latest update: Summary – there’s ongoing disruption to rail and road transport; you should monitor local media and check with your transport provider or the Austrian Railways (OBB) website",
-        "synonyms": []
+        "synonyms": [
+
+        ]
       },
       {
         "name": "Finland",
@@ -38,7 +42,9 @@
         "updated_at": "2016-01-04T00:00:00+00:00",
         "public_updated_at": "2015-01-04T00:00:00+00:00",
         "change_description": "Latest update: Summary – removal of advice on Assam floods and the curfew in Srinagar ",
-        "synonyms": []
+        "synonyms": [
+
+        ]
       },
       {
         "name": "Malaysia",

--- a/formats/travel_advice_index/publisher_v2/examples/travel_advice_index.json
+++ b/formats/travel_advice_index/publisher_v2/examples/travel_advice_index.json
@@ -12,7 +12,9 @@
         "updated_at": "2016-01-01T00:00:00+00:00",
         "public_updated_at": "2015-01-01T00:00:00+00:00",
         "change_description": "Latest update: Summary - on 26 October 2015 a serious earthquake struck causing casualties around the country and affecting communications networks; if someone you know is likely to have been involved and you're unable to contact them, contact the British Embassy in Kabul",
-        "synonyms": [ ]
+        "synonyms": [
+
+        ]
       },
       {
         "name": "Austria",
@@ -20,7 +22,9 @@
         "updated_at": "2016-01-02T00:00:00+00:00",
         "public_updated_at": "2015-01-02T00:00:00+00:00",
         "change_description": "Latest update: Summary – there’s ongoing disruption to rail and road transport; you should monitor local media and check with your transport provider or the Austrian Railways (OBB) website",
-        "synonyms": [ ]
+        "synonyms": [
+
+        ]
       },
       {
         "name": "Finland",
@@ -28,7 +32,9 @@
         "updated_at": "2016-01-03T00:00:00+00:00",
         "public_updated_at": "2015-01-03T00:00:00+00:00",
         "change_description": "Latest update: Summary – removal of advice on Northern Ireland football match",
-        "synonyms": [ "arctic" ]
+        "synonyms": [
+          "arctic"
+        ]
       },
       {
         "name": "India",
@@ -36,7 +42,9 @@
         "updated_at": "2016-01-04T00:00:00+00:00",
         "public_updated_at": "2015-01-04T00:00:00+00:00",
         "change_description": "Latest update: Summary – removal of advice on Assam floods and the curfew in Srinagar ",
-        "synonyms": [ ]
+        "synonyms": [
+
+        ]
       },
       {
         "name": "Malaysia",
@@ -44,7 +52,9 @@
         "updated_at": "2016-01-05T00:00:00+00:00",
         "public_updated_at": "2015-01-05T00:00:00+00:00",
         "change_description": "Latest update: Summary - haze can cause disruption to local, regional air travel and to government and private schools",
-        "synonyms": [ "Borneo" ]
+        "synonyms": [
+          "Borneo"
+        ]
       },
       {
         "name": "Spain",
@@ -52,15 +62,27 @@
         "updated_at": "2016-06-06T00:00:00+00:00",
         "public_updated_at": "2015-01-06T00:00:00+00:00",
         "change_description": "Latest update: Summary – information and advice for Manchester City fans travelling to Seville ",
-        "synonyms": [ "Ibiza", "Majorca", "Mallorca", "Lanzarote", "Barcelona", "Benidorm", "Tenerife", "Canary Islands", "Canaries", "Gran Canaria" ]
+        "synonyms": [
+          "Ibiza",
+          "Majorca",
+          "Mallorca",
+          "Lanzarote",
+          "Barcelona",
+          "Benidorm",
+          "Tenerife",
+          "Canary Islands",
+          "Canaries",
+          "Gran Canaria"
+        ]
       }
     ],
     "max_cache_time": 10,
     "publishing_request_id": "2546-1460985144476-19268198-3242"
   },
-  "format": "travel_advice_index",
   "locale": "en",
-  "need_ids": ["101191"],
+  "need_ids": [
+    "101191"
+  ],
   "publishing_app": "travel-advice-publisher",
   "rendering_app": "frontend",
   "routes": [
@@ -68,5 +90,7 @@
       "path": "/foreign-travel-advice/albania",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "travel_advice_index",
+  "schema_name": "travel_advice_index"
 }

--- a/formats/unpublishing/publisher_v2/examples/unpublishing.json
+++ b/formats/unpublishing/publisher_v2/examples/unpublishing.json
@@ -1,16 +1,17 @@
 {
-  "base_path":"/government/case-studies/bubble-trouble",
-  "title":"Bubble and trouble",
-  "description":"A case study about bubble and trouble.",
-  "format":"unpublishing",
-  "need_ids":[],
-  "locale":"en",
-  "public_updated_at":"2014-04-30T23:01:51.000+00:00",
+  "base_path": "/government/case-studies/bubble-trouble",
+  "title": "Bubble and trouble",
+  "description": "A case study about bubble and trouble.",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "public_updated_at": "2014-04-30T23:01:51.000+00:00",
   "publishing_app": "whitehall",
   "rendering_app": "government-frontend",
-  "details":{
+  "details": {
     "explanation": "This is now redundant",
-    "unpublished_at":"2014-05-01T14:59:17+01:00",
+    "unpublished_at": "2014-05-01T14:59:17+01:00",
     "alternative_url": null
   },
   "routes": [
@@ -18,5 +19,7 @@
       "path": "/government/case-studies/bubble-trouble",
       "type": "exact"
     }
-  ]
+  ],
+  "document_type": "unpublishing",
+  "schema_name": "unpublishing"
 }

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -1,9 +1,6 @@
 def schema_path_for(example)
   schema_filename = example.end_with?("_links.json") ? "links.json" : "schema.json"
-  candidates = []
-  candidates << (File.dirname(File.dirname(example)) + "/" + schema_filename).gsub(%r{formats/}, "dist/formats/")
-  candidates << (File.dirname(File.dirname(example)) + "/" + schema_filename).gsub(%r{formats/}, "formats/")
-  candidates.find { |path| File.exist?(path) }
+  (File.dirname(File.dirname(example)) + "/" + schema_filename).gsub(%r[formats/], "dist/formats/")
 end
 
 def valid?(example)


### PR DESCRIPTION
- Add document_type & schema_name to all examples
- Remove `format` from publisher examples. Frontends still rely on `format` being present, so we need to keep that attribute in the schema.

Part of: https://github.com/alphagov/govuk-content-schemas/pull/348