### PR TITLE
Fixes for coding standards

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 $LOAD_PATH << File.expand_path("../lib", __FILE__)
 
 begin
-  require 'rspec/core/rake_task'
+  require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:spec)
 rescue LoadError
 end
@@ -20,7 +20,7 @@ task :new_format, [:format_name] do |_task, args|
 
   template_files.each do |file|
     destination = "#{format_path}/publisher/#{file}"
-    if File.exists?(destination)
+    if File.exist?(destination)
       puts "\tSkipping #{destination} because it already exists"
     else
       FileUtils.cp("templates/#{file}", destination)
@@ -28,6 +28,6 @@ task :new_format, [:format_name] do |_task, args|
   end
 end
 
-task :default => [:build]
+task default: [:build]
 
-Dir.glob('lib/tasks/*.rake').each { |r| import r }
+Dir.glob("lib/tasks/*.rake").each { |r| import r }

--- a/bin/convert_finder_schemas
+++ b/bin/convert_finder_schemas
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH << File.dirname(__FILE__) + "/../lib"
-require 'govuk_content_schemas/finder_schema_converter'
-require 'json'
+require "govuk_content_schemas/finder_schema_converter"
+require "json"
 
 def usage
   $stderr.puts "USAGE: #{File.basename(__FILE__)} <finder_schema_1.json ... finder_schema_n.json>"
@@ -26,11 +26,11 @@ class DocumentTypeMapper
 
   def call(filepath)
     file_name = File.basename(filepath)
-    MAPPING.fetch(file_name) do |file_name|
-      document_type = file_name.chomp('s.json').gsub('-','_')
-      STDERR.puts "Implicitly mapping #{file_name} to '#{document_type}' document type."
-      STDERR.puts "To override #{file_name} mapping, edit DocumentTypeMapper::MAPPING."
-      MAPPING[file_name] = document_type
+    MAPPING.fetch(file_name) do |name|
+      document_type = name.chomp("s.json").tr("-", "_")
+      STDERR.puts "Implicitly mapping #{name} to '#{document_type}' document type."
+      STDERR.puts "To override #{name} mapping, edit DocumentTypeMapper::MAPPING."
+      MAPPING[name] = document_type
       document_type
     end
   end
@@ -43,41 +43,29 @@ end
 # code it here
 class SelectFieldMultiplicityIdentifier
   MULTI_SELECTS_BY_DOCUMENT_TYPE = {
-    "aaib_report" => [
-      "aircraft_category"
-    ],
-    "cma_case" => [
-      "market_sector"
-    ],
-    "countryside_stewardship_grant" => [
-      "land_use",
-      "tiers_or_standalone_items",
-      "funding_amount"
-    ],
-    "drug_safety_update" => [
-      "therapeutic_area"
-    ],
-    "european_structural_investment_fund" => [
-      "fund_type",
-      "location",
-      "funding_source"
-    ],
-    "international_development_fund" => [
+    "aaib_report" => %w[aircraft_category].freeze,
+    "cma_case" => %w[market_sector].freeze,
+    "countryside_stewardship_grant" => %w[
+      land_use
+      tiers_or_standalone_items
+      funding_amount
+    ].freeze,
+    "drug_safety_update" => %w[therapeutic_area].freeze,
+    "european_structural_investment_fund" => %w[
+      fund_type
+      location
+      funding_source
+    ].freeze,
+    "international_development_fund" => %w[
       "location",
       "development_sector",
       "eligible_entities",
       "value_of_funding"
-    ],
-    "maib_report" => [
-      "vessel_type"
-    ],
-    "medical_safety_alert" => [
-      "medical_specialism"
-    ],
-    "raib_report" => [
-      "railway_type"
-    ]
-  }
+    ].freeze,
+    "maib_report" => %w[vessel_type].freeze,
+    "medical_safety_alert" => %w[medical_specialism].freeze,
+    "raib_report" => %w[railway_type].freeze,
+  }.freeze
 
   def call(document_type, facet_name)
     MULTI_SELECTS_BY_DOCUMENT_TYPE.fetch(document_type, []).include?(facet_name)

--- a/lib/govuk_content_schemas/finder_schema_converter.rb
+++ b/lib/govuk_content_schemas/finder_schema_converter.rb
@@ -1,4 +1,4 @@
-require 'govuk_content_schemas'
+require "govuk_content_schemas"
 
 class GovukContentSchemas::FinderSchemaConverter
   attr_reader :document_type_mapper, :select_field_multiplicity_identifier
@@ -9,11 +9,11 @@ class GovukContentSchemas::FinderSchemaConverter
   end
 
   def default_document_type_mapper
-    ->(filename) { File.basename(filename, '.json') }
+    ->(filename) { File.basename(filename, ".json") }
   end
 
   def default_select_field_multiplicity_identifier
-    ->(document_type, facet_name) { false }
+    ->(_, _) { false }
   end
 
   def call(*files)
@@ -31,7 +31,7 @@ class GovukContentSchemas::FinderSchemaConverter
   class FinderSchema
     attr_reader :file, :document_type_mapper, :select_field_multiplicity_identifier
 
-    def initialize(file, document_type_mapper: , select_field_multiplicity_identifier: )
+    def initialize(file, document_type_mapper:, select_field_multiplicity_identifier:)
       @file = file
       @document_type_mapper = document_type_mapper
       @select_field_multiplicity_identifier = ->(facet_name) { select_field_multiplicity_identifier.call(document_type, facet_name) }
@@ -60,7 +60,7 @@ class GovukContentSchemas::FinderSchemaConverter
     end
 
     def facets
-      data['facets'].map { |facet_json| FinderFacet.type_of(select_field_multiplicity_identifier, facet_json).new(facet_json) }
+      data["facets"].map { |facet_json| FinderFacet.type_of(select_field_multiplicity_identifier, facet_json).new(facet_json) }
     end
 
     def document_type_definition
@@ -81,15 +81,15 @@ class GovukContentSchemas::FinderSchemaConverter
     attr_reader :json
 
     def self.type_of(select_field_multiplicity_identifier, json)
