### PR TITLE
Add 'temporary_update_type' to specialist documents

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -237,6 +237,10 @@
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "temporary_update_type": {
+          "type": "boolean",
+          "description": "Indicates that the user should choose a new update type on the next save."
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -33,6 +33,10 @@
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "temporary_update_type": {
+          "type": "boolean",
+          "description": "Indicates that the user should choose a new update type on the next save."
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -33,6 +33,10 @@
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "temporary_update_type": {
+          "type": "boolean",
+          "description": "Indicates that the user should choose a new update type on the next save."
         }
       }
     },

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -2124,6 +2124,10 @@
             },
             "change_history": {
               "$ref": "#/definitions/change_history"
+            },
+            "temporary_update_type": {
+              "type": "boolean",
+              "description": "Indicates that the user should choose a new update type on the next save."
             }
           },
           "definitions": {

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -29,6 +29,10 @@
     },
     "change_history": {
       "$ref": "#/definitions/change_history"
+    },
+    "temporary_update_type": {
+      "type": "boolean",
+      "description": "Indicates that the user should choose a new update type on the next save."
     }
   },
   "definitions": {


### PR DESCRIPTION
When adding an attachment to a document, it sends the
document to the Publishing API with the attachment's
metadata. If the user hasn't chosen an update_type for
the document, we intend to set it to 'minor' and set
this 'temporary_update_type' field to true. We can then
present a choice of update types to the user rather
than pre-selecting 'minor' for them.

Relates to:
https://trello.com/c/oxxALgmy/187-changes-to-update-type-for-raib-reports