### PR TITLE
Remove oneOf nesting

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "case_study"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -128,6 +119,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "case_study"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "case_study"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -447,136 +573,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "case_study"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -400,132 +522,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "coming_soon"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "coming_soon"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "coming_soon"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -367,136 +493,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "coming_soon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "coming_soon"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -332,132 +454,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "coming_soon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "contact"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -119,6 +110,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -559,136 +685,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "contact"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -1,7 +1,112 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -521,115 +626,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "contact"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "detailed_guide"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -128,6 +119,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "detailed_guide"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "detailed_guide"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -446,136 +572,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "detailed_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "detailed_guide"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -399,132 +521,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "detailed_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "document_collection"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -126,6 +117,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "document_collection"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "document_collection"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -451,136 +577,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "document_collection"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "document_collection"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -405,132 +527,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "document_collection"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "email_alert_signup"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "email_alert_signup"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "email_alert_signup"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -428,136 +554,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "email_alert_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "email_alert_signup"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -393,132 +515,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "email_alert_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "fatality_notice"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -125,6 +116,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "fatality_notice"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "fatality_notice"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -396,136 +522,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "fatality_notice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "fatality_notice"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -350,132 +472,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "fatality_notice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_release"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_release"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_release"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -377,136 +503,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_release"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_release"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -342,132 +464,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_release"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_releases_campaign"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_campaign"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_campaign"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -381,136 +507,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_campaign"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_campaign"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -346,132 +468,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_campaign"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_releases_geoblocker"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_geoblocker"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_geoblocker"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -365,136 +491,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_geoblocker"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_geoblocker"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -330,132 +452,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_geoblocker"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_releases_index"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -122,6 +113,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_index"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_index"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -368,136 +494,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_index"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -327,132 +449,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "financial_releases_success"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_success"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_success"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -370,136 +496,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_success"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "financial_releases_success"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -335,132 +457,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "financial_releases_success"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "finder"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -122,6 +113,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -517,136 +643,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "finder"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -473,132 +595,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "finder"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "finder_email_signup"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -123,6 +114,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder_email_signup"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder_email_signup"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -425,136 +551,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "finder_email_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder_email_signup"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -383,132 +505,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "finder_email_signup"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "hmrc_manual"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -472,136 +598,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -437,132 +559,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "hmrc_manual_section"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual_section"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual_section"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -462,136 +588,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual_section"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -427,132 +549,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "hmrc_manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "html_publication"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -120,6 +111,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "html_publication"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "html_publication"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -379,136 +505,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "html_publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "html_publication"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -340,132 +462,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "html_publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "mainstream_browse_page"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -128,6 +119,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "mainstream_browse_page"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "mainstream_browse_page"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -408,136 +534,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "mainstream_browse_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "mainstream_browse_page"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -357,132 +479,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "mainstream_browse_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "manual"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -119,6 +110,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -458,136 +584,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -417,132 +539,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "manual"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "manual_section"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -119,6 +110,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual_section"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual_section"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -411,136 +537,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual_section"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -370,132 +492,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "manual_section"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -5,22 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "pattern": "^(placeholder|placeholder_.+)$",
-      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -115,6 +107,14 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "pattern": "^(placeholder|placeholder_.+)$",
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
     },
     "format": {
       "type": "string"

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -1,7 +1,132 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "pattern": "^(placeholder|placeholder_.+)$",
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -440,135 +565,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "pattern": "^(placeholder|placeholder_.+)$",
-          "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -1,7 +1,128 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "pattern": "^(placeholder|placeholder_.+)$",
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -405,131 +526,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "pattern": "^(placeholder|placeholder_.+)$",
-          "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "policy"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -135,6 +126,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "policy"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "policy"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -504,136 +630,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "policy"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "policy"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -446,132 +568,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "policy"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "publication"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -131,6 +122,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "publication"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "publication"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -437,136 +563,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "publication"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -387,132 +509,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "publication"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_guide"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -122,6 +113,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_guide"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_guide"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -412,136 +538,5 @@
       "pattern": "^#.+$",
       "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'"
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_guide"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -369,132 +491,5 @@
       "pattern": "^#.+$",
       "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'"
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_guide"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_service_standard"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -119,6 +110,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_standard"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_standard"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -367,136 +493,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_service_standard"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_standard"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -325,132 +447,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_service_standard"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_topic"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -122,6 +113,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_topic"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_topic"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -401,136 +527,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_topic"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -358,132 +480,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "service_manual_topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -5,41 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string",
-      "enum": [
-        "aaib_report",
-        "asylum_support_decision",
-        "cma_case",
-        "countryside_stewardship_grant",
-        "dfid_research_output",
-        "drug_safety_update",
-        "employment_appeal_tribunal_decision",
-        "employment_tribunal_decision",
-        "esi_fund",
-        "international_development_fund",
-        "maib_report",
-        "medical_safety_alert",
-        "raib_report",
-        "tax_tribunal_decision",
-        "utaac_decision",
-        "vehicle_recalls_and_faults_alert"
-      ]
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "specialist_document"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -134,6 +107,33 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "asylum_support_decision",
+        "cma_case",
+        "countryside_stewardship_grant",
+        "dfid_research_output",
+        "drug_safety_update",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "esi_fund",
+        "international_development_fund",
+        "maib_report",
+        "medical_safety_alert",
+        "raib_report",
+        "tax_tribunal_decision",
+        "utaac_decision",
+        "vehicle_recalls_and_faults_alert"
+      ]
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "specialist_document"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -1,7 +1,151 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "asylum_support_decision",
+        "cma_case",
+        "countryside_stewardship_grant",
+        "dfid_research_output",
+        "drug_safety_update",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "esi_fund",
+        "international_development_fund",
+        "maib_report",
+        "medical_safety_alert",
+        "raib_report",
+        "tax_tribunal_decision",
+        "utaac_decision",
+        "vehicle_recalls_and_faults_alert"
+      ]
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "specialist_document"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -1629,154 +1773,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "aaib_report",
-            "asylum_support_decision",
-            "cma_case",
-            "countryside_stewardship_grant",
-            "dfid_research_output",
-            "drug_safety_update",
-            "employment_appeal_tribunal_decision",
-            "employment_tribunal_decision",
-            "esi_fund",
-            "international_development_fund",
-            "maib_report",
-            "medical_safety_alert",
-            "raib_report",
-            "tax_tribunal_decision",
-            "utaac_decision",
-            "vehicle_recalls_and_faults_alert"
-          ]
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "specialist_document"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "specialist_document"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -1594,132 +1716,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "specialist_document"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "statistics_announcement"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -120,6 +111,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "statistics_announcement"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "statistics_announcement"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -396,136 +522,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "statistics_announcement"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "statistics_announcement"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -357,132 +479,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "statistics_announcement"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "take_part"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "take_part"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "take_part"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -366,136 +492,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "take_part"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "take_part"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -331,132 +453,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "take_part"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "taxon"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -119,6 +110,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "taxon"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "taxon"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -364,136 +490,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "taxon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "taxon"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -325,132 +447,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "taxon"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "topic"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -122,6 +113,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topic"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topic"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -406,136 +532,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topic"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -363,132 +485,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "topic"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "topical_event_about_page"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -119,6 +110,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topical_event_about_page"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topical_event_about_page"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -369,136 +495,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "topical_event_about_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topical_event_about_page"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -331,132 +453,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "topical_event_about_page"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "travel_advice"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -119,6 +110,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -446,136 +572,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "travel_advice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -408,132 +530,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "travel_advice"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "travel_advice_index"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -119,6 +110,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice_index"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice_index"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -415,136 +541,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "travel_advice_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice_index"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -377,132 +499,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "travel_advice_index"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "unpublishing"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "unpublishing"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "unpublishing"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -380,136 +506,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "unpublishing"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "unpublishing"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -345,132 +467,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "unpublishing"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -5,23 +5,14 @@
   "required": [
     "base_path",
     "links",
-    "document_type",
-    "schema_name",
     "title",
     "details",
     "locale",
-    "content_id"
+    "content_id",
+    "document_type",
+    "schema_name"
   ],
   "properties": {
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "working_group"
-      ]
-    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
@@ -116,6 +107,15 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "working_group"
+      ]
     },
     "format": {
       "type": "string"

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -1,7 +1,133 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "working_group"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -362,136 +488,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "working_group"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "content_id",
-        "update_type"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -1,7 +1,129 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "type": "string"
+    },
+    "rendering_app": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content recieved a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "working_group"
+      ]
+    }
+  },
   "definitions": {
     "details": {
       "type": "object",
@@ -327,132 +449,5 @@
         }
       }
     }