-      if json['type'] == 'text' && json.has_key?('allowed_values')
-        if select_field_multiplicity_identifier.call(json['key'])
+      if json["type"] == "text" && json.has_key?("allowed_values")
+        if select_field_multiplicity_identifier.call(json["key"])
           FinderArrayFacet
         else
           FinderSingleSelectFacet
         end
-      elsif json['type'] == 'text'
+      elsif json["type"] == "text"
         FinderStringFacet
-      elsif json['type'] == 'date'
+      elsif json["type"] == "date"
         FinderDateFacet
       else
         raise "Unknown finder facet type #{json['type']}"
@@ -101,9 +101,8 @@ class GovukContentSchemas::FinderSchemaConverter
     end
 
     def facet_name
-      json['key']
+      json["key"]
     end
-
   end
 
   class FinderArrayFacet < FinderFacet
@@ -120,7 +119,7 @@ class GovukContentSchemas::FinderSchemaConverter
     end
 
     def allowed_values
-      json['allowed_values'].map { |record| record['value'] }
+      json["allowed_values"].map { |record| record["value"] }
     end
   end
 
@@ -135,7 +134,7 @@ class GovukContentSchemas::FinderSchemaConverter
     end
 
     def allowed_values
-      json['allowed_values'].map { |record| record['value'] }
+      json["allowed_values"].map { |record| record["value"] }
     end
   end
 

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -1,6 +1,6 @@
-require 'govuk_content_schemas'
-require 'govuk_content_schemas/utils'
-require 'json-schema'
+require "govuk_content_schemas"
+require "govuk_content_schemas/utils"
+require "json-schema"
 
 class GovukContentSchemas::FrontendSchemaGenerator
   include ::GovukContentSchemas::Utils
@@ -36,12 +36,13 @@ class GovukContentSchemas::FrontendSchemaGenerator
   end
 
 private
+
   def internal?(property_name)
     INTERNAL_PROPERTIES.include?(property_name)
   end
 
   def required_properties
-    required = @publisher_schema.schema['required'].to_a
+    required = @publisher_schema.schema["required"].to_a
 
     if required.empty?
       []
@@ -51,11 +52,11 @@ private
   end
 
   def publisher_properties
-    @pub_properties ||= @publisher_schema.schema['properties'] || {}
+    @pub_properties ||= @publisher_schema.schema["properties"] || {}
   end
 
   def publisher_links
-    @publisher_schema.schema["definitions"]["links"] || publisher_properties["links"] || {'properties' => {}}
+    @publisher_schema.schema["definitions"]["links"] || publisher_properties["links"] || { "properties" => {} }
   end
 
   def frontend_properties
@@ -63,18 +64,18 @@ private
     properties = resolve_multiple_content_types(properties)
 
     properties = properties.merge(
-      'links' => frontend_links,
-      'format' => { "type" => "string" },
-      'expanded_links' => { "type" => "object" },
-      'updated_at' => updated_at,
-      'base_path' => { '$ref' => '#/definitions/absolute_path' }
+      "links" => frontend_links,
+      "format" => { "type" => "string" },
+      "expanded_links" => { "type" => "object" },
+      "updated_at" => updated_at,
+      "base_path" => { "$ref" => "#/definitions/absolute_path" }
     )
 
     properties
   end
 
   def frontend_link_names
-    publisher_links.fetch('properties', {}).keys + ['available_translations']
+    publisher_links.fetch("properties", {}).keys + ["available_translations"]
   end
 
   def frontend_link_properties
@@ -92,28 +93,28 @@ private
   end
 
   def publisher_definitions
-    clone_hash(@publisher_schema.schema['definitions']) || {}
+    clone_hash(@publisher_schema.schema["definitions"]) || {}
   end
 
   def converted_definitions
-    resolve_multiple_content_types(publisher_definitions.reject { |k,v| k == "links" })
+    resolve_multiple_content_types(publisher_definitions.reject { |k| k == "links" })
   end
 
   def frontend_definitions
     {
-      'frontend_links' => frontend_links_definition.schema.reject { |k| k == '$schema' }
+      "frontend_links" => frontend_links_definition.schema.reject { |k| k == "$schema" }
     }.merge(converted_definitions)
   end
 
   def updated_at
     {
-      'type' => 'string',
-      'format' => 'date-time'
+      "type" => "string",
+      "format" => "date-time"
     }
   end
 
   def frontend_links_ref
-    {"$ref" => "#/definitions/frontend_links"}
+    { "$ref" => "#/definitions/frontend_links" }
   end
 
   def multiple_content_types_ref

--- a/lib/govuk_content_schemas/schema_combiner.rb
+++ b/lib/govuk_content_schemas/schema_combiner.rb
@@ -1,6 +1,6 @@
-require 'govuk_content_schemas'
-require 'govuk_content_schemas/utils'
-require 'json-schema'
+require "govuk_content_schemas"
+require "govuk_content_schemas/utils"
+require "json-schema"
 
 class GovukContentSchemas::SchemaCombiner
   include ::GovukContentSchemas::Utils
@@ -17,13 +17,13 @@ class GovukContentSchemas::SchemaCombiner
       combined_schema = clone_schema(schemas.fetch(:metadata))
       add_version_properties(combined_schema.schema)
       add_details(combined_schema.schema)
-      add_links(combined_schema.schema, 'definitions')
+      add_links(combined_schema.schema, "definitions")
       add_format_field(combined_schema.schema)
     else
       combined_schema = clone_schema(schemas.fetch(:links_metadata))
       add_version_properties(combined_schema.schema)
       add_details(combined_schema.schema)
-      add_links(combined_schema.schema, 'properties')
+      add_links(combined_schema.schema, "properties")
     end
 
     add_combined_definitions(combined_schema.schema)
@@ -39,17 +39,17 @@ private
     if version_schema
       version_schema = embeddable_schema(version_schema)
 
-      if schema['required']
-        schema['required'] = schema['required'] + version_schema['required']
+      if schema["required"]
+        schema["required"] = schema["required"] + version_schema["required"]
       end
 
-      schema['properties'] = schema['properties'].merge(version_schema['properties'])
+      schema["properties"] = schema["properties"].merge(version_schema["properties"])
     end
   end
 
   def add_details(schema)
     return unless schemas[:details]
