### PR TITLE
Allow redirects to gov.uk campaign URLs

### DIFF
--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -92,6 +92,11 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
       "description": "A path with optional query string and/or fragment."
     },
+    "govuk_campaign_url": {
+      "type": "string",
+      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)+campaign\\.gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$",
+      "description": "A gov.uk campaign URL with optional query string and/or fragment."
+    },
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
@@ -118,7 +123,11 @@
           "enum": [ "prefix", "exact" ]
         },
         "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
+          "type": "string",
+          "oneOf": [
+            { "$ref": "#/definitions/absolute_fullpath" },
+            { "$ref": "#/definitions/govuk_campaign_url" }
+          ]
         },
         "segments_mode": {
           "enum": [ "preserve", "ignore" ],

--- a/formats/redirect/publisher_v2/examples/govuk-campaign-redirect.json
+++ b/formats/redirect/publisher_v2/examples/govuk-campaign-redirect.json
@@ -1,0 +1,14 @@
+{
+  "base_path": "/campaign-slug",
+  "publishing_app": "short-url-manager",
+  "public_updated_at": "2016-09-30T12:00:00Z",
+  "redirects": [
+    {
+      "path": "/campaign-slug",
+      "type": "exact",
+      "destination": "https://my-campaign-title.campaign.gov.uk"
+    }
+  ],
+  "document_type": "redirect",
+  "schema_name": "redirect"
+}

--- a/formats/redirect/publisher_v2/schema.json
+++ b/formats/redirect/publisher_v2/schema.json
@@ -92,6 +92,11 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
       "description": "A path with optional query string and/or fragment."
     },
+    "govuk_campaign_url": {
+      "type": "string",
+      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)+campaign\\.gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$",
+      "description": "A gov.uk campaign URL with optional query string and/or fragment."
+    },
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
@@ -118,7 +123,11 @@
           "enum": [ "prefix", "exact" ]
         },
         "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
+          "type": "string",
+          "oneOf": [
+            { "$ref": "#/definitions/absolute_fullpath" },
+            { "$ref": "#/definitions/govuk_campaign_url" }
+          ]
         },
         "segments_mode": {
           "enum": [ "preserve", "ignore" ],


### PR DESCRIPTION
This PR relates to:
* alphagov/short-url-manager#62
* alphagov/publishing-api#531

This PR needs merging first:
* alphagov/govuk_schemas_gem#16

The content designers need to be able to configure short URLs for gov.uk campaigns. For example, it needs to be possible to set up a redirect from `https://www.gov.uk/campaign-slug` to `https://my-campaign-title.campaign.gov.uk`.

This PR updates the `redirect` schema to allow gov.uk campaign URLs to be the destination of redirects. The `govuk_campaign_url` regex should match any HTTPS URL where the host is a subdomain of `campaign.gov.uk`.

## Regex explanation

Demo: http://regexr.com/3eblr

```
https://               # gov.uk campaigns must be served over https
(
  [a-zA-Z0-9]          # Each subdomain must start with an alphanumeric character...
  (
    [a-zA-Z0-9-]{0,61} # ...can be up to 63 characters long, and can contain dashes...
    [A-Za-z0-9]        # ...and must end with an alphanumeric character
  )?
  \.
)+                     # Match at least 1 subdomain
campaign\.gov\.uk
```

The remainder of the regex has the same structure as `absolute_fullpath`.