### PR TITLE
Amend MOJ asylum content finder

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -707,15 +707,21 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string",
-          "enum": [
-            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
-            "section-4-2-support-for-failed-asylum-seekers",
-            "section-95-support-for-asylum-seekers"
-          ]
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+              "section-4-2-support-for-failed-asylum-seekers",
+              "section-95-support-for-asylum-seekers"
+            ]
+          }
         },
         "tribunal_decision_sub_category": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_landmark": {
           "type": "string",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -721,15 +721,21 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string",
-          "enum": [
-            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
-            "section-4-2-support-for-failed-asylum-seekers",
-            "section-95-support-for-asylum-seekers"
-          ]
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+              "section-4-2-support-for-failed-asylum-seekers",
+              "section-95-support-for-asylum-seekers"
+            ]
+          }
         },
         "tribunal_decision_sub_category": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_landmark": {
           "type": "string",

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -673,15 +673,21 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string",
-          "enum": [
-            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
-            "section-4-2-support-for-failed-asylum-seekers",
-            "section-95-support-for-asylum-seekers"
-          ]
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+              "section-4-2-support-for-failed-asylum-seekers",
+              "section-95-support-for-asylum-seekers"
+            ]
+          }
         },
         "tribunal_decision_sub_category": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_landmark": {
           "type": "string",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -616,15 +616,21 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string",
-          "enum": [
-            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
-            "section-4-2-support-for-failed-asylum-seekers",
-            "section-95-support-for-asylum-seekers"
-          ]
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+              "section-4-2-support-for-failed-asylum-seekers",
+              "section-95-support-for-asylum-seekers"
+            ]
+          }
         },
         "tribunal_decision_sub_category": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_landmark": {
           "type": "string",

--- a/formats/specialist_document/frontend/examples/asylum-support-decision.json
+++ b/formats/specialist_document/frontend/examples/asylum-support-decision.json
@@ -14,8 +14,8 @@
         "sally-verity-smith"
       ],
       "bulk_published": false,
-      "tribunal_decision_category": "section-4-2-support-for-failed-asylum-seekers",
-      "tribunal_decision_sub_category": "section-4-2-jurisdiction",
+      "tribunal_decision_category": ["section-4-2-support-for-failed-asylum-seekers"],
+      "tribunal_decision_sub_category": ["section-4-2-jurisdiction"],
       "tribunal_decision_landmark": "landmark",
       "tribunal_decision_reference_number": "AST / 06 / 04 / 13140",
       "tribunal_decision_decision_date": "2006-04-27",

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -178,15 +178,21 @@
           }
         },
         "tribunal_decision_category": {
-          "type": "string",
-          "enum": [
-            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
-            "section-4-2-support-for-failed-asylum-seekers",
-            "section-95-support-for-asylum-seekers"
-           ]
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+              "section-4-2-support-for-failed-asylum-seekers",
+              "section-95-support-for-asylum-seekers"
+            ]
+          }
         },
         "tribunal_decision_sub_category": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "tribunal_decision_landmark": {
           "type": "string",


### PR DESCRIPTION
The asylum content schema has been amended to allow the category and
sub-category fields to support multiple options.

Associated commits in specialist-publisher-rebuild and rummager