### PR TITLE
Add safety digests as a RAIB report type

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1642,7 +1642,8 @@
             "investigation-report",
             "bulletin",
             "interim-report",
-            "discontinuation-report"
+            "discontinuation-report",
+            "safety-digest"
           ]
         },
         "date_of_occurrence": {

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -1421,7 +1421,8 @@
             "investigation-report",
             "bulletin",
             "interim-report",
-            "discontinuation-report"
+            "discontinuation-report",
+            "safety-digest"
           ]
         },
         "date_of_occurrence": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1386,7 +1386,8 @@
             "investigation-report",
             "bulletin",
             "interim-report",
-            "discontinuation-report"
+            "discontinuation-report",
+            "safety-digest"
           ]
         },
         "date_of_occurrence": {

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -3220,7 +3220,8 @@
                     "investigation-report",
                     "bulletin",
                     "interim-report",
-                    "discontinuation-report"
+                    "discontinuation-report",
+                    "safety-digest"
                   ]
                 },
                 "date_of_occurrence": {

--- a/formats/finder/frontend/examples/raib-reports.json
+++ b/formats/finder/frontend/examples/raib-reports.json
@@ -55,6 +55,10 @@
           {
             "label": "Discontinuation report",
             "value": "discontinuation-report"
+          },
+          {
+            "label": "Safety digest",
+            "value": "safety-digest"
           }
         ],
         "display_as_result_metadata": true,

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -1125,7 +1125,8 @@
             "investigation-report",
             "bulletin",
             "interim-report",
-            "discontinuation-report"
+            "discontinuation-report",
+            "safety-digest"
           ]
         },
         "date_of_occurrence": {


### PR DESCRIPTION
This has been requested by RAIB

Trello: https://trello.com/c/e4i1jjw1/31-add-new-raib-report-type