### PR TITLE
[Do Not Merge] Add note and reason for change for latest change to service manual guides

### DIFF
--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -240,6 +240,12 @@
             ]
           }
         },
+        "latest_change_note": {
+          "type": "string"
+        },
+        "latest_change_reason_for_change": {
+          "type": "string"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -47,6 +47,12 @@
             ]
           }
         },
+        "latest_change_note": {
+          "type": "string"
+        },
+        "latest_change_reason_for_change": {
+          "type": "string"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -47,6 +47,12 @@
             ]
           }
         },
+        "latest_change_note": {
+          "type": "string"
+        },
+        "latest_change_reason_for_change": {
+          "type": "string"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -2061,6 +2061,12 @@
                 ]
               }
             },
+            "latest_change_note": {
+              "type": "string"
+            },
+            "latest_change_reason_for_change": {
+              "type": "string"
+            },
             "change_history": {
               "$ref": "#/definitions/change_history"
             }

--- a/formats/service_manual_guide/frontend/examples/point_page.json
+++ b/formats/service_manual_guide/frontend/examples/point_page.json
@@ -17,7 +17,9 @@
         "title": "Why it's in the standard",
         "href": "#why-its-in-the-standard"
       }
-    ]
+    ],
+    "latest_change_note": "This is our latest change",
+    "latest_change_reason_for_change": "This is the reason for our latest change"
   },
   "links": {
     "parent": [

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide.json
@@ -10,7 +10,9 @@
         "title": "What is it, why it works and how to do it",
         "href": "#what-is-it-why-it-works-and-how-to-do-it"
       }
-    ]
+    ],
+    "latest_change_note": "This is our latest change",
+    "latest_change_reason_for_change": "This is the reason for our latest change"
   },
   "links": {
     "content_owners": [

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
@@ -10,7 +10,9 @@
         "title": "What is it, why it works and how to do it",
         "href": "#what-is-it-why-it-works-and-how-to-do-it"
       }
-    ]
+    ],
+    "latest_change_note": "This is our latest change",
+    "latest_change_reason_for_change": "This is the reason for our latest change"
   },
   "links": {
     "service_manual_topics": [

--- a/formats/service_manual_guide/frontend/examples/with_change_history.json
+++ b/formats/service_manual_guide/frontend/examples/with_change_history.json
@@ -11,11 +11,13 @@
         "href": "#what-is-it-why-it-works-and-how-to-do-it"
       }
     ],
+    "latest_change_note": "This is our latest change",
+    "latest_change_reason_for_change": "This is the reason for our latest change",
     "change_history": [
       {
         "public_timestamp": "2017-10-09T08:17:10+00:00",
-        "note": "This is a change",
-        "reason_for_change": "This is our latest change"
+        "note": "This is the previous change",
+        "reason_for_change": "This is the reason for our previous change"
       },
       {
         "public_timestamp": "2016-01-09T08:17:10+00:00",

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -43,6 +43,12 @@
         ]
       }
     },
+    "latest_change_note": {
+      "type": "string"
+    },
+    "latest_change_reason_for_change": {
+      "type": "string"
+    },
     "change_history": {
       "$ref": "#/definitions/change_history"
     }

--- a/formats/service_manual_guide/publisher_v2/examples/point_page.json
+++ b/formats/service_manual_guide/publisher_v2/examples/point_page.json
@@ -11,7 +11,9 @@
         "title": "Why it's in the standard",
         "href": "#why-its-in-the-standard"
       }
-    ]
+    ],
+    "latest_change_note": "This is our latest change",
+    "latest_change_reason_for_change": "This is the reason for our latest change"
   },
   "base_path": "/service-standard/service-standard/understand-user-needs",
   "description": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
@@ -10,7 +10,9 @@
         "title": "What is it, why it works and how to do it",
         "href": "#what-is-it-why-it-works-and-how-to-do-it"
       }
-    ]
+    ],
+    "latest_change_note": "This is our latest change",
+    "latest_change_reason_for_change": "This is the reason for our latest change"
   },
   "base_path": "/service-manual/agile",
   "description": "What agile is, why it works and how to do it",

--- a/formats/service_manual_guide/publisher_v2/examples/with_change_history.json
+++ b/formats/service_manual_guide/publisher_v2/examples/with_change_history.json
@@ -11,6 +11,8 @@
         "href": "#what-is-it-why-it-works-and-how-to-do-it"
       }
     ],
+    "latest_change_note": "This is our latest change",
+    "latest_change_reason_for_change": "This is the reason for our latest change",
     "change_history": [
       {
         "public_timestamp": "2015-10-09T08:17:10+00:00",


### PR DESCRIPTION
Because we don't know the timestamp of when we'll publish until we call publish, we use change_history only for previous changes, and get the latest change note and summary directly from the details hash, along with public_updated_at.