### PR TITLE
Add api_path to frontend_links

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -188,6 +188,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -188,6 +188,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -186,6 +186,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -185,6 +185,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_release/notification/schema.json
+++ b/dist/formats/financial_release/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_releases_campaign/notification/schema.json
+++ b/dist/formats/financial_releases_campaign/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_releases_geoblocker/notification/schema.json
+++ b/dist/formats/financial_releases_geoblocker/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -182,6 +182,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_releases_index/notification/schema.json
+++ b/dist/formats/financial_releases_index/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/financial_releases_success/notification/schema.json
+++ b/dist/formats/financial_releases_success/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -182,6 +182,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -183,6 +183,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -180,6 +180,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -188,6 +188,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -175,6 +175,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -186,6 +186,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -195,6 +195,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -191,6 +191,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -182,6 +182,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -185,6 +185,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -194,6 +194,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -205,6 +205,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -180,6 +180,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -182,6 +182,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -179,6 +179,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -176,6 +176,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -187,6 +187,9 @@
           "base_path": {
             "$ref": "#/definitions/absolute_path"
           },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
           "api_url": {
             "type": "string",
             "format": "uri"

--- a/formats/frontend_links_definition.json
+++ b/formats/frontend_links_definition.json
@@ -43,6 +43,9 @@
       "base_path": {
         "$ref" : "#/definitions/absolute_path"
       },
+      "api_path": {
+        "$ref" : "#/definitions/absolute_path"
+      },
       "api_url": {
         "type": "string",
         "format": "uri"


### PR DESCRIPTION
This allows us to send an api_path as part of content item link payload.

This will allow us to work towards deprecating the environment specific web_url
and api_url.