### PR TITLE
Renaming `taxon_parents` to `parent_taxons`

### DIFF
--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxon_parents": {
+        "parent_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "alpha_taxons": {

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -17,7 +17,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxon_parents": {
+        "parent_taxons": {
           "description": "The list of taxon parents.",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxon_parents": {
+        "parent_taxons": {
           "description": "The list of taxon parents.",
           "$ref": "#/definitions/guid_list"
         },

--- a/formats/taxon/frontend/examples/taxon.json
+++ b/formats/taxon/frontend/examples/taxon.json
@@ -7,7 +7,7 @@
   "locale": "en",
   "details": {},
   "links": {
-    "taxon_parents": [
+    "parent_taxons": [
       {
         "content_id": "f6eef5ca-be55-41b2-98be-f72b3e649b84",
         "base_path": "/alpha-taxonomy/curriculum-and-qualifications",

--- a/formats/taxon/publisher/links.json
+++ b/formats/taxon/publisher/links.json
@@ -3,7 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "taxon_parents": {
+    "parent_taxons": {
       "description": "The list of taxon parents.",
       "$ref": "#/definitions/guid_list"
     }


### PR DESCRIPTION
This gives a bit more insight as to what this field is. It is intended to
have links to multiple parents of a taxon that are taxon themselves.

This change is a follow-up from comments on https://github.com/alphagov/collections-publisher/pull/210