-    schema['definitions'] = schema.fetch('definitions', {}).merge({'details' => embeddable_schema(schemas[:details])})
+    schema["definitions"] = schema.fetch("definitions", {}).merge("details" => embeddable_schema(schemas[:details]))
   end
 
   def add_links(schema, target)
@@ -57,16 +57,16 @@ private
 
     schema[target] = {} unless schema.key?(target)
     if schemas.key?(:links)
-      schema[target]['links'] = merge_schemas(schemas[:links], schemas.fetch(:base_links))
+      schema[target]["links"] = merge_schemas(schemas[:links], schemas.fetch(:base_links))
     else
-      schema[target]['links'] = embeddable_schema(schemas.fetch(:base_links))
+      schema[target]["links"] = embeddable_schema(schemas.fetch(:base_links))
     end
   end
 
   def merge_schemas(base_schema, other)
     merged_schema = embeddable_schema(base_schema)
     other = embeddable_schema(other)
-    merged_schema['properties'] = merged_schema['properties'].merge(other['properties'])
+    merged_schema["properties"] = merged_schema["properties"].merge(other["properties"])
     merged_schema
   end
 
@@ -104,7 +104,7 @@ private
 
   def add_combined_definitions(schema)
     return unless definitions_from_all_schemas.any?
-    schema['definitions'] = schema.fetch('definitions', {}).merge!(definitions_from_all_schemas)
+    schema["definitions"] = schema.fetch("definitions", {}).merge!(definitions_from_all_schemas)
   end
 
   def embeddable_schema(embeddable)
@@ -115,10 +115,10 @@ private
   end
 
   def definitions_from_all_schemas
-    combined = clone_hash(schemas.fetch(:definitions).schema.fetch('definitions', {}))
+    combined = clone_hash(schemas.fetch(:definitions).schema.fetch("definitions", {}))
 
     [schemas[:details], schemas[:links]].compact.inject(combined) do |memo, embedded_schema|
-      memo.merge(embedded_schema.schema.fetch('definitions', {}))
+      memo.merge(embedded_schema.schema.fetch("definitions", {}))
     end
   end
 end

--- a/lib/govuk_content_schemas/utils.rb
+++ b/lib/govuk_content_schemas/utils.rb
@@ -1,5 +1,5 @@
-require 'govuk_content_schemas'
-require 'json-schema'
+require "govuk_content_schemas"
+require "json-schema"
 
 module GovukContentSchemas::Utils
   def clone_hash(hash)

--- a/lib/tasks/combine_schemas.rake
+++ b/lib/tasks/combine_schemas.rake
@@ -1,8 +1,8 @@
-require 'rake/clean'
-require 'govuk_content_schemas/schema_combiner'
-require 'govuk_content_schemas/frontend_schema_generator'
-require 'json-schema'
-require 'json'
+require "rake/clean"
+require "govuk_content_schemas/schema_combiner"
+require "govuk_content_schemas/frontend_schema_generator"
+require "json-schema"
+require "json"
 
 CLEAN << "dist/formats"
 
@@ -11,7 +11,7 @@ schema_reader = JSON::Schema::Reader.new(accept_file: true, accept_uri: false)
 hand_made_publisher_schemas = FileList.new("formats/*/publisher/schema.json")
 hand_made_frontend_schemas = FileList.new("formats/*/frontend/schema.json")
 
-rule %r{^dist/formats/.*/(frontend|publisher)(_v2)?/schema.json} => ->(f) { f.sub(%r{^dist/}, '') } do |t|
+rule %r{^dist/formats/.*/(frontend|publisher)(_v2)?/schema.json} => ->(f) { f.sub(%r{^dist/}, "") } do |t|
   FileUtils.mkdir_p t.name.pathmap("%d")
   FileUtils.cp t.source, t.name
 end
@@ -64,7 +64,7 @@ combine_publisher_schemas = ->(task) do
 
   combiner = GovukContentSchemas::SchemaCombiner.new(source_schemas, format_name)
 
-  File.open(task.name, 'w') do |file|
+  File.open(task.name, "w") do |file|
     file.puts JSON.pretty_generate(combiner.combined.schema)
   end
 end
@@ -77,7 +77,7 @@ combine_frontend_schemas = ->(task) do
   frontend_generator = GovukContentSchemas::FrontendSchemaGenerator.new(publisher_schema, frontend_links_definition)
   frontend_schema = frontend_generator.generate.schema
 
-  File.open(task.name, 'w') do |file|
+  File.open(task.name, "w") do |file|
     file.puts JSON.pretty_generate(frontend_schema)
   end
 
@@ -89,7 +89,7 @@ combine_frontend_schemas = ->(task) do
   notification_schema["properties"].merge!(notification_base["properties"])
   notification_schema["required"] = (notification_schema["required"] + notification_base["required"]).uniq.sort
 
-  File.open(notification_schema_filename, 'w') do |file|
+  File.open(notification_schema_filename, "w") do |file|
     file.puts JSON.pretty_generate(notification_schema)
   end
 end

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -13,7 +13,7 @@ def valid?(example)
 end
 
 def base_path(example_file)
-  JSON.parse(File.read(example_file))['base_path']
+  JSON.parse(File.read(example_file))["base_path"]
 end
 
 def validate_schemas(schema_file_list)
@@ -43,18 +43,16 @@ task :validate_examples do
   abort "The following examples don't validate against their schemas:\n" + failed_examples.join("\n") if failed_examples.any?
 end
 
-task :validate_uniqueness_of_frontend_example_base_paths, :files do |t, args|
+task :validate_uniqueness_of_frontend_example_base_paths, :files do |_, args|
   frontend_examples = args[:files] || Rake::FileList.new("formats/*/frontend/examples/*.json")
-  grouped = frontend_examples.group_by {|file| base_path(file) }
-  duplicates = grouped.select {|base_path, group| group.count > 1 }
+  grouped = frontend_examples.group_by { |file| base_path(file) }
+  duplicates = grouped.select { |_, group| group.count > 1 }
 
   if duplicates.any?
     $stderr.puts "#{duplicates.count} duplicate(s) found:"
 
