### PR TITLE
Add schema_name and document_type to special_route

### DIFF
--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "format",
     "publishing_app",
     "routes"
   ],
@@ -15,6 +14,12 @@
       "$ref": "#/definitions/guid"
     },
     "format": {
+      "enum": [ "special_route" ]
+    },
+    "schema_name": {
+      "enum": [ "special_route" ]
+    },
+    "document_type": {
       "enum": [ "special_route" ]
     },
     "publishing_app": {

--- a/formats/special_route/publisher_v2/schema.json
+++ b/formats/special_route/publisher_v2/schema.json
@@ -3,7 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "format",
     "publishing_app",
     "routes"
   ],
@@ -15,6 +14,12 @@
       "$ref": "#/definitions/guid"
     },
     "format": {
+      "enum": [ "special_route" ]
+    },
+    "schema_name": {
+      "enum": [ "special_route" ]
+    },
+    "document_type": {
       "enum": [ "special_route" ]
     },
     "publishing_app": {


### PR DESCRIPTION
Currently this schema only accepts format; some applications have been
migrated to use schema_name/document_type. For now, support both,
without requiring either of them ; when no apps are sending format this
can be removed and the other two added to the required fields.