### PR TITLE
Remove "signup_link"

### DIFF
--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -128,6 +128,7 @@
       "type": "boolean"
     },
     "signup_link": {
+      "description": "DEPRECATED: Don't use this for linking to the email alert signup page. Use `links.email_alert_signup`.",
       "anyOf": [
         { "type": "string" },
         { "type": "null" }

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -89,6 +89,7 @@
       "type": "boolean"
     },
     "signup_link": {
+      "description": "DEPRECATED: Don't use this for linking to the email alert signup page. Use `links.email_alert_signup`.",
       "type": "string"
     },
     "summary": {


### PR DESCRIPTION
`details.signup_link` is a piece of technical debt from the time we didn't have the links hash, or didn't use it properly. Policy Publisher and Finder Publisher shouldn't be sending this.

This commit adds a comment to make sure nobody copies the pattern.