### PR TITLE
Remove `format`, make `document_type` required

### DIFF
--- a/dist/formats/gone/publisher/schema.json
+++ b/dist/formats/gone/publisher/schema.json
@@ -3,9 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "document_type",
     "publishing_app",
-    "update_type",
-    "routes"
+    "routes",
+    "schema_name",
+    "update_type"
   ],
   "properties": {
     "base_path": {
@@ -14,10 +16,6 @@
     "content_id": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [ "gone" ]
     },
     "document_type": {
       "enum": [ "gone" ]

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -3,8 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "document_type",
     "publishing_app",
-    "routes"
+    "routes",
+    "schema_name"
   ],
   "properties": {
     "base_path": {
@@ -12,10 +14,6 @@
     },
     "content_id": {
       "$ref": "#/definitions/guid"
-    },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [ "gone" ]
     },
     "document_type": {
       "enum": [ "gone" ]

--- a/dist/formats/redirect/publisher/schema.json
+++ b/dist/formats/redirect/publisher/schema.json
@@ -3,10 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "base_path",
+    "content_id",
+    "document_type",
     "publishing_app",
     "redirects",
-    "base_path",
-    "content_id"
+    "schema_name"
   ],
   "properties": {
     "base_path": {
@@ -14,10 +16,6 @@
     },
     "content_id": {
       "$ref": "#/definitions/guid"
-    },
-    "format": {
-      "description": "DEPRECATED: This field will be removed by Tijmen.",
-      "enum": [ "redirect" ]
     },
     "document_type": {
       "enum": [ "redirect" ]

--- a/formats/gone/publisher/schema.json
+++ b/formats/gone/publisher/schema.json
@@ -3,9 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "document_type",
     "publishing_app",
-    "update_type",
-    "routes"
+    "routes",
+    "schema_name",
+    "update_type"
   ],
   "properties": {
     "base_path": {
@@ -14,10 +16,6 @@
     "content_id": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [ "gone" ]
     },
     "document_type": {
       "enum": [ "gone" ]

--- a/formats/gone/publisher_v2/schema.json
+++ b/formats/gone/publisher_v2/schema.json
@@ -3,8 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "document_type",
     "publishing_app",
-    "routes"
+    "routes",
+    "schema_name"
   ],
   "properties": {
     "base_path": {
@@ -12,10 +14,6 @@
     },
     "content_id": {
       "$ref": "#/definitions/guid"
-    },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [ "gone" ]
     },
     "document_type": {
       "enum": [ "gone" ]

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -3,10 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "base_path",
+    "content_id",
+    "document_type",
     "publishing_app",
     "redirects",
-    "base_path",
-    "content_id"
+    "schema_name"
   ],
   "properties": {
     "base_path": {
@@ -14,10 +16,6 @@
     },
     "content_id": {
       "$ref": "#/definitions/guid"
-    },
-    "format": {
-      "description": "DEPRECATED: This field will be removed by Tijmen.",
-      "enum": [ "redirect" ]
     },
     "document_type": {
       "enum": [ "redirect" ]


### PR DESCRIPTION
This makes `document_type` & `schema_name` required and removes the last `format` fields from the handmade schemas. This is possible now that no apps send `format` to the publishing-api.

Part of: https://github.com/alphagov/govuk-content-schemas/pull/348