### PR TITLE
Recursively validate frontend links and fix examples

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -201,8 +201,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -201,8 +201,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -199,8 +199,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -198,8 +198,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -195,8 +195,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -195,8 +195,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -196,8 +196,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -193,8 +193,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -201,8 +201,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -188,8 +188,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -208,8 +208,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -204,8 +204,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -195,8 +195,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -198,8 +198,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -207,8 +207,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -193,8 +193,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -195,8 +195,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -192,8 +192,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -189,8 +189,11 @@
           },
           "links": {
             "type": "object",
-            "additionalProperties": true,
-            "description": "TODO: investigate if could this be validated recursively."
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
           }
         }
       }

--- a/formats/detailed_guide/frontend/examples/translated_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/translated_detailed_guide.json
@@ -52,127 +52,6 @@
     }
   },
   "document_type": "detailed_guidance",
-  "expanded_links": {
-    "available_translations": [
-      {
-        "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/guidance/prepare-a-charity-annual-return.cy",
-        "base_path": "/guidance/prepare-a-charity-annual-return.cy",
-        "content_id": "5fec94c4-7631-11e4-a3cb-005056011aef",
-        "description": "Mae'n rhaid i chi anfon ffurflen flynyddol (neu ddiweddaru eich manylion) bob blwyddyn os yw'ch elusen wedi cofrestru yng Nghymru neu Loegr.",
-        "locale": "cy",
-        "public_updated_at": "2013-05-22T23:00:00.000Z",
-        "title": "Paratoi ffurflen flynyddol elusen",
-        "web_url": "https://www.gov.uk/guidance/prepare-a-charity-annual-return.cy"
-      },
-      {
-        "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/guidance/prepare-a-charity-annual-return",
-        "base_path": "/guidance/prepare-a-charity-annual-return",
-        "content_id": "5fec94c4-7631-11e4-a3cb-005056011aef",
-        "description": "You must send an annual return (or update your details) every year if your charity is registered in England or Wales.",
-        "locale": "en",
-        "public_updated_at": "2013-05-22T23:00:00.000Z",
-        "title": "Prepare a charity annual return",
-        "web_url": "https://www.gov.uk/guidance/prepare-a-charity-annual-return"
-      }
-    ],
-    "organisations": [
-      {
-        "analytics_identifier": "D98",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/charity-commission",
-        "base_path": "/government/organisations/charity-commission",
-        "content_id": "489e651f-34c8-4b34-bdd7-e13c2324cde3",
-        "description": null,
-        "expanded_links": {},
-        "locale": "en",
-        "public_updated_at": "2014-10-15T14:35:31.000Z",
-        "title": "The Charity Commission",
-        "web_url": "https://www.gov.uk/government/organisations/charity-commission"
-      }
-    ],
-    "parent": [
-      {
-        "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/topic/running-charity/managing-charity",
-        "base_path": "/topic/running-charity/managing-charity",
-        "content_id": "cf2ab891-5bd9-4788-8254-f9444423719c",
-        "description": "List of information about Managing your charity.",
-        "expanded_links": {
-          "parent": [
-            {
-              "analytics_identifier": null,
-              "api_url": "https://www.gov.uk/api/content/topic/running-charity",
-              "base_path": "/topic/running-charity",
-              "content_id": "68f2ac58-4394-442a-b309-6a7f372f345e",
-              "description": "List of information about Setting up and running a charity.",
-              "expanded_links": {},
-              "locale": "en",
-              "public_updated_at": "2015-08-11T14:45:10.000Z",
-              "title": "Setting up and running a charity",
-              "web_url": "https://www.gov.uk/topic/running-charity"
-            }
-          ]
-        },
-        "locale": "en",
-        "public_updated_at": "2016-03-21T13:12:32.000Z",
-        "title": "Managing your charity",
-        "web_url": "https://www.gov.uk/topic/running-charity/managing-charity"
-      }
-    ],
-    "related_guides": [
-      {
-        "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/guidance/charity-commission-services-log-in-or-get-a-password",
-        "base_path": "/guidance/charity-commission-services-log-in-or-get-a-password",
-        "content_id": "601aa6ca-7631-11e4-a3cb-005056011aef",
-        "description": "Start or continue your charity's annual return or registration application, plus how to get a new or replacement password.",
-        "expanded_links": {},
-        "locale": "en",
-        "public_updated_at": "2013-03-31T23:00:00.000Z",
-        "title": "Charity Commission services: log in or get a password",
-        "web_url": "https://www.gov.uk/guidance/charity-commission-services-log-in-or-get-a-password"
-      },
-      {
-        "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/guidance/prepare-a-charity-trustees-annual-report",
-        "base_path": "/guidance/prepare-a-charity-trustees-annual-report",
-        "content_id": "5feebf0e-7631-11e4-a3cb-005056011aef",
-        "description": "What to put in your trustees' annual report, depending on your charity's income and the value of its assets.",
-        "expanded_links": {},
-        "locale": "en",
-        "public_updated_at": "2013-05-09T23:00:00.000Z",
-        "title": "Prepare a charity trustees' annual report",
-        "web_url": "https://www.gov.uk/guidance/prepare-a-charity-trustees-annual-report"
-      }
-    ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/topic/running-charity/money-accounts",
-        "base_path": "/topic/running-charity/money-accounts",
-        "content_id": "6db5a402-5916-4820-89a6-a19c6c9e085e",
-        "description": "List of information about Charity money, tax and accounts.",
-        "expanded_links": {},
-        "locale": "en",
-        "public_updated_at": "2015-08-11T15:10:00.000Z",
-        "title": "Charity money, tax and accounts",
-        "web_url": "https://www.gov.uk/topic/running-charity/money-accounts"
-      },
-      {
-        "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/topic/running-charity/managing-charity",
-        "base_path": "/topic/running-charity/managing-charity",
-        "content_id": "cf2ab891-5bd9-4788-8254-f9444423719c",
-        "description": "List of information about Managing your charity.",
-        "expanded_links": {},
-        "locale": "en",
-        "public_updated_at": "2016-03-21T13:12:32.000Z",
-        "title": "Managing your charity",
-        "web_url": "https://www.gov.uk/topic/running-charity/managing-charity"
-      }
-    ]
-  },
   "first_published_at": "2016-02-29T09:24:10.000+00:00",
   "format": "detailed_guide",
   "links": {
@@ -184,25 +63,6 @@
         "content_id": "5fec94c4-7631-11e4-a3cb-005056011aef",
         "description": "Mae'n rhaid i chi anfon ffurflen flynyddol (neu ddiweddaru eich manylion) bob blwyddyn os yw'ch elusen wedi cofrestru yng Nghymru neu Loegr.",
         "document_type": "detailed_guidance",
-        "links": {
-          "lead_organisations": [
-            "489e651f-34c8-4b34-bdd7-e13c2324cde3"
-          ],
-          "organisations": [
-            "489e651f-34c8-4b34-bdd7-e13c2324cde3"
-          ],
-          "parent": [
-            "cf2ab891-5bd9-4788-8254-f9444423719c"
-          ],
-          "related_guides": [
-            "601aa6ca-7631-11e4-a3cb-005056011aef",
-            "5feebf0e-7631-11e4-a3cb-005056011aef"
-          ],
-          "topics": [
-            "6db5a402-5916-4820-89a6-a19c6c9e085e",
-            "cf2ab891-5bd9-4788-8254-f9444423719c"
-          ]
-        },
         "locale": "cy",
         "public_updated_at": "2013-05-22T23:00:00.000+00:00",
         "schema_name": "detailed_guide",
@@ -216,25 +76,6 @@
         "content_id": "5fec94c4-7631-11e4-a3cb-005056011aef",
         "description": "You must send an annual return (or update your details) every year if your charity is registered in England or Wales.",
         "document_type": "detailed_guidance",
-        "links": {
-          "lead_organisations": [
-            "489e651f-34c8-4b34-bdd7-e13c2324cde3"
-          ],
-          "organisations": [
-            "489e651f-34c8-4b34-bdd7-e13c2324cde3"
-          ],
-          "parent": [
-            "cf2ab891-5bd9-4788-8254-f9444423719c"
-          ],
-          "related_guides": [
-            "601aa6ca-7631-11e4-a3cb-005056011aef",
-            "5feebf0e-7631-11e4-a3cb-005056011aef"
-          ],
-          "topics": [
-            "6db5a402-5916-4820-89a6-a19c6c9e085e",
-            "cf2ab891-5bd9-4788-8254-f9444423719c"
-          ]
-        },
         "locale": "en",
         "public_updated_at": "2013-05-22T23:00:00.000+00:00",
         "schema_name": "detailed_guide",
@@ -289,27 +130,6 @@
         "content_id": "601aa6ca-7631-11e4-a3cb-005056011aef",
         "description": "Start or continue your charity's annual return or registration application, plus how to get a new or replacement password.",
         "document_type": "detailed_guidance",
-        "links": {
-          "lead_organisations": [
-            "489e651f-34c8-4b34-bdd7-e13c2324cde3"
-          ],
-          "organisations": [
-            "489e651f-34c8-4b34-bdd7-e13c2324cde3"
-          ],
-          "parent": [
-            "cf2ab891-5bd9-4788-8254-f9444423719c"
-          ],
-          "related_guides": [
-            "5f525ead-7631-11e4-a3cb-005056011aef",
-            "5fec94c4-7631-11e4-a3cb-005056011aef"
-          ],
-          "related_mainstream": [
-            "4688ad1e-6a55-4471-9c59-092c942b6349"
-          ],
-          "topics": [
-            "cf2ab891-5bd9-4788-8254-f9444423719c"
-          ]
-        },
         "locale": "en",
         "public_updated_at": "2013-03-31T23:00:00.000+00:00",
         "schema_name": "detailed_guide",
@@ -323,29 +143,6 @@
         "content_id": "5feebf0e-7631-11e4-a3cb-005056011aef",
         "description": "What to put in your trustees' annual report, depending on your charity's income and the value of its assets.",
         "document_type": "detailed_guidance",
-        "links": {
-          "lead_organisations": [
-            "489e651f-34c8-4b34-bdd7-e13c2324cde3"
-          ],
-          "organisations": [
-            "489e651f-34c8-4b34-bdd7-e13c2324cde3"
-          ],
-          "parent": [
-            "6db5a402-5916-4820-89a6-a19c6c9e085e"
-          ],
-          "related_guides": [
-            "5f162fca-7631-11e4-a3cb-005056011aef",
-            "5fec94c4-7631-11e4-a3cb-005056011aef"
-          ],
-          "related_mainstream": [
-            "4688ad1e-6a55-4471-9c59-092c942b6349"
-          ],
-          "topics": [
-            "9430260c-677d-4da9-b61e-bb3b524cdad9",
-            "6db5a402-5916-4820-89a6-a19c6c9e085e",
-            "cf2ab891-5bd9-4788-8254-f9444423719c"
-          ]
-        },
         "locale": "en",
         "public_updated_at": "2013-05-09T23:00:00.000+00:00",
         "schema_name": "detailed_guide",
@@ -361,11 +158,6 @@
         "content_id": "6db5a402-5916-4820-89a6-a19c6c9e085e",
         "description": "List of information about Charity money, tax and accounts.",
         "document_type": "topic",
-        "links": {
-          "parent": [
-            "68f2ac58-4394-442a-b309-6a7f372f345e"
-          ]
-        },
         "locale": "en",
         "public_updated_at": "2015-08-11T15:10:00.000+00:00",
         "schema_name": "topic",
@@ -379,11 +171,6 @@
         "content_id": "cf2ab891-5bd9-4788-8254-f9444423719c",
         "description": "List of information about Managing your charity.",
         "document_type": "topic",
-        "links": {
-          "parent": [
-            "68f2ac58-4394-442a-b309-6a7f372f345e"
-          ]
-        },
         "locale": "en",
         "public_updated_at": "2016-03-21T13:12:32.000+00:00",
         "schema_name": "topic",

--- a/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
+++ b/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
@@ -14,8 +14,7 @@
         "locale": "en",
         "public_updated_at": "2016-06-13T14:30:40.000Z",
         "title": "Competition and Markets Authority cases",
-        "web_url": "https://www.gov.uk/cma-cases",
-        "expanded_links": { }
+        "web_url": "https://www.gov.uk/cma-cases"
       }
     ],
     "organisations": [
@@ -28,8 +27,7 @@
         "locale": "en",
         "public_updated_at": "2015-03-10T16:23:14.000Z",
         "title": "Competition and Markets Authority",
-        "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority",
-        "expanded_links": { }
+        "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority"
       }
     ],
     "available_translations": [
@@ -71,22 +69,7 @@
         "public_updated_at": "2016-06-13T14:30:40.000+00:00",
         "schema_name": "finder",
         "document_type": "finder",
-        "analytics_identifier": null,
-        "links": {
-          "topics": [
-            "fd11e3b0-76bc-4197-b652-a030b57915be",
-            "7aa3ec0c-683e-44ba-aa3f-cc9655651b9b",
-            "1433d403-333f-4d81-b83a-c5358412fd1b",
-            "65a89136-2117-41aa-ba96-35feb9d821f5",
-            "4a6f14ad-baa1-4b15-8026-8282913ef693"
-          ],
-          "email_alert_signup": [
-            "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a"
-          ],
-          "organisations": [
-            "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
-          ]
-        }
+        "analytics_identifier": null
       }
     ],
     "organisations": [
@@ -124,15 +107,7 @@
         "public_updated_at": "2016-06-13T14:30:40.000+00:00",
         "schema_name": "finder_email_signup",
         "document_type": "finder_email_signup",
-        "analytics_identifier": null,
-        "links": {
-          "related": [
-            "fef4ac7c-024a-4943-9f19-e85a8369a1f3"
-          ],
-          "organisations": [
-            "957eb4ec-089b-4f71-ba2a-dc69ac8919ea"
-          ]
-        }
+        "analytics_identifier": null
       }
     ]
   },