-    duplicates.each do |base_path, group|
-      group.each do |filename|
-        $stderr.puts "  #{filename}"
-      end
+    duplicates.each do |_, group|
+      group.each { |filename| $stderr.puts "  #{filename}" }
     end
     abort
   end

--- a/spec/lib/finder_schema_converter_spec.rb
+++ b/spec/lib/finder_schema_converter_spec.rb
@@ -1,4 +1,4 @@
-require 'govuk_content_schemas/finder_schema_converter'
+require "govuk_content_schemas/finder_schema_converter"
 
 RSpec.describe GovukContentSchemas::FinderSchemaConverter do
   let(:converter) { GovukContentSchemas::FinderSchemaConverter.new }
@@ -24,11 +24,11 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
 
     context "no facets" do
       let(:facets) { [] }
-      let(:document_type_name) { "my_random_document_type"}
+      let(:document_type_name) { "my_random_document_type" }
       let(:schema_file) { tmpdir + "#{document_type_name}.json" }
 
       it "derives the definition name from the file name" do
-        expect(converted['definitions'].keys).to eq(["#{document_type_name}_metadata"])
+        expect(converted["definitions"].keys).to eq(["#{document_type_name}_metadata"])
       end
     end
 
@@ -42,11 +42,11 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
           "display_as_result_metadata" => true,
           "filterable" => true,
           "allowed_values" => [
-            {"label" => "Commercial - fixed wing", "value" => "commercial-fixed-wing"},
-            {"label" => "Commercial - rotorcraft", "value" => "commercial-rotorcraft"},
-            {"label" => "General aviation - fixed wing", "value" => "general-aviation-fixed-wing"},
-            {"label" => "General aviation - rotorcraft", "value" => "general-aviation-rotorcraft"},
-            {"label" => "Sport aviation and balloons", "value" => "sport-aviation-and-balloons"}
+            { "label" => "Commercial - fixed wing", "value" => "commercial-fixed-wing" },
+            { "label" => "Commercial - rotorcraft", "value" => "commercial-rotorcraft" },
+            { "label" => "General aviation - fixed wing", "value" => "general-aviation-fixed-wing" },
+            { "label" => "General aviation - rotorcraft", "value" => "general-aviation-rotorcraft" },
+            { "label" => "Sport aviation and balloons", "value" => "sport-aviation-and-balloons" }
           ]
         }
       }
@@ -56,41 +56,37 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
       let(:converter) { GovukContentSchemas::FinderSchemaConverter.new(select_field_multiplicity_identifier: multiplicity_identifier) }
 
       context "select_field_multiplicity_identifier identifies the field as a single select" do
-        let(:multiplicity_identifier) { ->(document_type, facet_name) { false } }
+        let(:multiplicity_identifier) { ->(_, _) { false } }
 
         it "generates a field which matches a string constrained by the allowed_values" do
           expect(aircraft_category).to eq(
-            {
-              "type" => "string",
-              "enum" => [
-                "commercial-fixed-wing",
-                "commercial-rotorcraft",
-                "general-aviation-fixed-wing",
-                "general-aviation-rotorcraft",
-                "sport-aviation-and-balloons"
-              ]
-            }
+            "type" => "string",
+            "enum" => %w[
+              commercial-fixed-wing
+              commercial-rotorcraft
+              general-aviation-fixed-wing
+              general-aviation-rotorcraft
+              sport-aviation-and-balloons
+            ],
           )
         end
       end
 
       context "select_field_multiplicity_identifier identifies the field as a single select" do
-        let(:multiplicity_identifier) { ->(document_type, facet_name) { true } }
+        let(:multiplicity_identifier) { ->(_, _) { true } }
 
         it "generates a field which matches a array whose elements are constrained by the allowed_values" do
           expect(aircraft_category).to eq(
-            {
-              "type" => "array",
-              "items" => {
-                "type" => "string",
-                "enum" => [
-                  "commercial-fixed-wing",
-                  "commercial-rotorcraft",
-                  "general-aviation-fixed-wing",
-                  "general-aviation-rotorcraft",
-                  "sport-aviation-and-balloons"
-                ]
-              }
+            "type" => "array",
+            "items" => {
+              "type" => "string",
+              "enum" => %w[
+                commercial-fixed-wing
+                commercial-rotorcraft
+                general-aviation-fixed-wing
+                general-aviation-rotorcraft
+                sport-aviation-and-balloons
+              ],
             }
           )
         end
@@ -106,7 +102,7 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
           "type" => "date",
           "preposition" => "occurred",
           "display_as_result_metadata" => true,
-          "filterable" => true
+          "filterable" => true,
         }
       }
 
@@ -119,14 +115,14 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
               "properties" => {
                 "document_type" => {
                   "type" => "string",
-                  "enum" => ["schema"]
+                  "enum" => %w[schema],
                 },
                 "date_of_occurrence" => {
                   "type" => "string",
-                  "pattern" => "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-                }
-              }
-            }
+                  "pattern" => "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
+                },
+              },
+            },
           }
         )
       end
@@ -139,7 +135,7 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
           "name" => "Aircraft type",
           "type" => "text",
           "display_as_result_metadata" => false,
-          "filterable" => false
+          "filterable" => false,
         }
       }
 
@@ -152,13 +148,13 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
               "properties" => {
                 "document_type" => {
                   "type" => "string",
-                  "enum" => ["schema"]
+                  "enum" => %w[schema],
                 },
                 "aircraft_type" => {
                   "type" => "string"
-                }
-              }
-            }
+                },
+              },
+            },
           }
         )
       end
@@ -178,8 +174,8 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
       }
 
       it "uses the mapper to generate the document_type and facet name" do
-        expect(converted['definitions'].keys).to eq(["schema_CONVERTED_metadata"])
-        expect(converted['definitions']["schema_CONVERTED_metadata"]["properties"]["document_type"]).to eq(
+        expect(converted["definitions"].keys).to eq(["schema_CONVERTED_metadata"])
+        expect(converted["definitions"]["schema_CONVERTED_metadata"]["properties"]["document_type"]).to eq(
           "type" => "string",
           "enum" => ["schema_CONVERTED"]
         )
@@ -215,7 +211,7 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
     }
 
     it "produces definitions for each format" do
