### PR TITLE
Remove document type from specialist publisher metadata

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -640,12 +640,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "aaib_report"
-          ]
-        },
         "aircraft_category": {
           "type": "array",
           "items": {
@@ -694,12 +688,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "asylum_support_decision"
-          ]
-        },
         "tribunal_decision_judges": {
           "type": "array",
           "items": {
@@ -707,7 +695,12 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+            "section-4-2-support-for-failed-asylum-seekers",
+            "section-95-support-for-asylum-seekers"
+          ]
         },
         "tribunal_decision_sub_category": {
           "type": "string"
@@ -737,12 +730,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "cma_case"
-          ]
         },
         "case_type": {
           "type": "string",
@@ -847,12 +834,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "dfid_research_output"
-          ]
         },
         "dfid_review_status": {
           "type": "string",
@@ -1134,12 +1115,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "countryside_stewardship_grant"
-          ]
-        },
         "grant_type": {
           "type": "string",
           "enum": [
@@ -1208,12 +1183,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "drug_safety_update"
-          ]
-        },
         "therapeutic_area": {
           "type": "array",
           "items": {
@@ -1258,12 +1227,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "employment_appeal_tribunal_decision"
-          ]
-        },
         "hidden_indexable_content": {
           "type": "string"
         },
@@ -1299,12 +1262,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "employment_tribunal_decision"
-          ]
-        },
         "tribunal_decision_country": {
           "type": "string",
           "enum": [
@@ -1333,12 +1290,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "esi_fund"
-          ]
         },
         "fund_state": {
           "type": "string",
@@ -1408,12 +1359,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "international_development_fund"
-          ]
         },
         "fund_state": {
           "type": "string",
@@ -1518,12 +1463,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "maib_report"
-          ]
-        },
         "vessel_type": {
           "type": "array",
           "items": {
@@ -1559,12 +1498,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "medical_safety_alert"
-          ]
         },
         "alert_type": {
           "type": "string",
@@ -1618,12 +1551,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "raib_report"
-          ]
-        },
         "railway_type": {
           "type": "array",
           "items": {
@@ -1659,12 +1586,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "tax_tribunal_decision"
-          ]
-        },
         "tribunal_decision_category": {
           "type": "string",
           "enum": [
@@ -1691,12 +1612,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "utaac_decision"
-          ]
         },
         "tribunal_decision_judges": {
           "type": "array",
@@ -1731,12 +1646,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "vehicle_recalls_and_faults_alert"
-          ]
         },
         "fault_type": {
           "type": "string",

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -618,12 +618,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "aaib_report"
-          ]
-        },
         "aircraft_category": {
           "type": "array",
           "items": {
@@ -672,12 +666,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "asylum_support_decision"
-          ]
-        },
         "tribunal_decision_judges": {
           "type": "array",
           "items": {
@@ -685,7 +673,12 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+            "section-4-2-support-for-failed-asylum-seekers",
+            "section-95-support-for-asylum-seekers"
+          ]
         },
         "tribunal_decision_sub_category": {
           "type": "string"
@@ -715,12 +708,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "cma_case"
-          ]
         },
         "case_type": {
           "type": "string",
@@ -825,12 +812,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "dfid_research_output"
-          ]
         },
         "dfid_review_status": {
           "type": "string",
@@ -1112,12 +1093,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "countryside_stewardship_grant"
-          ]
-        },
         "grant_type": {
           "type": "string",
           "enum": [
@@ -1186,12 +1161,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "drug_safety_update"
-          ]
-        },
         "therapeutic_area": {
           "type": "array",
           "items": {
@@ -1236,12 +1205,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "employment_appeal_tribunal_decision"
-          ]
-        },
         "hidden_indexable_content": {
           "type": "string"
         },