-  },
-  "oneOf": [
-    {
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "schema_name": {
-          "type": "string",
-          "enum": [
-            "working_group"
-          ]
-        },
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "public_updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "publishing_app": {
-          "type": "string"
-        },
-        "rendering_app": {
-          "type": "string"
-        },
-        "locale": {
-          "$ref": "#/definitions/locale"
-        },
-        "need_ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "routes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/route"
-          }
-        },
-        "redirects": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/redirect_route"
-          }
-        },
-        "access_limited": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "users"
-          ],
-          "properties": {
-            "users": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "analytics_identifier": {
-          "$ref": "#/definitions/analytics_identifier"
-        },
-        "phase": {
-          "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-          "type": "string",
-          "enum": [
-            "alpha",
-            "beta",
-            "live"
-          ]
-        },
-        "details": {
-          "$ref": "#/definitions/details"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "last_edited_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last time when the content recieved a major or minor update."
-        },
-        "previous_version": {
-          "type": "string"
-        },
-        "update_type": {
-          "enum": [
-            "major",
-            "minor",
-            "republish"
-          ]
-        }
-      },
-      "required": [
-        "document_type",
-        "schema_name",
-        "title",
-        "details",
-        "publishing_app",
-        "rendering_app",
-        "locale",
-        "routes",
-        "base_path"
-      ],
-      "additionalProperties": false
-    }
-  ]
+  }
 }

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -41,7 +41,8 @@ private
   end
 
   def required_properties