-      expect(converted["definitions"].keys).to eq(['schema1_metadata', 'schema2_metadata'])
+      expect(converted["definitions"].keys).to eq(%w[schema1_metadata schema2_metadata])
     end
   end
 
@@ -225,9 +221,9 @@ RSpec.describe GovukContentSchemas::FinderSchemaConverter do
     }
 
     it "combines all of the facets from each file" do
-      expect(converted['definitions'].keys).to eq(['aaib-reports_metadata', 'drug-safety-updates_metadata'])
-      expect(converted['definitions']['aaib-reports_metadata']['properties'].keys).to eq(["document_type", "aircraft_category", "report_type", "date_of_occurrence", "aircraft_type", "location", "registration"])
-      expect(converted['definitions']['drug-safety-updates_metadata']['properties'].keys).to eq(["document_type", "therapeutic_area", "first_published_at"])
+      expect(converted["definitions"].keys).to eq(%w[aaib-reports_metadata drug-safety-updates_metadata])
+      expect(converted["definitions"]["aaib-reports_metadata"]["properties"].keys).to eq(%w[document_type aircraft_category report_type date_of_occurrence aircraft_type location registration])
+      expect(converted["definitions"]["drug-safety-updates_metadata"]["properties"].keys).to eq(%w[document_type therapeutic_area first_published_at])
     end
   end
 end

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -1,4 +1,4 @@
-require 'govuk_content_schemas/frontend_schema_generator'
+require "govuk_content_schemas/frontend_schema_generator"
 
 RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   include GovukContentSchemas::Utils
