### PR TITLE
Allow frontend schemas to have 'children' within their links.

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -120,6 +120,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -120,6 +120,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -118,6 +118,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -115,6 +115,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -112,6 +112,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -120,6 +120,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -127,6 +127,9 @@
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -123,6 +123,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -82,9 +82,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "service_manual_topics": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -110,6 +107,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/service_manual_homepage/publisher/schema.json
+++ b/dist/formats/service_manual_homepage/publisher/schema.json
@@ -138,10 +138,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "service_manual_topics": {
-          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
-          "$ref": "#/definitions/guid_list"
-        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -10,10 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "service_manual_topics": {
-          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
-          "$ref": "#/definitions/guid_list"
-        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -112,6 +112,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -108,6 +108,9 @@
         },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/formats/service_manual_homepage/frontend/examples/service_manual_homepage.json
+++ b/formats/service_manual_homepage/frontend/examples/service_manual_homepage.json
@@ -6,19 +6,54 @@
   "details": {
   },
   "links": {
-    "service_manual_topics": [
+    "children": [
+      {
+        "content_id": "18250ea0-947c-4e01-a4dd-cffabaf2fd6f",
+        "title": "Helping people to use your service",
+        "base_path": "/service-manual/helping-people-to-use-your-service",
+        "description": "Help and encourage people to use your digital service: assisted digital, digital take-up, user support.",
+        "api_url": "https://content-store.gov.uk/content/service-manual/helping-people-to-use-your-service",
+        "web_url": "https://www.gov.uk/service-manual/helping-people-to-use-your-service",
+        "locale": "en",
+        "schema_name": "service_manual_topic",
+        "document_type": "service_manual_topic",
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "ac4411b3-3c3b-4c80-a263-45e54eaca4df",
+        "title": "Funding and procurement",
+        "base_path": "/service-manual/funding-and-procurement",
+        "description": "How to get money, buy things and use the Digital Marketplace.",
+        "api_url": "https://content-store.gov.uk/content/service-manual/funding-and-procurement",
+        "web_url": "https://www.gov.uk/service-manual/funding-and-procurement",
+        "locale": "en",
+        "schema_name": "service_manual_topic",
+        "document_type": "service_manual_topic",
+        "analytics_identifier": null
+      },
       {
         "content_id": "370e00b2-3c79-4816-aaa9-1a7059e6155d",
-        "title": "Agile",
-        "base_path": "/service-manual/agile",
-        "description": "",
+        "title": "Agile delivery",
+        "base_path": "/service-manual/agile-delivery",
+        "description": "How to work in an agile way: principles, tools and governance.",
         "api_url": "https://content-store.gov.uk/content/service-manual/agile",
         "web_url": "https://www.gov.uk/service-manual/agile",
         "locale": "en",
         "schema_name": "service_manual_topic",
         "document_type": "service_manual_topic",
-        "analytics_identifier": null,
-        "links": {}
+        "analytics_identifier": null
+      },
+      {
+        "content_id": "1d665d61-24dc-4143-b7d5-6f94a49b50e0",
+        "title": "Measuring success",
+        "base_path": "/service-manual/measuring-success",
+        "description": "How to use data to improve your service: KPIs, reporting, analytics tools and techniques.",
+        "api_url": "https://content-store.gov.uk/content/service-manual/measuring-success",
+        "web_url": "https://www.gov.uk/service-manual/measuring-success",
+        "locale": "en",
+        "schema_name": "service_manual_topic",
+        "document_type": "service_manual_topic",
+        "analytics_identifier": null
       }
     ]
   },

--- a/formats/service_manual_homepage/publisher/links.json
+++ b/formats/service_manual_homepage/publisher/links.json
@@ -2,10 +2,5 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "properties": {
-    "service_manual_topics": {
-    	"description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
-    	"$ref": "#/definitions/guid_list"
-    }
-  }
+  "properties": {}
 }

--- a/formats/service_manual_homepage/publisher_v2/examples/service_manual_homepage_links.json
+++ b/formats/service_manual_homepage/publisher_v2/examples/service_manual_homepage_links.json
@@ -1,5 +1,0 @@
-{
-  "links": {
-    "service_manual_topics": ["cd02b82d-c706-435c-a2fc-2dcabd168ef4"]
-  }
-}

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -75,7 +75,10 @@ private
   end
 
   def frontend_link_names
-    publisher_links.fetch("properties", {}).keys + ["available_translations"]
+    publisher_links.fetch("properties", {}).keys + [
+      "available_translations",
+      "children"
+    ]
   end
 
   def frontend_link_properties

--- a/spec/lib/frontend_schema_generator_spec.rb
+++ b/spec/lib/frontend_schema_generator_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
     expect(generated.schema["definitions"]["frontend_links"]).to eq(expected_embed)
   end
 
-  it "transforms the links specification to allow expanded links and available_tranlsations" do
-    expect(generated.schema["properties"]["links"]).to eq(build_frontend_links_schema(*link_names, "available_translations"))
+  it "transforms the links specification to allow expanded links, available_translations and children" do
+    expect(generated.schema["properties"]["links"]).to eq(build_frontend_links_schema(*link_names, "available_translations", "children"))
   end
 
   context "publisher schema specifies a required link" do
@@ -117,8 +117,8 @@ RSpec.describe GovukContentSchemas::FrontendSchemaGenerator do
   context "no links in publisher schema" do
     let(:link_names) { nil }
 
-    it "transforms the links specification to allow available_tranlsations" do
-      expect(generated.schema["properties"]["links"]).to eq(build_frontend_links_schema("available_translations"))
+    it "transforms the links specification to allow for available_translations and children" do
+      expect(generated.schema["properties"]["links"]).to eq(build_frontend_links_schema("available_translations", "children"))
     end
   end
 


### PR DESCRIPTION
We're using the bidirectional parent/children relationship in the service manual. This means we don’t need to republish the homepage every time we want to add or remove a topic.

To reflect this we want to add children to the links in the frontend schema example, so we can use this when testing and when running the frontend against the draft content store.

Publishing applications should not be 'allowed' to specify children when patching links as it would conflict with the auto-populated ones that the publishing api provides when specifying parents. Therefore, we add `children` to the frontend schemas only by changing the frontend schema generator.