@@ -189,5 +164,4 @@
       "plural": "Competition and Markets Authority (CMA) cases with the following case types: "
     }
   }
-
 }

--- a/formats/finder_email_signup/frontend/examples/raib-report-email-signup.json
+++ b/formats/finder_email_signup/frontend/examples/raib-report-email-signup.json
@@ -3,7 +3,7 @@
   "base_path": "/raib-reports/email-signup",
   "content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
   "document_type": "finder_email_signup",
-  "expanded_links": {
+  "links": {
     "related": [
       {
         "analytics_identifier": null,
@@ -15,7 +15,7 @@
         "public_updated_at": "2016-06-13T14:30:40.000Z",
         "title": "Rail Accident Investigation Branch reports",
         "web_url": "https://www.gov.uk/raib-reports",
-        "expanded_links": { }
+        "links": { }
       }
     ],
     "organisations": [
@@ -29,7 +29,7 @@
         "public_updated_at": "2015-04-01T09:33:41.000Z",
         "title": "Rail Accident Investigation Branch",
         "web_url": "https://www.gov.uk/government/organisations/rail-accident-investigation-branch",
-        "expanded_links": { }
+        "links": { }
       }
     ],
     "available_translations": [
@@ -58,77 +58,6 @@
   "title": "Rail Accident Investigation Branch reports",
   "updated_at": "2016-06-13T14:31:34.931Z",
   "withdrawn_notice": { },
-  "links": {
-    "related": [
-      {
-        "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
-        "title": "Rail Accident Investigation Branch reports",
-        "base_path": "/raib-reports",
-        "description": "Find reports of RAIB investigations into rail accidents and incidents",
-        "api_url": "https://www.gov.uk/api/content/raib-reports",
-        "web_url": "https://www.gov.uk/raib-reports",
-        "locale": "en",
-        "public_updated_at": "2016-06-13T14:30:40.000+00:00",
-        "schema_name": "finder",
-        "document_type": "finder",
-        "analytics_identifier": null,
-        "links": {
-          "email_alert_signup": [
-            "db81c7e8-b1b6-4c29-992a-1289f1b63073"
-          ],
-          "organisations": [
-            "013872d8-8bbb-4e80-9b79-45c7c5cf9177"
-          ]
-        }
-      }
-    ],
-    "organisations": [
-      {
-        "content_id": "013872d8-8bbb-4e80-9b79-45c7c5cf9177",
-        "title": "Rail Accident Investigation Branch",
-        "base_path": "/government/organisations/rail-accident-investigation-branch",
-        "description": null,
-        "api_url": "https://www.gov.uk/api/content/government/organisations/rail-accident-investigation-branch",
-        "web_url": "https://www.gov.uk/government/organisations/rail-accident-investigation-branch",
-        "locale": "en",
-        "public_updated_at": "2015-04-01T09:33:41.000+00:00",
-        "schema_name": "placeholder",
-        "document_type": "organisation",
-        "analytics_identifier": "OT249",
-        "links": { },
-        "details": {
-          "brand": "department-for-transport",
-          "logo": {
-            "formatted_title": "Rail Accident<br/>Investigation Branch",
-            "crest": null
-          }
-        }
-      }
-    ],
-    "available_translations": [
-      {
-        "content_id": "db81c7e8-b1b6-4c29-992a-1289f1b63073",
-        "title": "Rail Accident Investigation Branch reports",
-        "base_path": "/raib-reports/email-signup",
-        "description": "You'll get an email each time a report is updated or a new report is published.",
-        "api_url": "https://www.gov.uk/api/content/raib-reports/email-signup",
-        "web_url": "https://www.gov.uk/raib-reports/email-signup",
-        "locale": "en",
-        "public_updated_at": "2016-06-13T14:30:40.000+00:00",
-        "schema_name": "finder_email_signup",
-        "document_type": "finder_email_signup",
-        "analytics_identifier": null,
-        "links": {
-          "related": [
-            "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd"
-          ],
-          "organisations": [
-            "013872d8-8bbb-4e80-9b79-45c7c5cf9177"
-          ]
-        }
-      }
-    ]
-  },
   "description": "You'll get an email each time a report is updated or a new report is published.",
   "details": {
     "beta": false,

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -59,8 +59,11 @@
       },
       "links": {
         "type": "object",
-        "additionalProperties": true,
-        "description": "TODO: investigate if could this be validated recursively."
+        "patternProperties": {
+          "^[a-z_]+$": {
+            "$ref": "#/definitions/frontend_links"
+          }
+        }
       }
     }
   }

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide.json
@@ -40,7 +40,8 @@
         "api_url": "http://content-store.dev.gov.uk/content/service-manual/communities/agile-delivery-community",
         "web_url": "http://www.dev.gov.uk/service-manual/communities/agile-delivery-community",
         "locale": "en",