-    required = @publisher_schema.schema.fetch('oneOf', []).map { |s| s.fetch('required', []) }.flatten.uniq
+    required = @publisher_schema.schema['required'].to_a
+
     if required.empty?
       []
     else
@@ -50,7 +51,7 @@ private
   end
 
   def publisher_properties
-    @pub_properties ||= @publisher_schema.schema.fetch('oneOf', []).reduce({}) { |prop, s| prop.merge(s.fetch('properties', {})) }
+    @pub_properties ||= @publisher_schema.schema['properties'] || {}
   end
 
   def publisher_links

--- a/lib/govuk_content_schemas/schema_combiner.rb
+++ b/lib/govuk_content_schemas/schema_combiner.rb
@@ -71,19 +71,12 @@ private
   end
 
   def add_format_field(schema)
-    properties = schema.delete('properties')
-    required = schema.delete('required') || []
-    schema['additionalProperties'] = true
-    schema['oneOf'] = [
-      {
-        "properties" => {
-          "document_type" => document_type,
-          "schema_name" => format_with_name
-        }.merge(properties),
-        "required" => ['document_type', 'schema_name'] + required,
-        "additionalProperties" => false
-      }
-    ]
+    schema["properties"]["document_type"] = document_type
+    schema["properties"]["schema_name"] = format_with_name
+    schema["required"] ||= []
+    schema["required"] << "document_type"
+    schema["required"] << "schema_name"
+    schema
   end
 
   def format_with_name

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -68,14 +68,6 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
     end
   end
 
