### PR TITLE
Allow email alert signups to work with links other than countries

### DIFF
--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -216,8 +216,9 @@
               "type": "object",
               "description": "The links used to match subscribers lists",
               "additionalProperties": false,
-              "properties": {
-                "countries": {
+              "maxProperties": 1,
+              "patternProperties": {
+                "^[a-z_]+$": {
                   "type": "array"
                 }
               }

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -33,8 +33,9 @@
               "type": "object",
               "description": "The links used to match subscribers lists",
               "additionalProperties": false,
-              "properties": {
-                "countries": {
+              "maxProperties": 1,
+              "patternProperties": {
+                "^[a-z_]+$": {
                   "type": "array"
                 }
               }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -33,8 +33,9 @@
               "type": "object",
               "description": "The links used to match subscribers lists",
               "additionalProperties": false,
-              "properties": {
-                "countries": {
+              "maxProperties": 1,
+              "patternProperties": {
+                "^[a-z_]+$": {
                   "type": "array"
                 }
               }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -236,6 +236,10 @@
             ]
           }
         },
+        "change_note": {
+          "type": "string",
+          "description": "The change note for this edition, as used by the email alert service"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -47,6 +47,10 @@
             ]
           }
         },
+        "change_note": {
+          "type": "string",
+          "description": "The change note for this edition, as used by the email alert service"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -47,6 +47,10 @@
             ]
           }
         },
+        "change_note": {
+          "type": "string",
+          "description": "The change note for this edition, as used by the email alert service"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -2062,6 +2062,10 @@
                 ]
               }
             },
+            "change_note": {
+              "type": "string",
+              "description": "The change note for this edition, as used by the email alert service"
+            },
             "change_history": {
               "$ref": "#/definitions/change_history"
             }

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -834,8 +834,9 @@
                   "type": "object",
                   "description": "The links used to match subscribers lists",
                   "additionalProperties": false,
-                  "properties": {
-                    "countries": {
+                  "maxProperties": 1,
+                  "patternProperties": {
+                    "^[a-z_]+$": {
                       "type": "array"
                     }
                   }

--- a/formats/email_alert_signup/publisher/details.json
+++ b/formats/email_alert_signup/publisher/details.json
@@ -25,8 +25,9 @@
           "type": "object",
           "description": "The links used to match subscribers lists",
           "additionalProperties": false,
-          "properties": {
-            "countries": { "type": "array" }
+          "maxProperties": 1,
+          "patternProperties": {
+              "^[a-z_]+$": { "type": "array" }
           }
         },
         "document_type": {

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide.json
@@ -11,6 +11,7 @@
         "href": "#what-is-it-why-it-works-and-how-to-do-it"
       }
     ],
+    "change_note": "This is our latest change.",
     "change_history": [
       {
         "public_timestamp": "2015-10-07T08:17:10+00:00",

--- a/formats/service_manual_guide/publisher/details.json
+++ b/formats/service_manual_guide/publisher/details.json
@@ -43,6 +43,10 @@
         ]
       }
     },
+    "change_note": {
+      "type": "string",
+      "description": "The change note for this edition, as used by the email alert service"
+    },
     "change_history": {
       "$ref": "#/definitions/change_history"
     }


### PR DESCRIPTION
The email-alert-api uses the links hash within subscriber_lists as a matcher, examining new documents that get published for matching `links` and `document` types and sending emails to relevant lists.

The schema currently limits the contents of the links hash to only permit countries, which means that only links to `countries` can be subscribed to.

We are building email alerts into the service manual, allowing users to subscribe to service manual topics. Therefore we need to create email_alert_signups based on documents that link to `service_manual_topics`, so we need to allow for this in the schema.

Rather than adding `service_manual_topics` as another 'special case' this instead allows exactly one property with a alphabetical, underscored key to be provided as long as the value is an array.