### PR TITLE
Correct rendering_app in examples for service manual guides and topics

### DIFF
--- a/formats/service_manual_guide/publisher_v2/examples/point_page.json
+++ b/formats/service_manual_guide/publisher_v2/examples/point_page.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "government-frontend",
+  "rendering_app": "service-manual-frontend",
   "locale": "en",
   "details": {
     "show_description": true,

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "government-frontend",
+  "rendering_app": "service-manual-frontend",
   "locale": "en",
   "details": {
     "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",

--- a/formats/service_manual_topic/publisher_v2/examples/service_manual_topic.json
+++ b/formats/service_manual_topic/publisher_v2/examples/service_manual_topic.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "government-frontend",
+  "rendering_app": "service-manual-frontend",
   "locale": "en",
   "update_type": "minor",
   "base_path": "/service-manual/technology",


### PR DESCRIPTION
Service manual guides and topics are rendered by service-manual-frontend, not government-frontend.