### PR TITLE
Remove "signup_link"

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -328,16 +328,6 @@
         "show_summaries": {
           "type": "boolean"
         },
-        "signup_link": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "summary": {
           "anyOf": [
             {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -265,16 +265,6 @@
         "show_summaries": {
           "type": "boolean"
         },
-        "signup_link": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "summary": {
           "anyOf": [
             {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -261,16 +261,6 @@
         "show_summaries": {
           "type": "boolean"
         },
-        "signup_link": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "summary": {
           "anyOf": [
             {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -294,9 +294,6 @@
         "show_summaries": {
           "type": "boolean"
         },
-        "signup_link": {
-          "type": "string"
-        },
         "summary": {
           "type": "string"
         },

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -218,9 +218,6 @@
         "show_summaries": {
           "type": "boolean"
         },
-        "signup_link": {
-          "type": "string"
-        },
         "summary": {
           "type": "string"
         },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -214,9 +214,6 @@
         "show_summaries": {
           "type": "boolean"
         },
-        "signup_link": {
-          "type": "string"
-        },
         "summary": {
           "type": "string"
         },

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -1166,16 +1166,6 @@
             "show_summaries": {
               "type": "boolean"
             },
-            "signup_link": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "summary": {
               "anyOf": [
                 {
@@ -1901,9 +1891,6 @@
             },
             "show_summaries": {
               "type": "boolean"
-            },
-            "signup_link": {
-              "type": "string"
             },
             "summary": {
               "type": "string"

--- a/formats/finder/frontend/examples/drug-device-alerts.json
+++ b/formats/finder/frontend/examples/drug-device-alerts.json
@@ -142,8 +142,7 @@
       "document_type": "medical_safety_alert"
     },
     "format_name": "Medical safety alert",
-    "show_summaries": true,
-    "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup"
+    "show_summaries": true
   },
   "links": {
     "email_alert_signup": [

--- a/formats/finder/frontend/examples/drug-safety-update.json
+++ b/formats/finder/frontend/examples/drug-safety-update.json
@@ -128,8 +128,7 @@
       "document_type": "drug_safety_update"
     },
     "format_name": "Drug Safety Update",
-    "show_summaries": true,
-    "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup"
+    "show_summaries": true
   },
   "links": {
     "email_alert_signup": [

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -127,12 +127,6 @@
     "show_summaries": {
       "type": "boolean"
     },
-    "signup_link": {
-      "anyOf": [
-        { "type": "string" },
-        { "type": "null" }
-      ]
-    },
     "summary": {
       "anyOf": [
         { "type": "string" },

--- a/formats/policy/frontend/examples/policy_area.json
+++ b/formats/policy/frontend/examples/policy_area.json
@@ -18,7 +18,6 @@
       ]
     },
     "human_readable_finder_format": "Policy",
-    "signup_link": "",
     "summary": "The government believes that the current benefits system is too complex, and there are insufficient incentives to encourage people on benefits to start paid work or increase their hours.",
     "show_summaries": false,
     "emphasised_organisations": ["a4759607-4fd8-4cf0-9d56-af9d14a71162"],

--- a/formats/policy/frontend/examples/policy_programme.json
+++ b/formats/policy/frontend/examples/policy_programme.json
@@ -17,7 +17,6 @@
       ]
     },
     "human_readable_finder_format": "Policy",
-    "signup_link": "",
     "summary": "Universal Credit brings together 6 benefits for people who are out of work or on a low income into a single payment. It's being introduced in stages, starting in October 2013. By the end of 2017 it's expected to be available across England and Wales.",
     "show_summaries": false,
     "emphasised_organisations": ["9417d532-a080-4856-9a0f-08b1d9d78c98"],

--- a/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
+++ b/formats/policy/frontend/examples/policy_with_inapplicable_nations.json
@@ -17,7 +17,6 @@
       ]
     },
     "human_readable_finder_format": "Policy",
-    "signup_link": "",
     "summary": "While day-to-day policing and justice functions are devolved to the Northern Ireland Executive, the UK government retains responsibility for national security issues in Northern Ireland.",
     "show_summaries": false,
     "emphasised_organisations": ["8927158f-e4b2-4361-b55d-02de7599b220"],

--- a/formats/policy/publisher/details.json
+++ b/formats/policy/publisher/details.json
@@ -88,9 +88,6 @@
     "show_summaries": {
       "type": "boolean"
     },
-    "signup_link": {
-      "type": "string"
-    },
     "summary": {
       "type": "string"
     },

--- a/formats/policy/publisher_v2/examples/policy.json
+++ b/formats/policy/publisher_v2/examples/policy.json
@@ -19,7 +19,6 @@
       ]
     },
     "human_readable_finder_format": "Policy",
-    "signup_link": "",
     "summary": "The government believes that the current benefits system is too complex, and there are insufficient incentives to encourage people on benefits to start paid work or increase their hours.",
     "show_summaries": false,
     "facets": [


### PR DESCRIPTION
`details.signup_link` is a piece of technical debt from the time we didn't have the links hash, or didn't use it properly. Policy Publisher and Finder Publisher shouldn't be sending this.