### PR TITLE
Rename Democratic Republic of Congo

### DIFF
--- a/formats/finder/frontend/examples/international-development-funding.json
+++ b/formats/finder/frontend/examples/international-development-funding.json
@@ -45,7 +45,7 @@
             "value": "burma"
           },
           {
-            "label": "Democratic Republic of Congo",
+            "label": "Democratic Republic of the Congo",
             "value": "democratic-republic-of-congo"
           },
           {


### PR DESCRIPTION
The country is now known as Democratic Republic of the Congo. We cannot change the slug at this point as Finding Things will need to [republish everything for it](https://github.com/alphagov/rummager/pull/700#discussion_r80919413).