### PR TITLE
Don't allow additional properties for frontend links

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -145,7 +145,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -153,6 +153,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -189,11 +202,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -145,7 +145,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -153,6 +153,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -189,11 +202,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -143,7 +143,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -151,6 +151,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -187,11 +200,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -142,7 +142,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -150,6 +150,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -186,11 +199,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -139,7 +139,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -147,6 +147,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -183,11 +196,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -139,7 +139,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -147,6 +147,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -183,11 +196,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -140,7 +140,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -148,6 +148,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -184,11 +197,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -137,7 +137,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -145,6 +145,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -181,11 +194,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -145,7 +145,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -153,6 +153,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -189,11 +202,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -132,7 +132,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -140,6 +140,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -176,11 +189,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -152,7 +152,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -160,6 +160,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -196,11 +209,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -148,7 +148,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -156,6 +156,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -192,11 +205,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -139,7 +139,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -147,6 +147,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -183,11 +196,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -142,7 +142,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -150,6 +150,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -186,11 +199,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -151,7 +151,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -159,6 +159,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -195,11 +208,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -137,7 +137,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -145,6 +145,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -181,11 +194,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -139,7 +139,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -147,6 +147,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -183,11 +196,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -136,7 +136,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -144,6 +144,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -180,11 +193,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -133,7 +133,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "content_id",
           "title",
@@ -141,6 +141,19 @@
           "locale"
         ],
         "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
@@ -177,11 +190,7 @@
           "links": {
             "type": "object",
             "additionalProperties": true,
-            "properties": {
-              "parent": {
-                "$ref": "#/definitions/guid_list"
-              }
-            }
+            "description": "TODO: investigate if could this be validated recursively."
           }
         }
       }

--- a/formats/detailed_guide/frontend/examples/detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/detailed_guide.json
@@ -69,16 +69,18 @@
         "api_url": "https://www.gov.uk/api/content/topic/business-tax/paye",
         "web_url": "https://www.gov.uk/topic/business-tax/paye",
         "locale": "en",
-        "parent": [
-          {
-            "content_id": "a481832e-5f10-4d3b-8131-a064b36730ae",
-            "title": "Business tax",
-            "base_path": "/topic/business-tax",
-            "api_url": "https://www.gov.uk/api/content/topic/business-tax",
-            "web_url": "https://www.gov.uk/topic/business-tax",
-            "locale": "en"
-          }
-        ]
+        "links": {
+          "parent": [
+            {
+              "content_id": "a481832e-5f10-4d3b-8131-a064b36730ae",
+              "title": "Business tax",
+              "base_path": "/topic/business-tax",
+              "api_url": "https://www.gov.uk/api/content/topic/business-tax",
+              "web_url": "https://www.gov.uk/topic/business-tax",
+              "locale": "en"
+            }
+          ]
+        }
       }
     ],
     "topics": [

--- a/formats/detailed_guide/frontend/examples/political_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/political_detailed_guide.json
@@ -45,16 +45,18 @@
         "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy/low-carbon-energy",
         "web_url": "https://www.gov.uk/topic/climate-change-energy/low-carbon-energy",
         "locale": "en",
-        "parent": [
-          {
-            "content_id": "57c6699d-ceda-4168-9d23-3fed774ca776",
-            "title": "Climate change and energy",
-            "base_path": "/topic/climate-change-energy",
-            "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy",
-            "web_url": "https://www.gov.uk/topic/climate-change-energy",
-            "locale": "en"
-          }
-        ]
+        "links": {
+          "parent": [
+            {
+              "content_id": "57c6699d-ceda-4168-9d23-3fed774ca776",
+              "title": "Climate change and energy",
+              "base_path": "/topic/climate-change-energy",
+              "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy",
+              "web_url": "https://www.gov.uk/topic/climate-change-energy",
+              "locale": "en"
+            }
+          ]
+        }
       }
     ],
     "related_guides": [

--- a/formats/detailed_guide/frontend/examples/translated_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/translated_detailed_guide.json
@@ -274,11 +274,6 @@
         "content_id": "cf2ab891-5bd9-4788-8254-f9444423719c",
         "description": "List of information about Managing your charity.",
         "document_type": "topic",
-        "links": {
-          "parent": [
-            "68f2ac58-4394-442a-b309-6a7f372f345e"
-          ]
-        },
         "locale": "en",
         "public_updated_at": "2016-03-21T13:12:32.000+00:00",
         "schema_name": "topic",

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -3,7 +3,7 @@
   "type": "array",
   "items": {
     "type": "object",
-    "additionalProperties": true,
+    "additionalProperties": false,
     "required": [
       "content_id",
       "title",
@@ -11,6 +11,19 @@
       "locale"
     ],
     "properties": {
+      "details": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "document_type": {
+        "type": "string"
+      },
+      "schema_name": {
+        "type": "string"
+      },
+      "public_updated_at": {
+        "type": "string"
+      },
       "content_id": {
         "$ref": "#/definitions/guid"
       },
@@ -47,11 +60,7 @@
       "links": {
         "type": "object",
         "additionalProperties": true,
-        "properties": {
-          "parent": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
+        "description": "TODO: investigate if could this be validated recursively."
       }
     }
   }

--- a/formats/service_manual_guide/frontend/examples/point_page.json
+++ b/formats/service_manual_guide/frontend/examples/point_page.json
@@ -47,8 +47,7 @@
         "locale": "en",
         "public_updated_at": "2016-06-22T10:35:24.641Z",
         "title": "The Digital Service Standard",
-        "web_url": "http://www.dev.gov.uk/service-manual/service-standard",
-        "expanded_links": {}
+        "web_url": "http://www.dev.gov.uk/service-manual/service-standard"
       }
     ]
   }


### PR DESCRIPTION
This changes the way the `links` are validated in frontend schemas.

Since #232 the frontend links have `additionalProperties` set to true. I think this is undesirable because it allows all data in the frontend links, defeating the purpose of schemas.

- Two detailed guide examples have the links incorrectly nested (`links -> parent -> parent` instead of `links -> parent -> links -> parent`). This wasn't picked up by the validation. This could have caused developers to build pages that work only with the incorrect example.
- The service manual example included a `expanded_links` example, which is not used anymore (and should never have been used in frontends).
