### PR TITLE
Service manual topics now link to email alert signups

### DIFF
--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -88,6 +88,9 @@
         "content_owners": {
           "$ref": "#/definitions/frontend_links"
         },
+        "email_alert_signup": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -184,6 +184,10 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
+        "email_alert_signup": {
+          "description": "References an email alert signup page for this topic",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -18,6 +18,10 @@
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
         },
+        "email_alert_signup": {
+          "description": "References an email alert signup page for this topic",
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/formats/service_manual_topic/frontend/examples/service_manual_topic.json
+++ b/formats/service_manual_topic/frontend/examples/service_manual_topic.json
@@ -74,6 +74,22 @@
         "web_url": "http://www.dev.gov.uk/service-manual/test-topic",
         "locale": "en"
       }
+    ],
+    "email_alert_signup": [
+      {
+        "analytics_identifier": null,
+        "api_url": "http://content-store.dev.gov.uk/content/service-manual/test-expanded-topic/email-signup",
+        "base_path": "/service-manual/test-expanded-topic/email-signup",
+        "content_id": "e57b21e6-2111-4a50-9ead-9c502cd40a3d",
+        "description": null,
+        "document_type": "email_alert_signup",
+        "locale": "en",
+        "public_updated_at": "2016-08-17T10:52:00Z",
+        "schema_name": "email_alert_signup",
+        "title": "Service Manual – Service Manual Test Expanded Topic",
+        "web_url": "http://www.dev.gov.uk/service-manual/test-expanded-topic/email-signup",
+        "links": {}
+      }
     ]
   },
   "description": "Service Manual Topic description",

--- a/formats/service_manual_topic/publisher/links.json
+++ b/formats/service_manual_topic/publisher/links.json
@@ -10,6 +10,10 @@
     "content_owners": {
       "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
       "$ref": "#/definitions/guid_list"
+    },
+    "email_alert_signup": {
+      "description": "References an email alert signup page for this topic",
+      "$ref": "#/definitions/guid_list"
     }
   }
 }

--- a/formats/service_manual_topic/publisher_v2/examples/service_manual_topic_links.json
+++ b/formats/service_manual_topic/publisher_v2/examples/service_manual_topic_links.json
@@ -7,6 +7,7 @@
     "content_owners": [
       "fb87cca9-311e-4fd3-af42-03616164a407",
       "d6f49e7f-4f54-44e6-815b-ac3098a5f509"
-    ]
+    ],
+    "email_alert_signup": ["e57b21e6-2111-4a50-9ead-9c502cd40a3d"]
   }
 }


### PR DESCRIPTION
Within the service manual we're making it possible for users to sign up for email alerts with particular service manual topics.

To do this we're creating an email_alert_signup for each topic, and associating it with the topic.