@@ -37,7 +37,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   }
 
   let(:frontend_links_definition) {
-    build_schema('frontend_links.json', properties: build_string_properties('test'))
+    build_schema("frontend_links.json", properties: build_string_properties("test"))
   }
 
   subject(:generated) {
@@ -58,18 +58,18 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
 
   it "removes internal properties from the top level properties list" do
     internal_properties.each do |internal_property|
-      expect(generated.schema['properties'].keys).to_not include(internal_property)
+      expect(generated.schema["properties"].keys).to_not include(internal_property)
     end
   end
 
   it "removes internal properties from the top level list of required properties" do
     internal_properties.each do |internal_property|
-      expect(generated.schema['required']).to_not include(internal_property)
+      expect(generated.schema["required"]).to_not include(internal_property)
     end
   end
 
   it "adds updated_at as an allowed datetime property" do
-    expect(generated.schema['properties']).to include(
+    expect(generated.schema["properties"]).to include(
       "updated_at" => {
         "type" => "string",
         "format" => "date-time"
@@ -78,7 +78,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   end
 
   it "adds base_path as a required string property" do
-    expect(generated.schema['properties']).to include(
+    expect(generated.schema["properties"]).to include(
       "base_path" => {
         "$ref" => "#/definitions/absolute_path"
       }
@@ -89,19 +89,19 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   end
 
   it "injects a frontend_links definition" do
-    expect(generated.schema['definitions']).to include('frontend_links')
-    expected_embed = frontend_links_definition.schema.reject { |k| k == '$schema' }
-    expect(generated.schema['definitions']['frontend_links']).to eq(expected_embed)
+    expect(generated.schema["definitions"]).to include("frontend_links")
+    expected_embed = frontend_links_definition.schema.reject { |k| k == "$schema" }
+    expect(generated.schema["definitions"]["frontend_links"]).to eq(expected_embed)
   end
 
   it "transforms the links specification to allow expanded links and available_tranlsations" do
-    expect(generated.schema['properties']['links']).to eq(build_frontend_links_schema(*link_names, 'available_translations'))
+    expect(generated.schema["properties"]["links"]).to eq(build_frontend_links_schema(*link_names, "available_translations"))
   end
 
   context "publisher schema specifies a required link" do
     let(:publisher_schema_with_required_link) {
       clone_schema(publisher_schema).tap do |cloned|
-        cloned.schema['properties']['links']['required'] = link_names
+        cloned.schema["properties"]["links"]["required"] = link_names
       end
     }
 
@@ -110,7 +110,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
     }
 
     it "preserves list of required items" do
-      expect(generated.schema['properties']['links']['required']).to eq(link_names)
+      expect(generated.schema["properties"]["links"]["required"]).to eq(link_names)
     end
   end
 
@@ -118,7 +118,7 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
     let(:link_names) { nil }
 
     it "transforms the links specification to allow available_tranlsations" do
-      expect(generated.schema['properties']['links']).to eq(build_frontend_links_schema('available_translations'))
+      expect(generated.schema["properties"]["links"]).to eq(build_frontend_links_schema("available_translations"))
     end
   end
 

--- a/spec/lib/schema_combiner_spec.rb
+++ b/spec/lib/schema_combiner_spec.rb
@@ -1,10 +1,10 @@
-require 'govuk_content_schemas/schema_combiner'
+require "govuk_content_schemas/schema_combiner"
 
 RSpec.describe GovukContentSchemas::SchemaCombiner do
-  let(:metadata_schema) { build_schema('metadata.json', properties: build_string_properties('body')) }
-  let(:definitions) { build_schema('definitions.json', definitions: build_string_properties('def1')) }
-  let(:base_links) { build_schema('base_links.json', properties: build_ref_properties(["mainstream_browse_pages"], 'guid_list')) }
-  let(:format_name) { 'my_format' }
+  let(:metadata_schema) { build_schema("metadata.json", properties: build_string_properties("body")) }
+  let(:definitions) { build_schema("definitions.json", definitions: build_string_properties("def1")) }
+  let(:base_links) { build_schema("base_links.json", properties: build_ref_properties(["mainstream_browse_pages"], "guid_list")) }
+  let(:format_name) { "my_format" }
 
   let(:schemas) {
     {
@@ -19,35 +19,33 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
   end
 
   context "combining a simple metadata and details schema" do
-    let(:details_schema) { build_schema('details.json', properties: build_string_properties('detail')) }
+    let(:details_schema) { build_schema("details.json", properties: build_string_properties("detail")) }
 
-    it 'adds a details property to the combined schema definitions' do
-      expect(combined.schema['definitions']['details']).to be_a(Hash)
+    it "adds a details property to the combined schema definitions" do
+      expect(combined.schema["definitions"]["details"]).to be_a(Hash)
     end
 
-    it 'duplicates the metadata to add format and document_type/schema_name options' do
-      expect(combined.schema['properties']).to include('schema_name', 'document_type')
+    it "duplicates the metadata to add format and document_type/schema_name options" do
+      expect(combined.schema["properties"]).to include("schema_name", "document_type")
     end
 
-    it 'strips the $schema key from the embedded details property' do
-      expect(combined.schema['definitions']['details']).not_to have_key('$schema')
+    it "strips the $schema key from the embedded details property" do
+      expect(combined.schema["definitions"]["details"]).not_to have_key("$schema")
     end
 
-    it 'embeds the remaining content of the details schema as the details property definition' do
-      remaining_content_of_details_schema = details_schema.schema.reject { |k, v| k == '$schema'}
-      expect(combined.schema['definitions']['details']).to eq(remaining_content_of_details_schema)
+    it "embeds the remaining content of the details schema as the details property definition" do
+      remaining_content_of_details_schema = details_schema.schema.reject { |k| k == "$schema" }
+      expect(combined.schema["definitions"]["details"]).to eq(remaining_content_of_details_schema)
     end
 
-    it 'uses the original uri for the combined schema' do
+    it "uses the original uri for the combined schema" do
       expect(combined.uri).to eq(metadata_schema.uri)
     end
 
     context "without a document_types schema" do
       it "allows any string in the document_type field" do
-        expect(combined.schema['properties']['document_type']).to eq(
-          {
-            "type" => "string",
-          }
+        expect(combined.schema["properties"]["document_type"]).to eq(
+          "type" => "string",
         )
       end
     end
@@ -57,11 +55,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
         {
           "document_type" => {
             "type" => "string",
-            "enum" => [
-              "aaib_report",
-              "asylum_support_decision",
-              "cma_case",
-            ]
+            "enum" => %w[aaib_report asylum_support_decision cma_case],
           }
         }
       }
@@ -71,22 +65,22 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
           definitions: definitions,
           metadata: metadata_schema,
           details: details_schema,
-          document_types: build_schema('document_types.json', properties: document_types )
+          document_types: build_schema("document_types.json", properties: document_types)
         }
       }
 
       it "sets the allowed values for the document_type field" do
-        expect(combined.schema['properties']['document_type']).to eq(document_types["document_type"])
+        expect(combined.schema["properties"]["document_type"]).to eq(document_types["document_type"])
       end
     end
   end
 
   context "combining v1 metadata with common metadata and details" do
     let(:v1_metadata) {
-      build_schema('v1_metadata.json', properties: build_string_properties('bar'), required: ['bar'])
+      build_schema("v1_metadata.json", properties: build_string_properties("bar"), required: ["bar"])
     }
 
-    let(:details) { build_schema('details.json', properties: build_string_properties('detail'), definitions: {}) }
+    let(:details) { build_schema("details.json", properties: build_string_properties("detail"), definitions: {}) }
 
     subject(:combined) do
       described_class.new({
@@ -98,27 +92,27 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
     end
 
     it "combines the v1 metadata with simple metadata and details and adds the format" do
-      expect(combined.schema['properties'].keys).to match_array(['bar', 'body', 'document_type', 'schema_name'])
-      expect(combined.schema['definitions']).to have_key('details')
+      expect(combined.schema["properties"].keys).to match_array(%w[bar body document_type schema_name])
+      expect(combined.schema["definitions"]).to have_key("details")
     end
   end
 
   context "combining schemas and definitions" do
     let(:definitions) {
-      build_schema('definitions.json',
-        definitions: build_string_properties('def1')
+      build_schema("definitions.json",
+        definitions: build_string_properties("def1")
       )
     }
     let(:metadata_schema) {
-      build_schema('metadata.json',
-        properties: build_string_properties('body')
+      build_schema("metadata.json",
+        properties: build_string_properties("body")
       )
     }
 
     let(:details_schema) {
-      build_schema('details.json',
-        properties: build_string_properties('detail'),
-        definitions: build_string_properties('def2')
+      build_schema("details.json",
+        properties: build_string_properties("detail"),
+        definitions: build_string_properties("def2")
       )
     }
 
@@ -130,21 +124,21 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
       }, format_name).combined
     end
 
-    it 'removes the definitions from the embedded details property' do
-      expect(combined.schema['definitions']['details']).not_to have_key('definitions')
+    it "removes the definitions from the embedded details property" do
+      expect(combined.schema["definitions"]["details"]).not_to have_key("definitions")
     end
 
-    it 'merges the definitions from the details schema into the top-level definitions' do
-      expect(combined.schema['definitions']).to include('def1', 'def2')
-      expect(combined.schema['definitions']['def2']).to eq(details_schema.schema['definitions']['def2'])
+    it "merges the definitions from the details schema into the top-level definitions" do
+      expect(combined.schema["definitions"]).to include("def1", "def2")
+      expect(combined.schema["definitions"]["def2"]).to eq(details_schema.schema["definitions"]["def2"])
     end
   end
 
   context "combining a metadata schema and a links schema" do
     let(:links_schema) {
-      build_schema('links.json',
-        properties: build_string_properties('organisations'),
-        definitions: build_string_properties('guid_list')
+      build_schema("links.json",
+        properties: build_string_properties("organisations"),
+        definitions: build_string_properties("guid_list")
       )
     }
     subject(:combined) do
@@ -156,46 +150,45 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
       }, format_name).combined
     end
 
-    it 'adds a links property to the combined schema' do
-      expect(combined.schema['definitions']['links']).to be_a(Hash)
+    it "adds a links property to the combined schema" do
+      expect(combined.schema["definitions"]["links"]).to be_a(Hash)
     end
 
-    it 'strips the $schema key from the embedded links property' do
-      expect(combined.schema['definitions']['links']).not_to have_key('$schema')
+    it "strips the $schema key from the embedded links property" do
+      expect(combined.schema["definitions"]["links"]).not_to have_key("$schema")
     end
 
-    it 'embeds the remaining content of the links schema as the links property definition' do
-      remaining_content_of_links_schema = links_schema.schema.reject { |k, v| %w{$schema definitions}.include?(k) }
-      expect(combined.schema['definitions']['links']['properties'].keys).to eq(['organisations', 'mainstream_browse_pages'])
+    it "embeds the remaining content of the links schema as the links property definition" do
+      expect(combined.schema["definitions"]["links"]["properties"].keys).to eq(%w[organisations mainstream_browse_pages])
     end
 
-    it 'merges the definitions from the links schema into the combined schemas definitions' do
-      expect(combined.schema['definitions']).to include('guid_list')
-      expect(combined.schema['definitions']['guid_list']).to eq(links_schema.schema['definitions']['guid_list'])
+    it "merges the definitions from the links schema into the combined schemas definitions" do
+      expect(combined.schema["definitions"]).to include("guid_list")
+      expect(combined.schema["definitions"]["guid_list"]).to eq(links_schema.schema["definitions"]["guid_list"])
     end
   end
 
   context "combining metadata and details for a v2 schema" do
     let(:metadata_schema) {
-      build_schema('metadata.json',
-                   properties: build_string_properties('body'),
-                   required: ['content_id', 'body', 'update_type'])
+      build_schema("metadata.json",
+                   properties: build_string_properties("body"),
+                   required: %w[content_id body update_type])
     }
 
     let(:v2_metadata) {
-      build_schema('v2_metadata.json', properties: build_string_properties('foo'), required: ['foo'])
+      build_schema("v2_metadata.json", properties: build_string_properties("foo"), required: ["foo"])
     }
 
     let(:details_schema) {
-      build_schema('details.json', properties: build_string_properties('detail'))
+      build_schema("details.json", properties: build_string_properties("detail"))
     }
 
     let(:links_schema) {
-      build_schema('links.json', properties: build_string_properties('organisations'))
+      build_schema("links.json", properties: build_string_properties("organisations"))
     }
 
     let(:definitions) {
-      build_schema('definitions.json', definitions: build_string_properties('def1', 'def2'))
+      build_schema("definitions.json", definitions: build_string_properties("def1", "def2"))
     }
 
     subject(:combined) do
@@ -207,44 +200,44 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
       }, format_name).combined
     end
 
-    it 'removes the definitions from the embedded details property' do
-      expect(combined.schema['definitions']['details']).not_to have_key('definitions')
+    it "removes the definitions from the embedded details property" do
+      expect(combined.schema["definitions"]["details"]).not_to have_key("definitions")
     end
 
-    it 'merges the definitions into the combined schema' do
-      expect(combined.schema['definitions']).to include('def1', 'def2')
+    it "merges the definitions into the combined schema" do
+      expect(combined.schema["definitions"]).to include("def1", "def2")
     end
 
     it "doesn't merge the links schema" do
-      expect(combined.schema).not_to have_key('links')
+      expect(combined.schema).not_to have_key("links")
     end
 
     it "merges in v2 required properties" do
-      expect(combined.schema['required']).to include('foo')
+      expect(combined.schema["required"]).to include("foo")
     end
 
     it "merges in v2 properties" do
-      expect(combined.schema['properties']).to have_key('foo')
+      expect(combined.schema["properties"]).to have_key("foo")
     end
   end
 
   context "combining links and definitions for a v2 schema" do
     let(:links_metadata) {
-      build_schema('links_metadata.json',
-                   properties: build_string_properties('base_path'),
-                   required: ['base_path'])
+      build_schema("links_metadata.json",
+                   properties: build_string_properties("base_path"),
+                   required: ["base_path"])
     }
 
     let(:base_links) {
-      build_schema('base_links.json', properties: build_ref_properties(['organisations', 'parent'], 'guid_list'))
+      build_schema("base_links.json", properties: build_ref_properties(%w[organisations parent], "guid_list"))
     }
 
     let(:links_schema) {
-      build_schema('links.json', properties: build_string_properties('organisations', 'mainstream_browse_pages'))
+      build_schema("links.json", properties: build_string_properties("organisations", "mainstream_browse_pages"))
     }
 
     let(:definitions) {
-      build_schema('definitions.json', definitions: build_string_properties('guid_list'))
+      build_schema("definitions.json", definitions: build_string_properties("guid_list"))
     }
 
     subject(:combined) do
@@ -256,27 +249,27 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
       }, format_name).combined
     end
 
-    it 'preserves $schema key' do
-      expect(combined.schema).to have_key('$schema')
+    it "preserves $schema key" do
+      expect(combined.schema).to have_key("$schema")
     end
 
-    it 'defines metadata properties' do
-      expect(combined.schema['properties']).to have_key('base_path')
+    it "defines metadata properties" do
+      expect(combined.schema["properties"]).to have_key("base_path")
     end
 
-    it 'defines required properties' do
-      expect(combined.schema['required']).to include('base_path')
+    it "defines required properties" do
+      expect(combined.schema["required"]).to include("base_path")
     end
 
-    it 'embeds the merged links schemas as the links property' do
-      remaining_content_of_links_schema = links_schema.schema.reject { |k, v| %w{$schema definitions}.include?(k) }
-      expect(combined.schema['properties']['links']['properties'].keys).to match_array(
-        ['organisations', 'mainstream_browse_pages', 'parent'])
+    it "embeds the merged links schemas as the links property" do
+      expect(combined.schema["properties"]["links"]["properties"].keys).to match_array(
+        %w[organisations mainstream_browse_pages parent]
+      )
     end
 
-    it 'merges the definitions from the definitions schema into the combined schemas definitions' do
-      expect(combined.schema['definitions']).to include('guid_list')
-      expect(combined.schema['definitions']['guid_list']).to eq(definitions.schema['definitions']['guid_list'])
+    it "merges the definitions from the definitions schema into the combined schemas definitions" do
+      expect(combined.schema["definitions"]).to include("guid_list")
+      expect(combined.schema["definitions"]["guid_list"]).to eq(definitions.schema["definitions"]["guid_list"])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-$LOAD_PATH << File.expand_path('../lib', File.dirname(__FILE__))
+$LOAD_PATH << File.expand_path("../lib", File.dirname(__FILE__))
 
-Dir[File.dirname(__FILE__) + '/support/*.rb'].each do |helper|
+Dir[File.dirname(__FILE__) + "/support/*.rb"].each do |helper|
   require helper
 end
 
@@ -18,7 +18,7 @@ RSpec.configure do |config|
   config.warnings = false
 
   if config.files_to_run.one?
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
 
   config.order = :random

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -3,11 +3,11 @@ require "rake"
 shared_context "rake" do
   let(:rake)      { Rake::Application.new }
   let(:task_name) { self.class.top_level_description }
-  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  let(:task_path) { "lib/tasks/#{task_name.split(':').first}" }
   subject         { rake[task_name] }
 
   def loaded_files_excluding_current_rake_file
-    $".reject {|file| file == project_root.join("#{task_path}.rake").to_s }
+    $".reject { |file| file == project_root.join("#{task_path}.rake").to_s }
   end
 
   before do

--- a/spec/support/schema_builder_helpers.rb
+++ b/spec/support/schema_builder_helpers.rb
@@ -1,5 +1,5 @@
-require 'pathname'
-require 'json-schema'
+require "pathname"
+require "json-schema"
 
 module SchemaBuilderHelpers
   def project_root
@@ -11,15 +11,15 @@ module SchemaBuilderHelpers
       "$schema" => "http://json-schema.org/draft-04/schema#",
       "type" => "object"
     }
-    schema['properties'] = properties if properties
-    schema['definitions'] = definitions if definitions
-    schema['required'] = required if required
+    schema["properties"] = properties if properties
+    schema["definitions"] = definitions if definitions
+    schema["required"] = required if required
     JSON::Schema.new(schema, URI.parse(name))
   end
 
   def build_string_properties(*properties)
     properties.inject({}) do |memo, property_name|
-      memo.merge(property_name => {"type" => "string"})
+      memo.merge(property_name => { "type" => "string" })
     end
   end
 
@@ -33,16 +33,16 @@ module SchemaBuilderHelpers
 
   def build_publisher_schema(properties, link_names = nil, required_properties = nil)
     properties = build_string_properties(*properties)
-    properties['links'] = build_publisher_links_schema(*link_names) if link_names
-    definitions = build_string_properties('guid_list')
-    build_schema('schema.json', properties: properties, required: required_properties, definitions: definitions)
+    properties["links"] = build_publisher_links_schema(*link_names) if link_names
+    definitions = build_string_properties("guid_list")
+    build_schema("schema.json", properties: properties, required: required_properties, definitions: definitions)
   end
 
   def build_publisher_links_schema(*link_names)
     {
       "type" => "object",
       "additionalProperties" => false,
-      "properties" => build_ref_properties(link_names, "guid_list")
+      "properties" => build_ref_properties(link_names, "guid_list"),
     }
   end
 
@@ -50,7 +50,7 @@ module SchemaBuilderHelpers
     {
       "type" => "object",
       "additionalProperties" => false,
-      "properties" => build_ref_properties(link_names, "frontend_links")
+      "properties" => build_ref_properties(link_names, "frontend_links"),
     }
   end
 

--- a/spec/tasks/combine_schema_spec.rb
+++ b/spec/tasks/combine_schema_spec.rb
@@ -1,15 +1,15 @@
-require 'spec_helper'
-require 'rake'
-require 'fileutils'
+require "spec_helper"
+require "rake"
+require "fileutils"
 
-require 'govuk_content_schemas/schema_combiner'
-require 'govuk_content_schemas/frontend_schema_generator'
+require "govuk_content_schemas/schema_combiner"
+require "govuk_content_schemas/frontend_schema_generator"
 
 RSpec::Matchers.define :exist do
   match { |actual| File.exist?(actual) }
 end
 
-RSpec.describe 'combine_schemas' do
+RSpec.describe "combine_schemas" do
   include_context "rake"
   let(:task_path) { "lib/tasks/combine_schemas" }
 
@@ -29,8 +29,8 @@ RSpec.describe 'combine_schemas' do
         v2_metadata: reader.read(project_root.join("formats/v2_metadata.json")),
         links_metadata: reader.read(project_root.join("formats/links_metadata.json")),
         definitions: reader.read(project_root.join("formats/definitions.json")),
-        details: build_schema('details.json', properties: build_string_properties('detail')),
-        links: build_schema('links.json', properties: build_string_properties('links')),
+        details: build_schema("details.json", properties: build_string_properties("detail")),
+        links: build_schema("links.json", properties: build_string_properties("links")),
         base_links: reader.read(project_root.join("formats/base_links.json"))
       }
     }
@@ -47,7 +47,6 @@ RSpec.describe 'combine_schemas' do
     end
 
     context "with common metadata" do
-
       before(:each) do
         subject.invoke
       end
@@ -60,8 +59,9 @@ RSpec.describe 'combine_schemas' do
         end
 
         it "derives the format name from the filesystem path" do
-          expect(generated_schema.schema['properties']['schema_name']).to eq(
-            {"type" => "string", "enum" => [format_name]}
+          expect(generated_schema.schema["properties"]["schema_name"]).to eq(
+            "type" => "string",
+            "enum" => [format_name],
           )
         end
 

--- a/spec/tasks/validate_uniqueness_of_frontend_example_base_paths_spec.rb
+++ b/spec/tasks/validate_uniqueness_of_frontend_example_base_paths_spec.rb
@@ -1,8 +1,8 @@
-require 'spec_helper'
-require 'json'
-require 'rake'
+require "spec_helper"
+require "json"
+require "rake"
 
-RSpec.describe 'validate' do
+RSpec.describe "validate" do
   include_context "rake"
 
   def generate_example(name, base_path)


### PR DESCRIPTION
This applies all `govuk_lint_ruby` fixes and goes through and makes usage of double quotes consistent.