@@ -1277,12 +1240,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "employment_tribunal_decision"
-          ]
-        },
         "tribunal_decision_country": {
           "type": "string",
           "enum": [
@@ -1311,12 +1268,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "esi_fund"
-          ]
         },
         "fund_state": {
           "type": "string",
@@ -1386,12 +1337,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "international_development_fund"
-          ]
         },
         "fund_state": {
           "type": "string",
@@ -1496,12 +1441,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "maib_report"
-          ]
-        },
         "vessel_type": {
           "type": "array",
           "items": {
@@ -1537,12 +1476,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "medical_safety_alert"
-          ]
         },
         "alert_type": {
           "type": "string",
@@ -1596,12 +1529,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "raib_report"
-          ]
-        },
         "railway_type": {
           "type": "array",
           "items": {
@@ -1637,12 +1564,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "tax_tribunal_decision"
-          ]
-        },
         "tribunal_decision_category": {
           "type": "string",
           "enum": [
@@ -1669,12 +1590,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "utaac_decision"
-          ]
         },
         "tribunal_decision_judges": {
           "type": "array",
@@ -1709,12 +1624,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "vehicle_recalls_and_faults_alert"
-          ]
         },
         "fault_type": {
           "type": "string",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -561,12 +561,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "aaib_report"
-          ]
-        },
         "aircraft_category": {
           "type": "array",
           "items": {
@@ -615,12 +609,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "asylum_support_decision"
-          ]
-        },
         "tribunal_decision_judges": {
           "type": "array",
           "items": {
@@ -628,7 +616,12 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+            "section-4-2-support-for-failed-asylum-seekers",
+            "section-95-support-for-asylum-seekers"
+          ]
         },
         "tribunal_decision_sub_category": {
           "type": "string"
@@ -658,12 +651,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "cma_case"
-          ]
         },
         "case_type": {
           "type": "string",
@@ -768,12 +755,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "dfid_research_output"
-          ]
         },
         "dfid_review_status": {
           "type": "string",
@@ -1055,12 +1036,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "countryside_stewardship_grant"
-          ]
-        },
         "grant_type": {
           "type": "string",
           "enum": [
@@ -1129,12 +1104,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "drug_safety_update"
-          ]
-        },
         "therapeutic_area": {
           "type": "array",
           "items": {
@@ -1179,12 +1148,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "employment_appeal_tribunal_decision"
-          ]
-        },
         "hidden_indexable_content": {
           "type": "string"
         },
@@ -1220,12 +1183,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "employment_tribunal_decision"
-          ]
-        },
         "tribunal_decision_country": {
           "type": "string",
           "enum": [
@@ -1254,12 +1211,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "esi_fund"
-          ]
         },
         "fund_state": {
           "type": "string",
@@ -1329,12 +1280,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "international_development_fund"
-          ]
         },
         "fund_state": {
           "type": "string",
@@ -1439,12 +1384,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "maib_report"
-          ]
-        },
         "vessel_type": {
           "type": "array",
           "items": {
@@ -1480,12 +1419,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "medical_safety_alert"
-          ]
         },
         "alert_type": {
           "type": "string",
@@ -1539,12 +1472,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "raib_report"
-          ]
-        },
         "railway_type": {
           "type": "array",
           "items": {
@@ -1580,12 +1507,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "tax_tribunal_decision"
-          ]
-        },
         "tribunal_decision_category": {
           "type": "string",
           "enum": [
@@ -1612,12 +1533,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "utaac_decision"
-          ]
         },
         "tribunal_decision_judges": {
           "type": "array",
@@ -1652,12 +1567,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "vehicle_recalls_and_faults_alert"
-          ]
         },
         "fault_type": {
           "type": "string",

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -2253,12 +2253,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "aaib_report"
-                  ]
-                },
                 "aircraft_category": {
                   "type": "array",
                   "items": {
@@ -2307,12 +2301,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "asylum_support_decision"
-                  ]
-                },
                 "tribunal_decision_judges": {
                   "type": "array",
                   "items": {
@@ -2320,7 +2308,12 @@
                   }
                 },
                 "tribunal_decision_category": {
-                  "type": "string"
+                  "type": "string",
+                  "enum": [
+                    "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+                    "section-4-2-support-for-failed-asylum-seekers",
+                    "section-95-support-for-asylum-seekers"
+                  ]
                 },
                 "tribunal_decision_sub_category": {
                   "type": "string"
@@ -2350,12 +2343,6 @@
               "properties": {
                 "bulk_published": {
                   "type": "boolean"
-                },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "cma_case"
-                  ]
                 },
                 "case_type": {
                   "type": "string",
@@ -2460,12 +2447,6 @@
               "properties": {
                 "bulk_published": {
                   "type": "boolean"
-                },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "dfid_research_output"
-                  ]
                 },
                 "dfid_review_status": {
                   "type": "string",
@@ -2747,12 +2728,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "countryside_stewardship_grant"
-                  ]
-                },
                 "grant_type": {
                   "type": "string",
                   "enum": [
@@ -2821,12 +2796,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "drug_safety_update"
-                  ]
-                },
                 "therapeutic_area": {
                   "type": "array",
                   "items": {
@@ -2871,12 +2840,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "employment_appeal_tribunal_decision"
-                  ]
-                },
                 "hidden_indexable_content": {
                   "type": "string"
                 },
