### PR TITLE
Add validation for rendering_app & publishing_app

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -352,6 +352,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -351,6 +351,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -319,6 +319,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -114,6 +114,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -264,6 +264,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -272,6 +272,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -283,6 +283,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -239,6 +239,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -196,6 +196,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -464,6 +464,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -472,6 +472,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -431,6 +431,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -105,6 +105,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -368,6 +368,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -351,6 +351,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -350,6 +350,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -318,6 +318,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -114,6 +114,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -263,6 +263,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -355,6 +355,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -356,6 +356,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -323,6 +323,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -113,6 +113,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -269,6 +269,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -334,6 +334,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -345,6 +345,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -301,6 +301,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -258,6 +258,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -293,6 +293,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -295,6 +295,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -262,6 +262,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -113,6 +113,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -208,6 +208,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -282,6 +282,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_release/notification/schema.json
+++ b/dist/formats/financial_release/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -293,6 +293,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -249,6 +249,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_release/publisher_v2/schema.json
+++ b/dist/formats/financial_release/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -206,6 +206,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -286,6 +286,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_campaign/notification/schema.json
+++ b/dist/formats/financial_releases_campaign/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -297,6 +297,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -253,6 +253,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_campaign/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -210,6 +210,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -270,6 +270,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_geoblocker/notification/schema.json
+++ b/dist/formats/financial_releases_geoblocker/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -281,6 +281,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -237,6 +237,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -194,6 +194,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -273,6 +273,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_index/notification/schema.json
+++ b/dist/formats/financial_releases_index/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -278,6 +278,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -240,6 +240,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -108,6 +108,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_index/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_index/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -191,6 +191,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -275,6 +275,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_success/notification/schema.json
+++ b/dist/formats/financial_releases_success/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -286,6 +286,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -242,6 +242,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/financial_releases_success/publisher_v2/schema.json
+++ b/dist/formats/financial_releases_success/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -199,6 +199,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -409,6 +409,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -414,6 +414,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -379,6 +379,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -111,6 +111,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -327,6 +327,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -330,6 +330,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -334,6 +334,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -297,6 +297,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -109,6 +109,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -247,6 +247,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -377,6 +377,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -388,6 +388,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -344,6 +344,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -301,6 +301,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -367,6 +367,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -378,6 +378,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -334,6 +334,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -291,6 +291,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -284,6 +284,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -291,6 +291,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -251,6 +251,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -106,6 +106,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -204,6 +204,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -309,6 +309,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -308,6 +308,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -280,6 +280,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -118,6 +118,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -221,6 +221,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -360,6 +360,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -368,6 +368,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -330,6 +330,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -108,6 +108,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -281,6 +281,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -313,6 +313,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -321,6 +321,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -283,6 +283,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -108,6 +108,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -234,6 +234,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -362,6 +362,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -373,6 +373,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -329,6 +329,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -286,6 +286,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -402,6 +402,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -394,6 +394,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -373,6 +373,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -125,6 +125,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -307,6 +307,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -342,6 +342,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -338,6 +338,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -309,6 +309,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -117,6 +117,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -251,6 +251,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -314,6 +314,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -319,6 +319,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -283,6 +283,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -110,6 +110,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -232,6 +232,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -263,6 +263,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -271,6 +271,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/publisher/schema.json
+++ b/dist/formats/service_manual_homepage/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -231,6 +231,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -106,6 +106,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -184,6 +184,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -268,6 +268,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -276,6 +276,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -239,6 +239,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -109,6 +109,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -189,6 +189,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -307,6 +307,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -309,6 +309,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -277,6 +277,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -114,6 +114,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -222,6 +222,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -310,6 +310,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -321,6 +321,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -277,6 +277,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -216,6 +216,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -301,6 +301,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -308,6 +308,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -268,6 +268,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -106,6 +106,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -221,6 +221,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -271,6 +271,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -282,6 +282,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -238,6 +238,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -195,6 +195,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -272,6 +272,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -280,6 +280,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -240,6 +240,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -106,6 +106,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -193,6 +193,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -309,6 +309,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -314,6 +314,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -278,6 +278,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -110,6 +110,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -227,6 +227,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -274,6 +274,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -282,6 +282,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -241,6 +241,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -105,6 +105,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -195,6 +195,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -351,6 +351,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -359,6 +359,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -318,6 +318,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -105,6 +105,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -272,6 +272,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -320,6 +320,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -328,6 +328,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -287,6 +287,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -105,6 +105,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -241,6 +241,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -285,6 +285,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -296,6 +296,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -252,6 +252,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -209,6 +209,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -38,10 +38,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -267,6 +267,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -43,10 +43,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -278,6 +278,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -40,10 +40,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -234,6 +234,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -102,6 +102,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -39,10 +39,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -191,6 +191,11 @@
       "items": {
         "$ref": "#/definitions/guid"
       }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
     },
     "image": {
       "type": "object",

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -52,6 +52,11 @@
         "$ref": "#/definitions/guid"
       }
     },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -36,10 +36,10 @@
       "format": "date-time"
     },
     "publishing_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "rendering_app": {
-      "type": "string"
+      "$ref": "#/definitions/application_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"


### PR DESCRIPTION
Makes sure that rendering_app and publishing_app are well formed.

In publishing-api they're validated by a more lax ["hostname" validator](https://github.com/alphagov/publishing-api/blob/master/app/validators/dns_hostname_validator.rb). The regex used here is more strict, but I think it would be good to enforce the current pattern of only using a-z and dashes. All current applications conform to that schema.
