### PR TITLE
Add an ‘uploaded_attachment’ field to specialist documents

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -225,6 +225,10 @@
             "$ref": "#/definitions/asset_link"
           }
         },
+        "uploaded_attachment": {
+          "type": "boolean",
+          "description": "This is true if the last update to the document uploaded an attachment."
+        },
         "metadata": {
           "$ref": "#/definitions/any_metadata"
         },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -21,6 +21,10 @@
             "$ref": "#/definitions/asset_link"
           }
         },
+        "uploaded_attachment": {
+          "type": "boolean",
+          "description": "This is true if the last update to the document uploaded an attachment."
+        },
         "metadata": {
           "$ref": "#/definitions/any_metadata"
         },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -21,6 +21,10 @@
             "$ref": "#/definitions/asset_link"
           }
         },
+        "uploaded_attachment": {
+          "type": "boolean",
+          "description": "This is true if the last update to the document uploaded an attachment."
+        },
         "metadata": {
           "$ref": "#/definitions/any_metadata"
         },

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -2112,6 +2112,10 @@
                 "$ref": "#/definitions/asset_link"
               }
             },
+            "uploaded_attachment": {
+              "type": "boolean",
+              "description": "This is true if the last update to the document uploaded an attachment."
+            },
             "metadata": {
               "$ref": "#/definitions/any_metadata"
             },

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -17,6 +17,10 @@
         "$ref": "#/definitions/asset_link"
       }
     },
+    "uploaded_attachment": {
+      "type": "boolean",
+      "description": "This is true if the last update to the document uploaded an attachment."
+    },
     "metadata": {
       "$ref": "#/definitions/any_metadata"
     },


### PR DESCRIPTION
Relates to: https://trello.com/c/oxxALgmy/187-changes-to-update-type-for-raib-reports