### PR TITLE
Add external related links to placeholders

### DIFF
--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -256,6 +256,24 @@
             }
           }
         },
+        "external_related_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "tags": {
           "type": "object",
           "properties": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -187,6 +187,24 @@
             }
           }
         },
+        "external_related_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "tags": {
           "type": "object",
           "properties": {

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -183,6 +183,24 @@
             }
           }
         },
+        "external_related_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "tags": {
           "type": "object",
           "properties": {

--- a/dist/message_queue.json
+++ b/dist/message_queue.json
@@ -1765,6 +1765,24 @@
                 }
               }
             },
+            "external_related_links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "title",
+                  "url"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
             "tags": {
               "type": "object",
               "properties": {

--- a/formats/placeholder/frontend/examples/battle-of-the-somme-centenary-commemorations.json
+++ b/formats/placeholder/frontend/examples/battle-of-the-somme-centenary-commemorations.json
@@ -10,6 +10,16 @@
   ],
   "public_updated_at": "2015-07-04T11:32:28.000+01:00",
   "details": {
+    "external_related_links": [
+      {
+        "title": "Somme EN",
+        "url": "http://somme2016.org/en/"
+      },
+      {
+        "title": "Somme FR",
+        "url": "http://somme2016.org/fr/"
+      }
+    ]
   },
   "schema_name": "placeholder_topical_event",
   "document_type": "placeholder_topical_event",

--- a/formats/placeholder/frontend/examples/organisation.json
+++ b/formats/placeholder/frontend/examples/organisation.json
@@ -31,6 +31,12 @@
     "logo": {
       "formatted_title": "Bona Vacantia",
       "crest": "single-identity"
-    }
+    },
+    "external_related_links": [
+      {
+        "title": "Definition",
+        "url": "http://www.dictionary.com/browse/bona-vacantia"
+      }
+    ]
   }
 }

--- a/formats/placeholder/publisher/details.json
+++ b/formats/placeholder/publisher/details.json
@@ -54,6 +54,21 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["title", "url"],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "tags": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
The final objective is storing and retrieving them from the content-store.

Ticket: https://trello.com/c/rDKC4sLm/133-send-related-external-links-to-pub-api-from-publisher

Part of: https://trello.com/c/mOeDK914/107-epic-related-links-and-panopticon