### PR TITLE
Rename link type: alpha_taxons to taxons

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -100,7 +100,7 @@
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -104,7 +104,7 @@
         "document_collections": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -22,7 +22,7 @@
         "document_collections": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -24,7 +24,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -91,7 +91,7 @@
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -216,7 +216,7 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -13,7 +13,7 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -100,7 +100,7 @@
         "related_mainstream": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -103,7 +103,7 @@
         "related_mainstream": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -22,7 +22,7 @@
         "related_mainstream": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -98,7 +98,7 @@
         "topical_events": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -108,7 +108,7 @@
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -21,7 +21,7 @@
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -85,7 +85,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -97,7 +97,7 @@
         "ministers": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -53,7 +53,7 @@
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -21,7 +21,7 @@
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -34,7 +34,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -38,7 +38,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -22,7 +22,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -94,7 +94,7 @@
         "press_releases": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -25,7 +25,7 @@
         "press_releases": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -16,7 +16,7 @@
         "press_releases": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -27,7 +27,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -97,7 +97,7 @@
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -174,7 +174,7 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -19,7 +19,7 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -98,7 +98,7 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -86,7 +86,7 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -21,7 +21,7 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -129,7 +129,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -119,7 +119,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -92,7 +92,7 @@
         "organisations"
       ],
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -36,7 +36,7 @@
         "organisations"
       ],
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -14,7 +14,7 @@
         "organisations"
       ],
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -100,7 +100,7 @@
         "related_topics": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -65,7 +65,7 @@
         "related_topics": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -26,7 +26,7 @@
         "related_topics": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -97,7 +97,7 @@
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -119,7 +119,7 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -20,7 +20,7 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -97,7 +97,7 @@
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -72,7 +72,7 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -20,7 +20,7 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -87,7 +87,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -97,7 +97,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -110,7 +110,7 @@
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -161,7 +161,7 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -33,7 +33,7 @@
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -103,7 +103,7 @@
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -94,7 +94,7 @@
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -25,7 +25,7 @@
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -94,7 +94,7 @@
         "service_manual_topics": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -64,7 +64,7 @@
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -18,7 +18,7 @@
           "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -91,7 +91,7 @@
         "points": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -41,7 +41,7 @@
           "description": "Related points in the digital service standard.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -14,7 +14,7 @@
           "description": "Related points in the digital service standard.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -94,7 +94,7 @@
         "content_owners": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -58,7 +58,7 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -18,7 +18,7 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -44,7 +44,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -98,7 +98,7 @@
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -61,7 +61,7 @@
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -22,7 +22,7 @@
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -23,7 +23,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -91,7 +91,7 @@
         "parent_taxons": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -21,7 +21,7 @@
           "description": "The list of taxon parents.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -14,7 +14,7 @@
           "description": "The list of taxon parents.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -94,7 +94,7 @@
         "linked_items": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -63,7 +63,7 @@
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -18,7 +18,7 @@
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -91,7 +91,7 @@
         "parent"
       ],
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -26,7 +26,7 @@
         "parent"
       ],
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -13,7 +13,7 @@
         "parent"
       ],
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -91,7 +91,7 @@
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -103,7 +103,7 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -13,7 +13,7 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -91,7 +91,7 @@
         "related": {
           "$ref": "#/definitions/frontend_links"
         },
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -72,7 +72,7 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -13,7 +13,7 @@
         "related": {
           "$ref": "#/definitions/guid_list"
         },
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -37,7 +37,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -88,7 +88,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -19,7 +19,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -4416,7 +4416,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "alpha_taxons": {
+        "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },

--- a/formats/base_links.json
+++ b/formats/base_links.json
@@ -3,7 +3,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "alpha_taxons": {
+    "taxons": {
       "description": "Prototype-stage taxonomy label for this content item",
       "$ref": "#/definitions/guid_list"
     },


### PR DESCRIPTION
When we started experimenting with new taxonomy we used alpha_taxonomy as
the link type. Now that we're no longer in alpha we'd like to be consistent
in using the link type.

Trello: https://trello.com/c/tt0UdAV3/35-use-taxons-as-link-type-everywhere
2349d27