### PR TITLE
Validate metadata of specialist documents correctly

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -567,7 +567,7 @@
     },
     "any_metadata": {
       "type": "object",
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#/definitions/aaib_report_metadata"
         },

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -581,7 +581,7 @@
     },
     "any_metadata": {
       "type": "object",
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#/definitions/aaib_report_metadata"
         },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -533,7 +533,7 @@
     },
     "any_metadata": {
       "type": "object",
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#/definitions/aaib_report_metadata"
         },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -476,7 +476,7 @@
     },
     "any_metadata": {
       "type": "object",
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#/definitions/aaib_report_metadata"
         },

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -38,7 +38,7 @@
   "definitions": {
     "any_metadata": {
       "type": "object",
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#/definitions/aaib_report_metadata"
         },


### PR DESCRIPTION
This commit changes the validation of the specialist document "metadata" hash.

The fix is quite interesting, because I think we've been misunderstanding a part of the JSON Schema spec -- or at least I was.

Currently, the schema mandates that `details.metadata` in a specialist document conform to one of ~15 subschemas, each conforming to one of the specialist document types.

By using the `oneOf` keyword, we require that *exactly one* of the subschemas validates. In practice, it's perfectly possible for the metadata of an AAIB Report to be also valid for the metadata of a RAIB report.

The`anyOf` keyword actually does what we want: it will make sure that the metadata is valid against at least one schema.

The TIL is: you almost never want `oneOf`, unless you're doing something to enforce mutually exclusive attributes.

More on the JSON Schema spec: http://json-schema.org/latest/json-schema-validation.html#anchor88

This was discovered while trying to generate random content in the `govuk_schemas` gem (https://github.com/alphagov/govuk_schemas_gem).