@@ -2912,12 +2875,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "employment_tribunal_decision"
-                  ]
-                },
                 "tribunal_decision_country": {
                   "type": "string",
                   "enum": [
@@ -2946,12 +2903,6 @@
               "properties": {
                 "bulk_published": {
                   "type": "boolean"
-                },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "esi_fund"
-                  ]
                 },
                 "fund_state": {
                   "type": "string",
@@ -3021,12 +2972,6 @@
               "properties": {
                 "bulk_published": {
                   "type": "boolean"
-                },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "international_development_fund"
-                  ]
                 },
                 "fund_state": {
                   "type": "string",
@@ -3131,12 +3076,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "maib_report"
-                  ]
-                },
                 "vessel_type": {
                   "type": "array",
                   "items": {
@@ -3172,12 +3111,6 @@
               "properties": {
                 "bulk_published": {
                   "type": "boolean"
-                },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "medical_safety_alert"
-                  ]
                 },
                 "alert_type": {
                   "type": "string",
@@ -3231,12 +3164,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "raib_report"
-                  ]
-                },
                 "railway_type": {
                   "type": "array",
                   "items": {
@@ -3272,12 +3199,6 @@
                 "bulk_published": {
                   "type": "boolean"
                 },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "tax_tribunal_decision"
-                  ]
-                },
                 "tribunal_decision_category": {
                   "type": "string",
                   "enum": [
@@ -3304,12 +3225,6 @@
               "properties": {
                 "bulk_published": {
                   "type": "boolean"
-                },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "utaac_decision"
-                  ]
                 },
                 "tribunal_decision_judges": {
                   "type": "array",
@@ -3344,12 +3259,6 @@
               "properties": {
                 "bulk_published": {
                   "type": "boolean"
-                },
-                "document_type": {
-                  "type": "string",
-                  "enum": [
-                    "vehicle_recalls_and_faults_alert"
-                  ]
                 },
                 "fault_type": {
                   "type": "string",

--- a/formats/specialist_document/frontend/examples/aaib-reports.json
+++ b/formats/specialist_document/frontend/examples/aaib-reports.json
@@ -30,8 +30,7 @@
       "bulk_published": false,
       "aircraft_type": "Rotorsport UK Calidus",
       "location": "Damyns Hall Aerodrome, Essex",
-      "registration": "G-PCPC",
-      "document_type": "aaib_report"
+      "registration": "G-PCPC"
     },
     "max_cache_time": 10,
     "headers": [

--- a/formats/specialist_document/frontend/examples/asylum-support-decision.json
+++ b/formats/specialist_document/frontend/examples/asylum-support-decision.json
@@ -14,13 +14,12 @@
         "sally-verity-smith"
       ],
       "bulk_published": false,
-      "tribunal_decision_category": "section-4-2-failed-asylum-seekers",
+      "tribunal_decision_category": "section-4-2-support-for-failed-asylum-seekers",
       "tribunal_decision_sub_category": "section-4-2-jurisdiction",
       "tribunal_decision_landmark": "landmark",
       "tribunal_decision_reference_number": "AST / 06 / 04 / 13140",
       "tribunal_decision_decision_date": "2006-04-27",
-      "hidden_indexable_content": "The appellant, an Iranian Kurd born on 20 February 1979, appeals against the decision of the Secretary of State who refused support under Section 4 of the Immigration and Asylum Act 1999 (“the Act”) on 8 April 2006 on the grounds that the appellant did not satisfy one or more of the conditions set out in Regulation 3 of the Immigration and Asylum (Provision of Accommodation to Failed Asylum Seekers) Regulations 2005 (“the 2005 Regulations”). \r\n...\r\n",
-      "document_type": "asylum_support_decision"
+      "hidden_indexable_content": "The appellant, an Iranian Kurd born on 20 February 1979, appeals against the decision of the Secretary of State who refused support under Section 4 of the Immigration and Asylum Act 1999 (“the Act”) on 8 April 2006 on the grounds that the appellant did not satisfy one or more of the conditions set out in Regulation 3 of the Immigration and Asylum (Provision of Accommodation to Failed Asylum Seekers) Regulations 2005 (“the 2005 Regulations”). \r\n...\r\n"
     },
     "max_cache_time": 10,
     "change_history": [

--- a/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
@@ -36,8 +36,7 @@
       ],
       "funding_amount": [
         "more-than-500"
-      ],
-      "document_type": "countryside_stewardship_grant"
+      ]
     },
     "max_cache_time": 10,
     "headers": [

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -33,8 +33,7 @@
         "paediatrics",
         "theatre-practitioners"
       ],
