### PR TITLE
Deploy schemas to draft content store

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,6 @@ for server in $(govuk_node_list -c backend); do
   rsync -r dist/* deploy@$server:/data/apps/publishing-api/shared/govuk-content-schemas/
 done
 
-for server in $(govuk_node_list -c content_store); do
+for server in $(govuk_node_list -c "draft_content_store,content_store"); do
   rsync -r dist/* deploy@$server:/data/apps/content-store/shared/govuk-content-schemas/
 done


### PR DESCRIPTION
The content store validates presented content against the relevant frontend schema regardless of whether it's a draft or live content store. So copy schemas to the draft stores too.