### PR TITLE
Make DetailedGuide consistent

### DIFF
--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -94,6 +94,9 @@
         "related_mainstream": {
           "$ref": "#/definitions/frontend_links"
         },
+        "related_mainstream_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -227,6 +227,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_mainstream": {
+          "$ref": "#/definitions/guid_list",
+          "_comment": "DEPRECATED USE related_mainstream_content"
+        },
+        "related_mainstream_content": {
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -20,6 +20,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_mainstream": {
+          "$ref": "#/definitions/guid_list",
+          "_comment": "DEPRECATED USE related_mainstream_content"
+        },
+        "related_mainstream_content": {
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
@@ -80,6 +80,24 @@
         "locale": "en"
       }
     ],
+    "related_mainstream_content": [
+      {
+        "content_id": "dd113259-fcaf-4e9b-83d5-d1148f33cf34",
+        "title": "Overseas British passport applications",
+        "base_path": "/overseas-passports",
+        "api_url": "https://www.gov.uk/api/content/overseas-passports",
+        "web_url": "https://www.gov.uk/overseas-passports",
+        "locale": "en"
+      },
+      {
+        "content_id": "f02fc2c9-f5ff-4ea2-acc4-730bbda957bb",
+        "title": "Cancel a lost or stolen passport",
+        "base_path": "/report-a-lost-or-stolen-passport",
+        "api_url": "https://www.gov.uk/api/content/report-a-lost-or-stolen-passport",
+        "web_url": "https://www.gov.uk/report-a-lost-or-stolen-passport",
+        "locale": "en"
+      }
+    ],
     "related_mainstream": [
       {
         "content_id": "dd113259-fcaf-4e9b-83d5-d1148f33cf34",

--- a/formats/detailed_guide/publisher/links.json
+++ b/formats/detailed_guide/publisher/links.json
@@ -13,6 +13,10 @@
       "$ref": "#/definitions/guid_list"
     },
     "related_mainstream": {
+      "$ref": "#/definitions/guid_list",
+      "_comment": "DEPRECATED USE related_mainstream_content"
+    },
+    "related_mainstream_content": {
       "$ref": "#/definitions/guid_list"
     }
   }


### PR DESCRIPTION
Previously the `links` entry for related mainstream was called `related_mainstream` while the `details` entry was called `related_mainstream_content`. 

This PR names them consistently `related_mainstream_content`.

