### PR TITLE
Use link expansion for the Service Standard

### DIFF
--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -91,7 +91,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "points": {
+        "children": {
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
@@ -193,29 +193,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "points": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string",
-                "description": "The title of the point. It matches the title of the relevant page."
-              },
-              "summary": {
-                "type": "string",
-                "description": "The summary of the point. It matches the summary on the relevant page."
-              },
-              "base_path": {
-                "$ref": "#/definitions/absolute_path"
-              }
-            },
-            "required": [
-              "title",
-              "summary",
-              "base_path"
-            ]
-          }
+        "body": {
+          "type": "string",
+          "description": "A single line of text that serves as a second, less prominent introduction."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -7,29 +7,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "points": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string",
-                "description": "The title of the point. It matches the title of the relevant page."
-              },
-              "summary": {
-                "type": "string",
-                "description": "The summary of the point. It matches the summary on the relevant page."
-              },
-              "base_path": {
-                "$ref": "#/definitions/absolute_path"
-              }
-            },
-            "required": [
-              "title",
-              "summary",
-              "base_path"
-            ]
-          }
+        "body": {
+          "type": "string",
+          "description": "A single line of text that serves as a second, less prominent introduction."
         }
       }
     },
@@ -37,9 +17,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "points": {
-          "description": "Related points in the digital service standard.",
-          "$ref": "#/definitions/guid_list"
+        "children": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -10,9 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "points": {
-          "description": "Related points in the digital service standard.",
-          "$ref": "#/definitions/guid_list"
+        "children": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -7,29 +7,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "points": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string",
-                "description": "The title of the point. It matches the title of the relevant page."
-              },
-              "summary": {
-                "type": "string",
-                "description": "The summary of the point. It matches the summary on the relevant page."
-              },
-              "base_path": {
-                "$ref": "#/definitions/absolute_path"
-              }
-            },
-            "required": [
-              "title",
-              "summary",
-              "base_path"
-            ]
-          }
+        "body": {
+          "type": "string",
+          "description": "A single line of text that serves as a second, less prominent introduction."
         }
       }
     },

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -2078,29 +2078,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "points": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "type": "string",
-                    "description": "The title of the point. It matches the title of the relevant page."
-                  },
-                  "summary": {
-                    "type": "string",
-                    "description": "The summary of the point. It matches the summary on the relevant page."
-                  },
-                  "base_path": {
-                    "$ref": "#/definitions/absolute_path"
-                  }
-                },
-                "required": [
-                  "title",
-                  "summary",
-                  "base_path"
-                ]
-              }
+            "body": {
+              "type": "string",
+              "description": "A single line of text that serves as a second, less prominent introduction."
             }
           }
         },

--- a/formats/service_manual_service_standard/frontend/examples/service_manual_service_standard.json
+++ b/formats/service_manual_service_standard/frontend/examples/service_manual_service_standard.json
@@ -26,25 +26,7 @@
         "locale": "en",
         "public_updated_at": "2016-06-29T14:10:56.000Z",
         "title": "1. Understand user needs",