-  it "merges properties from all top-level oneOf options" do
-    additional_properties = %w{a_property another_property yet_another}
-    publisher_schema.schema['oneOf'] << {'properties' => build_string_properties(*additional_properties)}
-
-    expected_keys = publisher_properties - internal_properties + additional_properties
-    expect(generated.schema['properties'].keys).to include(*expected_keys)
-  end
-
   it "adds updated_at as an allowed datetime property" do
     expect(generated.schema['properties']).to include(
       "updated_at" => {
@@ -109,7 +101,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   context "publisher schema specifies a required link" do
     let(:publisher_schema_with_required_link) {
       clone_schema(publisher_schema).tap do |cloned|
-        cloned.schema['oneOf'][0]['properties']['links']['required'] = link_names
+        cloned.schema['properties']['links']['required'] = link_names
       end
     }
 
@@ -177,7 +169,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
     end
 
     let(:generated) do
-      schema = build_schema("schema.json", oneOf: [{'properties' => properties}], definitions: {})
+      schema = build_schema("schema.json", properties: properties, definitions: {})
       described_class.new(schema, frontend_links_definition).generate
     end
 

--- a/spec/lib/schema_combiner_spec.rb
+++ b/spec/lib/schema_combiner_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
     end
 
     it 'duplicates the metadata to add format and document_type/schema_name options' do
-      expect(combined.schema).not_to have_key('properties')
-      prop2 = combined.schema['oneOf'][0]['properties']
-      expect(prop2.keys).to include('schema_name', 'document_type')
+      expect(combined.schema['properties']).to include('schema_name', 'document_type')
     end
 
     it 'strips the $schema key from the embedded details property' do
@@ -46,7 +44,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
 
     context "without a document_types schema" do
       it "allows any string in the document_type field" do
-        expect(combined.schema['oneOf'][0]['properties']['document_type']).to eq(
+        expect(combined.schema['properties']['document_type']).to eq(
           {
             "type" => "string",
           }
@@ -78,7 +76,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
       }
 
       it "sets the allowed values for the document_type field" do
-        expect(combined.schema['oneOf'][0]['properties']['document_type']).to eq(document_types["document_type"])
+        expect(combined.schema['properties']['document_type']).to eq(document_types["document_type"])
       end
     end
   end
@@ -100,7 +98,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
     end
 
     it "combines the v1 metadata with simple metadata and details and adds the format" do
-      expect(combined.schema['oneOf'][0]['properties'].keys).to match_array(['bar', 'body', 'document_type', 'schema_name'])
+      expect(combined.schema['properties'].keys).to match_array(['bar', 'body', 'document_type', 'schema_name'])
       expect(combined.schema['definitions']).to have_key('details')
     end
   end
@@ -222,11 +220,11 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
     end
 
     it "merges in v2 required properties" do
-      expect(combined.schema['oneOf'][0]['required']).to include('foo')
+      expect(combined.schema['required']).to include('foo')
     end
 
     it "merges in v2 properties" do
-      expect(combined.schema['oneOf'][0]['properties']).to have_key('foo')
+      expect(combined.schema['properties']).to have_key('foo')
     end
   end
 

--- a/spec/support/schema_builder_helpers.rb
+++ b/spec/support/schema_builder_helpers.rb
@@ -6,7 +6,7 @@ module SchemaBuilderHelpers
     Pathname.new(File.expand_path("../../", __dir__))
   end
 
-  def build_schema(name, properties: nil, definitions: nil, required: nil, oneOf: nil)
+  def build_schema(name, properties: nil, definitions: nil, required: nil)
     schema = {
       "$schema" => "http://json-schema.org/draft-04/schema#",
       "type" => "object"
@@ -14,7 +14,6 @@ module SchemaBuilderHelpers
     schema['properties'] = properties if properties
     schema['definitions'] = definitions if definitions
     schema['required'] = required if required
-    schema['oneOf'] = oneOf if oneOf
     JSON::Schema.new(schema, URI.parse(name))
   end
 
@@ -36,7 +35,7 @@ module SchemaBuilderHelpers
     properties = build_string_properties(*properties)
     properties['links'] = build_publisher_links_schema(*link_names) if link_names
     definitions = build_string_properties('guid_list')
-    build_schema('schema.json', oneOf: [{'properties' => properties, 'required' => required_properties}], definitions: definitions)
+    build_schema('schema.json', properties: properties, required: required_properties, definitions: definitions)
   end
 
   def build_publisher_links_schema(*link_names)

--- a/spec/tasks/combine_schema_spec.rb
+++ b/spec/tasks/combine_schema_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'combine_schemas' do
         end
 
         it "derives the format name from the filesystem path" do
-          expect(generated_schema.schema['oneOf'][0]['properties']['schema_name']).to eq(
+          expect(generated_schema.schema['properties']['schema_name']).to eq(
             {"type" => "string", "enum" => [format_name]}
           )
         end


### PR DESCRIPTION
This is a follow-up to https://github.com/alphagov/govuk-content-schemas/pull/374. It removes the now-unnecessary nesting of the schema in a `oneOf`.