### PR TITLE
Add notes_for_editors to taxon details hash

### DIFF
--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -195,7 +195,11 @@
       "properties": {
         "internal_name": {
           "type": "string",
-          "description": "An internal name for admin interfaces. Includes parent."
+          "description": "An internal name for admin interfaces."
+        },
+        "notes_for_editors": {
+          "type": "string",
+          "description": "Usage notes for editors when tagging content to a taxon."
         }
       }
     },

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -135,7 +135,11 @@
       "properties": {
         "internal_name": {
           "type": "string",
-          "description": "An internal name for admin interfaces. Includes parent."
+          "description": "An internal name for admin interfaces."
+        },
+        "notes_for_editors": {
+          "type": "string",
+          "description": "Usage notes for editors when tagging content to a taxon."
         }
       }
     },

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -131,7 +131,11 @@
       "properties": {
         "internal_name": {
           "type": "string",
-          "description": "An internal name for admin interfaces. Includes parent."
+          "description": "An internal name for admin interfaces."
+        },
+        "notes_for_editors": {
+          "type": "string",
+          "description": "Usage notes for editors when tagging content to a taxon."
         }
       }
     },

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -3477,7 +3477,11 @@
           "properties": {
             "internal_name": {
               "type": "string",
-              "description": "An internal name for admin interfaces. Includes parent."
+              "description": "An internal name for admin interfaces."
+            },
+            "notes_for_editors": {
+              "type": "string",
+              "description": "Usage notes for editors when tagging content to a taxon."
             }
           }
         },

--- a/formats/taxon/publisher/details.json
+++ b/formats/taxon/publisher/details.json
@@ -5,7 +5,11 @@
   "properties": {
     "internal_name": {
       "type": "string",
-      "description": "An internal name for admin interfaces. Includes parent."
+      "description": "An internal name for admin interfaces."
+    },
+    "notes_for_editors": {
+      "type": "string",
+      "description": "Usage notes for editors when tagging content to a taxon."
     }
   }
 }


### PR DESCRIPTION
Also includes minor amendment to description field explanation - a taxon
internal name may not necessarily include the parent.