-        "web_url": "https://www.gov.uk/service-manual/service-standard/understand-user-needs",
-        "links": {
-          "parent": [
-            {
-              "analytics_identifier": null,
-              "api_url": "https://www.gov.uk/api/content/service-manual/service-standard",
-              "base_path": "/service-manual/service-standard",
-              "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
-              "description": null,
-              "document_type": "service_manual_service_standard",
-              "locale": "en",
-              "public_updated_at": "2016-06-30T13:28:52.610Z",
-              "schema_name": "service_manual_service_standard",
-              "title": "Digital Service Standard",
-              "web_url": "https://www.gov.uk/service-manual/service-standard",
-              "links": {}
-            }
-          ]
-        }
+        "web_url": "https://www.gov.uk/service-manual/service-standard/understand-user-needs"
       },
       {
         "analytics_identifier": null,
@@ -55,25 +37,7 @@
         "locale": "en",
         "public_updated_at": "2016-06-29T15:00:03.000Z",
         "title": "2. Do ongoing user research",
-        "web_url": "https://www.gov.uk/service-manual/service-standard/do-ongoing-user-research",
-        "links": {
-          "parent": [
-            {
-              "analytics_identifier": null,
-              "api_url": "https://www.gov.uk/api/content/service-manual/service-standard",
-              "base_path": "/service-manual/service-standard",
-              "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
-              "description": null,
-              "document_type": "service_manual_service_standard",
-              "locale": "en",
-              "public_updated_at": "2016-06-30T13:28:52.610Z",
-              "schema_name": "service_manual_service_standard",
-              "title": "Digital Service Standard",
-              "web_url": "https://www.gov.uk/service-manual/service-standard",
-              "links": {}
-            }
-          ]
-        }
+        "web_url": "https://www.gov.uk/service-manual/service-standard/do-ongoing-user-research"
       },
       {
         "analytics_identifier": null,
@@ -84,25 +48,7 @@
         "locale": "en",
         "public_updated_at": "2016-06-29T15:11:52.000Z",
         "title": "3. Have a multidisciplinary team",
-        "web_url": "https://www.gov.uk/service-manual/service-standard/have-a-multidisciplinary-team",
-        "links": {
-          "parent": [
-            {
-              "analytics_identifier": null,
-              "api_url": "https://www.gov.uk/api/content/service-manual/service-standard",
-              "base_path": "/service-manual/service-standard",
-              "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
-              "description": null,
-              "document_type": "service_manual_service_standard",
-              "locale": "en",
-              "public_updated_at": "2016-06-30T13:28:52.610Z",
-              "schema_name": "service_manual_service_standard",
-              "title": "Digital Service Standard",
-              "web_url": "https://www.gov.uk/service-manual/service-standard",
-              "links": {}
-            }
-          ]
-        }
+        "web_url": "https://www.gov.uk/service-manual/service-standard/have-a-multidisciplinary-team"
       }
     ],
     "available_translations": [

--- a/formats/service_manual_service_standard/frontend/examples/service_manual_service_standard.json
+++ b/formats/service_manual_service_standard/frontend/examples/service_manual_service_standard.json
@@ -1,25 +1,129 @@
 {
-  "format": "service_manual_service_standard",
+  "analytics_identifier": null,
   "base_path": "/service-manual/service-standard",
-  "content_id": "cd02b82d-c706-435c-a2fc-2dcabd168ef4",
-  "title": "Digital Service Standard",
-  "locale": "en",
-  "schema_name": "service_manual_service_standard",
+  "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
   "document_type": "service_manual_service_standard",
-  "details": {
-    "points": [
+  "first_published_at": "2016-06-29T14:56:50.000+00:00",
+  "format": "service_manual_service_standard",
+  "locale": "en",
+  "need_ids": [],
+  "phase": "beta",
+  "public_updated_at": "2016-06-30T13:28:52.000+00:00",
+  "publishing_app": "service-manual-publisher",
+  "rendering_app": "service-manual-frontend",
+  "schema_name": "service_manual_service_standard",
+  "title": "Digital Service Standard",
+  "updated_at": "2016-06-30T13:28:53.128Z",
+  "withdrawn_notice": {},
+  "links": {
+    "children": [
       {
+        "analytics_identifier": null,
+        "api_url": "https://www.gov.uk/api/content/service-manual/service-standard/understand-user-needs",
+        "base_path": "/service-manual/service-standard/understand-user-needs",
+        "content_id": "639bd981-ad5a-4160-a0fe-011bc7a71715",
+        "description": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
+        "locale": "en",
+        "public_updated_at": "2016-06-29T14:10:56.000Z",
         "title": "1. Understand user needs",
-        "summary": "Summary goes here",
-        "base_path": "/service-manual/service-standard/understand-user-needs"
+        "web_url": "https://www.gov.uk/service-manual/service-standard/understand-user-needs",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_url": "https://www.gov.uk/api/content/service-manual/service-standard",
+              "base_path": "/service-manual/service-standard",
+              "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
+              "description": null,
+              "document_type": "service_manual_service_standard",
+              "locale": "en",
+              "public_updated_at": "2016-06-30T13:28:52.610Z",
+              "schema_name": "service_manual_service_standard",
+              "title": "Digital Service Standard",
+              "web_url": "https://www.gov.uk/service-manual/service-standard",
+              "links": {}
+            }
+          ]
+        }
       },
       {
+        "analytics_identifier": null,
+        "api_url": "https://www.gov.uk/api/content/service-manual/service-standard/do-ongoing-user-research",
+        "base_path": "/service-manual/service-standard/do-ongoing-user-research",
+        "content_id": "57ca5168-b6ce-4498-aecf-cca42f1ebd6b",
+        "description": "Put a plan in place for ongoing user research and usability testing to continuously seek feedback from users to improve the service.",
+        "locale": "en",
+        "public_updated_at": "2016-06-29T15:00:03.000Z",
         "title": "2. Do ongoing user research",
-        "summary": "Another summary goes here",
-        "base_path": "/service-manual/service-standard/do-ongoing-user-research"
+        "web_url": "https://www.gov.uk/service-manual/service-standard/do-ongoing-user-research",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_url": "https://www.gov.uk/api/content/service-manual/service-standard",
+              "base_path": "/service-manual/service-standard",
+              "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
+              "description": null,
+              "document_type": "service_manual_service_standard",
+              "locale": "en",
+              "public_updated_at": "2016-06-30T13:28:52.610Z",
+              "schema_name": "service_manual_service_standard",
+              "title": "Digital Service Standard",
+              "web_url": "https://www.gov.uk/service-manual/service-standard",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "analytics_identifier": null,
+        "api_url": "https://www.gov.uk/api/content/service-manual/service-standard/have-a-multidisciplinary-team",
+        "base_path": "/service-manual/service-standard/have-a-multidisciplinary-team",
+        "content_id": "a08c46ce-d521-4422-ae9d-dad8925f9cda",
+        "description": "Put in place a sustainable multidisciplinary team that can design, build and operate the service, led by a suitably skilled and senior service manager with decision-making responsibility.",
+        "locale": "en",
+        "public_updated_at": "2016-06-29T15:11:52.000Z",
+        "title": "3. Have a multidisciplinary team",
+        "web_url": "https://www.gov.uk/service-manual/service-standard/have-a-multidisciplinary-team",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_url": "https://www.gov.uk/api/content/service-manual/service-standard",
+              "base_path": "/service-manual/service-standard",
+              "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
+              "description": null,
+              "document_type": "service_manual_service_standard",
+              "locale": "en",
+              "public_updated_at": "2016-06-30T13:28:52.610Z",
+              "schema_name": "service_manual_service_standard",
+              "title": "Digital Service Standard",
+              "web_url": "https://www.gov.uk/service-manual/service-standard",
+              "links": {}
+            }
+          ]
+        }
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
+        "title": "Digital Service Standard",
+        "base_path": "/service-manual/service-standard",
+        "description": null,
+        "api_url": "https://www.gov.uk/api/content/service-manual/service-standard",
+        "web_url": "https://www.gov.uk/service-manual/service-standard",
+        "locale": "en",
+        "public_updated_at": "2016-06-30T13:28:52.000+00:00",
+        "schema_name": "service_manual_service_standard",
+        "document_type": "service_manual_service_standard",
+        "analytics_identifier": null,
+        "links": {}
       }
     ]
   },