-      "issued_date": "2015-07-06",
-      "document_type": "medical_safety_alert"
+      "issued_date": "2015-07-06"
     },
     "max_cache_time": 10,
     "headers": [

--- a/formats/specialist_document/frontend/examples/drug-safety-update.json
+++ b/formats/specialist_document/frontend/examples/drug-safety-update.json
@@ -24,8 +24,7 @@
       "bulk_published": false,
       "therapeutic_area": [
         "endocrinology-diabetology-metabolism"
-      ],
-      "document_type": "drug_safety_update"
+      ]
     },
     "max_cache_time": 10,
     "headers": [

--- a/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
@@ -11,7 +11,6 @@
   "details": {
     "metadata": {
       "bulk_published": false,
-      "document_type": "employment_appeal_tribunal_decision",
       "hidden_indexable_content": "Appeal No. UKEAT/0144/15/LA\\n\tAt the Tribunal\n\tOn 7 October 2015\n\tJudgment handed down on 27 October 2015",
       "tribunal_decision_categories": [
         "race-discrimination"

--- a/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
@@ -17,8 +17,7 @@
       ],
       "tribunal_decision_country": "england-and-wales",
       "tribunal_decision_decision_date": "2008-12-19",
-      "bulk_published": false,
-      "document_type": "employment_tribunal_decision"
+      "bulk_published": false
     },
     "max_cache_time": 10,
     "change_history": [

--- a/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
+++ b/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
@@ -32,8 +32,7 @@
       "funding_source": [
         "european-social-fund"
       ],
-      "closing_date": "2015-05-29",
-      "document_type": "esi_fund"
+      "closing_date": "2015-05-29"
     },
     "max_cache_time": 10,
     "headers": [

--- a/formats/specialist_document/frontend/examples/international-development-funding.json
+++ b/formats/specialist_document/frontend/examples/international-development-funding.json
@@ -42,8 +42,7 @@
       "value_of_funding": [
         "500001-to-1000000",
         "more-than-1000000"
-      ],
-      "document_type": "international_development_fund"
+      ]
     },
     "max_cache_time": 10,
     "headers": [

--- a/formats/specialist_document/frontend/examples/maib-reports.json
+++ b/formats/specialist_document/frontend/examples/maib-reports.json
@@ -27,8 +27,7 @@
         "fishing-vessel"
       ],
       "report_type": "investigation-report",
-      "date_of_occurrence": "2014-12-21",
-      "document_type": "maib_report"
+      "date_of_occurrence": "2014-12-21"
     },
     "max_cache_time": 10,
     "headers": [

--- a/formats/specialist_document/frontend/examples/raib-reports.json
+++ b/formats/specialist_document/frontend/examples/raib-reports.json
@@ -29,8 +29,7 @@
         "heavy-rail"
       ],
       "report_type": "investigation-report",