-        "analytics_identifier": null
+        "analytics_identifier": null,
+        "links": {}
       }
     ],
     "service_manual_topics": [
@@ -55,17 +56,7 @@
         "schema_name": "service_manual_topic",
         "document_type": "service_manual_topic",
         "analytics_identifier": null,
-        "links": {
-          "linked_items": [
-            "fb81a47b-7c8f-4280-b6c7-b6fa25822222"
-          ],
-          "content_owners": [
-            "e50286e4-2d79-44aa-bcf4-f024e5e17061"
-          ],
-          "organisations": [
-            "af07d5a5-df63-4ddc-9383-6a666845ebe9"
-          ]
-        }
+        "links": {}
       }
     ]
   },

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
@@ -42,17 +42,7 @@
         "schema_name": "service_manual_topic",
         "document_type": "service_manual_topic",
         "analytics_identifier": null,
-        "links": {
-          "linked_items": [
-            "fb81a47b-7c8f-4280-b6c7-b6fa25822222"
-          ],
-          "content_owners": [
-            "e50286e4-2d79-44aa-bcf4-f024e5e17061"
-          ],
-          "organisations": [
-            "af07d5a5-df63-4ddc-9383-6a666845ebe9"
-          ]
-        }
+        "links": {}
       }
     ]
   },