-  "links": {
+  "description": "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
+  "details": {
+    "body": "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use."
   }
 }

--- a/formats/service_manual_service_standard/publisher/details.json
+++ b/formats/service_manual_service_standard/publisher/details.json
@@ -3,29 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "points": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "The title of the point. It matches the title of the relevant page."
-          },
-          "summary": {
-            "type": "string",
-            "description": "The summary of the point. It matches the summary on the relevant page."
-          },
-          "base_path": {
-            "$ref" : "#/definitions/absolute_path"
-          }
-        },
-        "required": [
-          "title",
-          "summary",
-          "base_path"
-        ]
-      }
+    "body": {
+      "type": "string",
+      "description": "A single line of text that serves as a second, less prominent introduction."
     }
   }
 }

--- a/formats/service_manual_service_standard/publisher/links.json
+++ b/formats/service_manual_service_standard/publisher/links.json
@@ -3,9 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "points": {
-      "description": "Related points in the digital service standard.",
-      "$ref": "#/definitions/guid_list"
+    "children": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
     }
   }
 }

--- a/formats/service_manual_service_standard/publisher_v2/examples/service_manual_service_standard.json
+++ b/formats/service_manual_service_standard/publisher_v2/examples/service_manual_service_standard.json
@@ -14,20 +14,9 @@
       "type": "exact"
     }
   ],
