### PR TITLE
Remove children from the service standard's links in publisher schemas

### DIFF
--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -82,9 +82,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "children": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "email_alert_signup": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -113,6 +110,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -143,13 +143,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "children": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": true
-          }
-        },
         "email_alert_signup": {
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -10,13 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "children": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": true
-          }
-        },
         "email_alert_signup": {
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/guid_list"

--- a/formats/service_manual_service_standard/publisher/links.json
+++ b/formats/service_manual_service_standard/publisher/links.json
@@ -3,13 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "children": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true
-      }
-    },
     "email_alert_signup": {
       "description": "References an email alert signup page for the service standard",
       "$ref": "#/definitions/guid_list"


### PR DESCRIPTION
The frontend schema generator now adds children to the frontend schemas only, which is a better representation of how children are used.