### PR TITLE
Add an example of a topic that does not use sections

### DIFF
--- a/formats/service_manual_topic/frontend/examples/service_manual_topic_without_sections.json
+++ b/formats/service_manual_topic/frontend/examples/service_manual_topic_without_sections.json
@@ -1,0 +1,64 @@
+{
+  "base_path": "/service-manual/service-assessments",
+  "content_id": "20c9788e-4e74-4cfe-939b-61fcf47962e0",
+  "title": "Service assessments",
+  "format": "service_manual_topic",
+  "need_ids": [],
+  "locale": "en",
+  "updated_at": "2016-01-15T16:53:47.645Z",
+  "public_updated_at": "2016-01-15T15:31:21.000+00:00",
+  "phase": "alpha",
+  "analytics_identifier": null,
+  "links": {
+    "content_owners": [
+      {
+        "content_id": "c5042bc1-d95c-41d7-8742-1f0b59f891ff",
+        "title": "Standards and assurance community",
+        "base_path": "/service-manual/communities/standards-and-assurance-community",
+        "description": "The standards and assurance community is for anyone with an interest in government standards and how they can be used to build high quality digital services.",
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/standards-and-assurance-community",
+        "web_url": "http://www.dev.gov.uk/service-manual/communities/standards-and-assurance-community",
+        "locale": "en",
+        "analytics_identifier": null
+      }
+    ],
+    "linked_items": [
+      {
+        "content_id": "a69b577d-8660-4bee-90de-e5ac3b267a03",
+        "title": "How service assessments work",
+        "base_path": "/service-manual/service-assessments/how-service-assessments-work",
+        "description": "What happens at a service assessment and what to do when you get your results.",
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/service-assessments/how-service-assessments-work",
+        "web_url": "http://www.dev.gov.uk/service-manual/service-assessments/how-service-assessments-work",
+        "locale": "en",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "5394d049-1f7d-466e-af1a-44afd7dab46f",
+        "title": "Check if you need to get your service assessed",
+        "base_path": "/service-manual/service-assessments/check-if-you-need-a-service-assessment",
+        "description": "How to find out if your service needs to be assessed and arrange your 3 assessments.",
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/service-assessments/check-if-you-need-a-service-assessment",
+        "web_url": "http://www.dev.gov.uk/service-manual/service-assessments/check-if-you-need-a-service-assessment",
+        "locale": "en",
+        "analytics_identifier": null
+      }
+    ]
+  },
+  "description": "Check if you need a service assessment and find out how to book one.",
+  "details": {
+    "visually_collapsed": true,
+    "groups": [
+      {
+        "name": "",
+        "description": "",
+        "content_ids": [
+          "a69b577d-8660-4bee-90de-e5ac3b267a03",
+          "5394d049-1f7d-466e-af1a-44afd7dab46f"
+        ]
+      }
+    ]
+  },
+  "schema_name": "service_manual_topic",
+  "document_type": "service_manual_topic"
+}


### PR DESCRIPTION
Some topics exist that have exactly one group (section) which has neither a name nor a description. We need to test that as a special case in the front-end, so add an example we can use.