-  "details": {
-    "points": [
-      {
-        "title": "1. Understand user needs",
-        "summary": "Summary goes here",
-        "base_path": "/service-manual/service-standard/understand-user-needs"
-      },
-      {
-        "title": "2. Do ongoing user research",
-        "summary": "Another summary goes here",
-        "base_path": "/service-manual/service-standard/do-ongoing-user-research"
-      }
-    ]
-  },
   "document_type": "service_manual_service_standard",
-  "schema_name": "service_manual_service_standard"
+  "schema_name": "service_manual_service_standard",
+  "details": {
+    "body": "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use."
+  }
 }


### PR DESCRIPTION
This PR updates the `service_manual_service_standard` schema and examples to use link expansion.

Currently it doesn't seem possible to have a frontend example of a parent/child relationship which has been link-expanded that matches it's frontend schema.

It seems the definitions of each link type are overwritten for the frontend schemas so that they are "#/definitions/frontend_links". https://github.com/alphagov/govuk-content-schemas/blob/b283419dc1f43d69396e88fdd559ea2f4ce1889b/lib/govuk_content_schemas/frontend_schema_generator.rb#L81

The "#/definitions/frontend_links" definition mostly matches an expanded link but falls down when it gets into the links of the expanded link where it expects every link type to be a "#/definitions/guid_list".

Here are a couple of heavily redacted examples to show what we have and what the frontend schema wants. The difference is that the former has it's /links/children/*/links/parent expanded whereas the later has a guid list.

This is the structure of a link expanded content item in the wild:
```
{
  "base_path": "/service-manual/service-standard",
  "links": {
    "children": [
      {
        "base_path": "/service-manual/service-standard/have-a-multidisciplinary-team",
        "links": {
          "parent": [
            {
              "base_path": "/service-manual/service-standard",
              "links": {}
            }
          ]
        }
      }
    ]
  }
}
```

This is the structure of a content item that the schema expects:
```
{
  "base_path": "/service-manual/service-standard",
  "links": {
    "children": [
      {
        "base_path": "/service-manual/service-standard/have-a-multidisciplinary-team",
        "links": {
          "parent": ["00f693d4-866a-4fe6-a8d6-09cd7db8980b"]
        }
      }
    ]
  }
}
```

I'm not sure how much this matters? For parent/child link expanded stuff, the /links/children/*/links/parent data is also available in the root object.. it's a link expanded reference to itself. I think a slight problem is that our examples won't look exactly like they do in the wild, which will cause confusion and people use real content items as the basis for fixutres. A larger potential problem is for another link type where the relationship isn't self-referential like the parent/child one and we actually want that data..

Perhaps the "#/definitions/frontend_links" definition could be made more flexible to allow the link types to be either a guid_list or another "#/definitions/frontend_links". Or a "#/definitions/frontend_expanded_links" maybe?