### PR TITLE
Allow document_type & schema_name in old `gone`

### DIFF
--- a/dist/formats/gone/publisher/schema.json
+++ b/dist/formats/gone/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "format",
     "publishing_app",
     "update_type",
     "routes"
@@ -17,6 +16,13 @@
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
     },
     "format": {
+      "description": "DEPRECATED. This field will be removed by Tijmen.",
+      "enum": [ "gone" ]
+    },
+    "document_type": {
+      "enum": [ "gone" ]
+    },
+    "schema_name": {
       "enum": [ "gone" ]
     },
     "publishing_app": {

--- a/formats/gone/publisher/schema.json
+++ b/formats/gone/publisher/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "format",
     "publishing_app",
     "update_type",
     "routes"
@@ -17,6 +16,13 @@
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
     },
     "format": {
+      "description": "DEPRECATED. This field will be removed by Tijmen.",
+      "enum": [ "gone" ]
+    },
+    "document_type": {
+      "enum": [ "gone" ]
+    },
+    "schema_name": {
       "enum": [ "gone" ]
     },
     "publishing_app": {


### PR DESCRIPTION
This format is a deprecated V1 format, but it still needs to be updated so that the examples will be valid with the new fields.

Follow up to: https://github.com/alphagov/govuk-content-schemas/pull/349
Needed for: https://github.com/alphagov/govuk-content-schemas/pull/351 to pass.
Part of: https://github.com/alphagov/govuk-content-schemas/pull/348