### PR TITLE
Remove deprecated detailed guide links

### DIFF
--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -91,9 +91,6 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
-        "related_mainstream": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "related_mainstream_content": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -226,10 +226,6 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
-        "related_mainstream": {
-          "$ref": "#/definitions/guid_list",
-          "_comment": "DEPRECATED USE related_mainstream_content"
-        },
         "related_mainstream_content": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -19,10 +19,6 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
-        "related_mainstream": {
-          "$ref": "#/definitions/guid_list",
-          "_comment": "DEPRECATED USE related_mainstream_content"
-        },
         "related_mainstream_content": {
           "$ref": "#/definitions/guid_list"
         },

--- a/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/related_mainstream_detailed_guide.json
@@ -97,24 +97,6 @@
         "web_url": "https://www.gov.uk/report-a-lost-or-stolen-passport",
         "locale": "en"
       }
-    ],
-    "related_mainstream": [
-      {
-        "content_id": "dd113259-fcaf-4e9b-83d5-d1148f33cf34",
-        "title": "Overseas British passport applications",
-        "base_path": "/overseas-passports",
-        "api_url": "https://www.gov.uk/api/content/overseas-passports",
-        "web_url": "https://www.gov.uk/overseas-passports",
-        "locale": "en"
-      },
-      {
-        "content_id": "f02fc2c9-f5ff-4ea2-acc4-730bbda957bb",
-        "title": "Cancel a lost or stolen passport",
-        "base_path": "/report-a-lost-or-stolen-passport",
-        "api_url": "https://www.gov.uk/api/content/report-a-lost-or-stolen-passport",
-        "web_url": "https://www.gov.uk/report-a-lost-or-stolen-passport",
-        "locale": "en"
-      }
     ]
   }
 }

--- a/formats/detailed_guide/publisher/links.json
+++ b/formats/detailed_guide/publisher/links.json
@@ -12,10 +12,6 @@
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },
-    "related_mainstream": {
-      "$ref": "#/definitions/guid_list",
-      "_comment": "DEPRECATED USE related_mainstream_content"
-    },
     "related_mainstream_content": {
       "$ref": "#/definitions/guid_list"
     }


### PR DESCRIPTION
`related_mainstream` has now been removed from the apps that depended upon it.

https://github.com/alphagov/government-frontend/pull/185
https://github.com/alphagov/whitehall/pull/2769

It was previously deprecated and can now be removed in favour of `related_mainstream_content`.