--- a/formats/service_manual_homepage/frontend/examples/service_manual_homepage.json
+++ b/formats/service_manual_homepage/frontend/examples/service_manual_homepage.json
@@ -18,17 +18,7 @@
         "schema_name": "service_manual_topic",
         "document_type": "service_manual_topic",
         "analytics_identifier": null,
-        "links": {
-          "linked_items": [
-            "fb81a47b-7c8f-4280-b6c7-b6fa25822222"
-          ],
-          "content_owners": [
-            "e50286e4-2d79-44aa-bcf4-f024e5e17061"
-          ],
-          "organisations": [
-            "af07d5a5-df63-4ddc-9383-6a666845ebe9"
-          ]
-        }
+        "links": {}
       }
     ]
   },

--- a/formats/travel_advice/frontend/examples/alt-country.json
+++ b/formats/travel_advice/frontend/examples/alt-country.json
@@ -19,11 +19,7 @@
         "api_url": "https://www.gov.uk/api/content/renew-adult-passport",
         "web_url": "https://www.gov.uk/renew-adult-passport",
         "locale": "en",
-        "links": {
-          "parent": [
-            "86eb717a-fb40-42e7-83fa-d031a03880fb"
-          ]
-        }
+        "links": {}
       },
       {
         "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
@@ -43,11 +39,7 @@
         "api_url": "https://www.gov.uk/api/content/driving-abroad",
         "web_url": "https://www.gov.uk/driving-abroad",
         "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
+        "links": {}
       },
       {
         "content_id": "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
@@ -57,11 +49,7 @@
         "api_url": "https://www.gov.uk/api/content/hand-luggage-restrictions",
         "web_url": "https://www.gov.uk/hand-luggage-restrictions",
         "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
+        "links": {}
       },
       {
         "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
@@ -84,34 +72,6 @@
         "web_url": "https://www.gov.uk/browse/abroad",
         "locale": "en",
         "links": {}
-      },
-      {
-        "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
-        "title": "Travel abroad",
-        "base_path": "/browse/abroad/travel-abroad",
-        "description": null,
-        "api_url": "https://www.gov.uk/api/content/browse/abroad/travel-abroad",
-        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
-        "locale": "en",
-        "links": {
-          "parent": [
-            "86eb717a-fb40-42e7-83fa-d031a03880fb"
-          ]
-        }
-      },
-      {
-        "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
-        "title": "Foreign travel advice",
-        "base_path": "/foreign-travel-advice",
-        "description": null,
-        "api_url": "https://www.gov.uk/api/content/foreign-travel-advice",
-        "web_url": "https://www.gov.uk/foreign-travel-advice",
-        "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
       }
     ],
     "available_translations": [

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -106,11 +106,7 @@
         "api_url": "https://www.gov.uk/api/content/renew-adult-passport",
         "web_url": "https://www.gov.uk/renew-adult-passport",
         "locale": "en",
-        "links": {
-          "parent": [
-            "86eb717a-fb40-42e7-83fa-d031a03880fb"
-          ]
-        }
+        "links": {}
       },
       {
         "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
@@ -130,11 +126,7 @@
         "api_url": "https://www.gov.uk/api/content/driving-abroad",
         "web_url": "https://www.gov.uk/driving-abroad",
         "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
+        "links": {}
       },
       {
         "content_id": "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
@@ -144,11 +136,7 @@
         "api_url": "https://www.gov.uk/api/content/hand-luggage-restrictions",
         "web_url": "https://www.gov.uk/hand-luggage-restrictions",
         "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
+        "links": {}
       },
       {
         "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
@@ -171,34 +159,6 @@
         "web_url": "https://www.gov.uk/browse/abroad",
         "locale": "en",
         "links": {}
-      },
-      {
-        "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
-        "title": "Travel abroad",
-        "base_path": "/browse/abroad/travel-abroad",
-        "description": null,
-        "api_url": "https://www.gov.uk/api/content/browse/abroad/travel-abroad",
-        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
-        "locale": "en",
-        "links": {
-          "parent": [
-            "86eb717a-fb40-42e7-83fa-d031a03880fb"
-          ]
-        }
-      },
-      {
-        "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
-        "title": "Foreign travel advice",
-        "base_path": "/foreign-travel-advice",
-        "description": null,
-        "api_url": "https://www.gov.uk/api/content/foreign-travel-advice",
-        "web_url": "https://www.gov.uk/foreign-travel-advice",
-        "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
       }
     ],
     "available_translations": [

--- a/formats/travel_advice/frontend/examples/no-parts.json
+++ b/formats/travel_advice/frontend/examples/no-parts.json
@@ -56,11 +56,7 @@
         "api_url": "https://www.gov.uk/api/content/renew-adult-passport",
         "web_url": "https://www.gov.uk/renew-adult-passport",
         "locale": "en",
-        "links": {
-          "parent": [
-            "86eb717a-fb40-42e7-83fa-d031a03880fb"
-          ]
-        }
+        "links": {}
       },
       {
         "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
@@ -80,11 +76,7 @@
         "api_url": "https://www.gov.uk/api/content/driving-abroad",
         "web_url": "https://www.gov.uk/driving-abroad",
         "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
+        "links": { }
       },
       {
         "content_id": "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
@@ -94,11 +86,7 @@
         "api_url": "https://www.gov.uk/api/content/hand-luggage-restrictions",
         "web_url": "https://www.gov.uk/hand-luggage-restrictions",
         "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
+        "links": { }
       },
       {
         "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
@@ -121,34 +109,6 @@
         "web_url": "https://www.gov.uk/browse/abroad",
         "locale": "en",
         "links": {}
-      },
-      {
-        "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
-        "title": "Travel abroad",
-        "base_path": "/browse/abroad/travel-abroad",
-        "description": null,
-        "api_url": "https://www.gov.uk/api/content/browse/abroad/travel-abroad",
-        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad",
-        "locale": "en",
-        "links": {
-          "parent": [
-            "86eb717a-fb40-42e7-83fa-d031a03880fb"
-          ]
-        }
-      },
-      {
-        "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
-        "title": "Foreign travel advice",
-        "base_path": "/foreign-travel-advice",
-        "description": null,
-        "api_url": "https://www.gov.uk/api/content/foreign-travel-advice",
-        "web_url": "https://www.gov.uk/foreign-travel-advice",
-        "locale": "en",
-        "links": {
-          "parent": [
-            "b9849cd6-61a7-42dc-8124-362d2c7d48b0"
-          ]
-        }
       }
     ]
   },


### PR DESCRIPTION
This adds recursive validation of frontend links per @boffbowsh's suggestion in https://github.com/alphagov/govuk-content-schemas/pull/389#r79144815.

This means that the links-inside-links that have been expanded by the publishing-api also need to conform to the frontend links schema. The only thing that is not validated after this change is that the link type actually is allowed for the format. That's something for another day.

After implementing the validation is becomes clear that there are many completely wrong examples. This is quite scary because the examples are often used in unit tests. An example of a bug caused by incorrect examples is alphagov/government-frontend#180.
