### PR TITLE
Make rendering_app optional for contacts

### DIFF
--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -6,7 +6,6 @@
     "title",
     "details",
     "publishing_app",
-    "rendering_app",
     "locale",
     "document_type",
     "schema_name"

--- a/formats/contact/publisher_v2/metadata.json
+++ b/formats/contact/publisher_v2/metadata.json
@@ -6,7 +6,6 @@
     "title",
     "details",
     "publishing_app",
-    "rendering_app",
     "locale"
   ],
   "properties": {


### PR DESCRIPTION
It doesn't make sense for it to be required, and meanwhile it's causing validation errors.