### PR TITLE
Add taxon parents link to taxon

### DIFF
--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -88,6 +88,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "taxon_parents": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "alpha_taxons": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -17,6 +17,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "taxon_parents": {
+          "description": "The list of taxon parents.",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -10,6 +10,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "taxon_parents": {
+          "description": "The list of taxon parents.",
+          "$ref": "#/definitions/guid_list"
+        },
         "alpha_taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/formats/taxon/frontend/examples/taxon.json
+++ b/formats/taxon/frontend/examples/taxon.json
@@ -7,6 +7,24 @@
   "locale": "en",
   "details": {},
   "links": {
+    "taxon_parents": [
+      {
+        "content_id": "f6eef5ca-be55-41b2-98be-f72b3e649b84",
+        "base_path": "/alpha-taxonomy/curriculum-and-qualifications",
+        "title": "Curriculum and qualifications",
+        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/curriculum-and-qualifications",
+        "web_url": "https://www.gov.uk/alpha-taxonomy/curriculum-and-qualifications",
+        "locale": "en"
+      },
+      {
+        "content_id": "6b404e13-f681-44cb-b51f-bff084710fd9",
+        "base_path": "/alpha-taxonomy/driving-and-vehicles",
+        "title": "Driving and vehicles",
+        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/driving-and-vehicles",
+        "web_url": "https://www.gov.uk/alpha-taxonomy/driving-and-vehicles",
+        "locale": "en"
+      }
+    ],
     "parent": [
       {
         "content_id": "f6eef5ca-be55-41b2-98be-f72b3e649b84",

--- a/formats/taxon/publisher/links.json
+++ b/formats/taxon/publisher/links.json
@@ -2,5 +2,10 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "properties": {}
+  "properties": {
+    "taxon_parents": {
+      "description": "The list of taxon parents.",
+      "$ref": "#/definitions/guid_list"
+    }
+  }
 }


### PR DESCRIPTION
We would like to allow taxons to have multiple taxon parents associated. Rather than changing the existing `parent` link (which is used for the breadcrumbs and only allows one association), we created a new link type called `taxon_parents`. This should allow a number of parents on any given taxon.

More details here: https://trello.com/c/nImPlcNS/19-allow-taxons-to-have-multiple-parents