-      "date_of_occurrence": "2014-09-24",
-      "document_type": "raib_report"
+      "date_of_occurrence": "2014-09-24"
     },
     "max_cache_time": 10,
     "change_history": [

--- a/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
@@ -11,7 +11,6 @@
   "details": {
     "metadata": {
       "bulk_published": false,
-      "document_type": "tax_tribunal_decision",
       "tribunal_decision_category": "tax",
       "tribunal_decision_decision_date": "2015-09-08",
       "hidden_indexable_content": "whether FTT entitled not to find or infer that car dealer had accounted for VAT on bonuses paid by manufacturers to dealer on purchase of demonstrator and courtesy cars in claim periods - appeal dismissed"

--- a/formats/specialist_document/frontend/examples/utaac-decision.json
+++ b/formats/specialist_document/frontend/examples/utaac-decision.json
@@ -23,8 +23,7 @@
         "benefits-for-children-benefit-increases-for-children",
         "bereavement-and-death-benefits-bereaved-parents-allowance"
       ],
-      "bulk_published": false,
-      "document_type": "utaac_decision"
+      "bulk_published": false
     },
     "max_cache_time": 10,
     "change_history": [

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -123,12 +123,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "aaib_report"
-          ]
-        },
         "aircraft_category": {
           "type": "array",
           "items": {
@@ -177,12 +171,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "asylum_support_decision"
-          ]
-        },
         "tribunal_decision_judges": {
           "type": "array",
           "items": {
@@ -190,7 +178,12 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+            "section-4-2-support-for-failed-asylum-seekers",
+            "section-95-support-for-asylum-seekers"
+           ]
         },
         "tribunal_decision_sub_category": {
           "type": "string"
@@ -220,12 +213,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "cma_case"
-          ]
         },
         "case_type": {
           "type": "string",
@@ -330,12 +317,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "dfid_research_output"
-          ]
         },
         "dfid_review_status": {
           "type": "string",
@@ -617,12 +598,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "countryside_stewardship_grant"
-          ]
-        },
         "grant_type": {
           "type": "string",
           "enum": [
@@ -691,12 +666,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "drug_safety_update"
-          ]
-        },
         "therapeutic_area": {
           "type": "array",
           "items": {
@@ -741,12 +710,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "employment_appeal_tribunal_decision"
-          ]
-        },
         "hidden_indexable_content": {
           "type": "string"
         },
@@ -782,12 +745,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "employment_tribunal_decision"
-          ]
-        },
         "tribunal_decision_country": {
           "type": "string",
           "enum": [
@@ -816,12 +773,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "esi_fund"
-          ]
         },
         "fund_state": {
           "type": "string",
@@ -891,12 +842,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "international_development_fund"
-          ]
         },
         "fund_state": {
           "type": "string",
@@ -1001,12 +946,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "maib_report"
-          ]
-        },
         "vessel_type": {
           "type": "array",
           "items": {
@@ -1042,12 +981,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "medical_safety_alert"
-          ]
         },
         "alert_type": {
           "type": "string",
@@ -1101,12 +1034,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "raib_report"
-          ]
-        },
         "railway_type": {
           "type": "array",
           "items": {
@@ -1142,12 +1069,6 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "tax_tribunal_decision"
-          ]
-        },
         "tribunal_decision_category": {
           "type": "string",
           "enum": [
@@ -1174,12 +1095,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "utaac_decision"
-          ]
         },
         "tribunal_decision_judges": {
           "type": "array",
@@ -1214,12 +1129,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "document_type": {
-          "type": "string",
-          "enum": [
-            "vehicle_recalls_and_faults_alert"
-          ]
         },
         "fault_type": {
           "type": "string",

--- a/formats/specialist_document/publisher_v2/examples/dfid_research_output.json
+++ b/formats/specialist_document/publisher_v2/examples/dfid_research_output.json
@@ -31,7 +31,6 @@
     ],
     "change_history": [],
     "metadata": {
-      "document_type": "dfid_research_output",
       "bulk_published": true,
       "dfid_review_status": "unreviewed",
       "dfid_document_type": "book_chapter",

--- a/formats/specialist_document/publisher_v2/examples/specialist_document.json
+++ b/formats/specialist_document/publisher_v2/examples/specialist_document.json
@@ -48,8 +48,7 @@
       "market_sector": [
         "energy"
       ],
-      "outcome_type": "ca98-commitment",
-      "document_type": "cma_case"
+      "outcome_type": "ca98-commitment"
     },
     "max_cache_time": 10
   },


### PR DESCRIPTION
https://trello.com/c/Y0ncSoTO/258-clean-up-remove-document-type-from-pub-api-metadata-payload

Remove duplicate `document_type` property from the `specialist_document` schema metadata.
To do this we have to [be explicit in the enums for the `tribunal_decision_category` property](https://github.com/alphagov/govuk-content-schemas/commit/8212a1e3551017fd3c3dbb0bf52b399f38869f56#diff-1a705374a0f9ac97b29928d07d04b0bfR182) to satisfy [the `oneOf` clause for document specific metadata](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/specialist_document/publisher/details.json#L41).

Needs https://github.com/alphagov/specialist-publisher-rebuild/pull/891 to build correctly.
https://github.com/alphagov/specialist-publisher/pull/737 added for completeness.