### PR TITLE
Remove "policies" link type

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -112,9 +112,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -255,10 +255,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -47,10 +47,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -175,10 +175,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -103,9 +103,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -367,10 +367,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -38,10 +38,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -112,9 +112,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -254,10 +254,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -47,10 +47,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -110,9 +110,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -259,10 +259,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -46,10 +46,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -237,10 +237,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -109,9 +109,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -198,10 +198,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -46,10 +46,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_release/publisher/schema.json
+++ b/dist/formats/financial_release/publisher/schema.json
@@ -185,10 +185,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_release/publisher_v2/links.json
+++ b/dist/formats/financial_release/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_campaign/publisher/schema.json
+++ b/dist/formats/financial_releases_campaign/publisher/schema.json
@@ -189,10 +189,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_campaign/publisher_v2/links.json
+++ b/dist/formats/financial_releases_campaign/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_geoblocker/publisher/schema.json
+++ b/dist/formats/financial_releases_geoblocker/publisher/schema.json
@@ -173,10 +173,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
+++ b/dist/formats/financial_releases_geoblocker/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -106,9 +106,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_index/publisher/schema.json
+++ b/dist/formats/financial_releases_index/publisher/schema.json
@@ -176,10 +176,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_index/publisher_v2/links.json
+++ b/dist/formats/financial_releases_index/publisher_v2/links.json
@@ -41,10 +41,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/financial_releases_success/publisher/schema.json
+++ b/dist/formats/financial_releases_success/publisher/schema.json
@@ -178,10 +178,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/financial_releases_success/publisher_v2/links.json
+++ b/dist/formats/financial_releases_success/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -109,9 +109,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -315,10 +315,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -44,10 +44,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -107,9 +107,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -233,10 +233,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -42,10 +42,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -280,10 +280,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -270,10 +270,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -104,9 +104,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -187,10 +187,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -39,10 +39,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -112,9 +112,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -216,10 +216,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -51,10 +51,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -106,9 +106,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -266,10 +266,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -41,10 +41,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -106,9 +106,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -219,10 +219,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -41,10 +41,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -265,10 +265,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -122,9 +122,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -309,10 +309,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -58,10 +58,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -115,9 +115,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -245,10 +245,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -50,10 +50,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -106,9 +106,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -219,10 +219,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -43,10 +43,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_homepage/publisher/schema.json
+++ b/dist/formats/service_manual_homepage/publisher/schema.json
@@ -163,10 +163,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -103,9 +103,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -172,10 +172,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -39,10 +39,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -109,9 +109,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -213,10 +213,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -47,10 +47,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -213,10 +213,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -107,9 +107,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "available_translations": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -207,10 +207,6 @@
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
-        },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -42,10 +42,6 @@
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
-        },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -174,10 +174,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -103,9 +103,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -176,10 +176,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -39,10 +39,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -106,9 +106,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -214,10 +214,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -43,10 +43,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -103,9 +103,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -177,10 +177,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -38,10 +38,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -103,9 +103,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -254,10 +254,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -38,10 +38,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -103,9 +103,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -223,10 +223,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -38,10 +38,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -188,10 +188,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -100,9 +100,6 @@
         "parent": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -170,10 +170,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -35,10 +35,6 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
-          "description": "These are for collecting content related to a particular government policy.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/formats/base_links.json
+++ b/formats/base_links.json
@@ -28,10 +28,6 @@
       "$ref": "#/definitions/guid_list",
       "maxItems": 1
     },
-    "policies": {
-      "description": "These are for collecting content related to a particular government policy.",
-      "$ref": "#/definitions/guid_list"
-    },
     "policy_areas": {
       "description": "A largely deprecated tag currently only used to power email alerts.",
       "$ref": "#/definitions/guid_list"

--- a/formats/publication/frontend/examples/political_publication.json
+++ b/formats/publication/frontend/examples/political_publication.json
@@ -61,17 +61,6 @@
         "web_url": "https://www.gov.uk/government/collections/climate-change-agreements-guidance",
         "locale": "en"
       }
-    ],
-    "policies": [
-      {
-        "content_id": "5d2b69f0-7631-11e4-a3cb-005056011aef",
-        "title": "Climate change impact in developing countries",
-        "api_path": "/api/content/government/policies/climate-change-impact-in-developing-countries",
-        "base_path": "/government/policies/climate-change-impact-in-developing-countries",
-        "api_url": "https://www.gov.uk/api/content/government/policies/climate-change-impact-in-developing-countries",
-        "web_url": "https://www.gov.uk/government/policies/climate-change-impact-in-developing-countries",
-        "locale": "en"
-      }
     ]
   },
   "schema_name": "publication",

--- a/formats/working_group/frontend/examples/with_policies.json
+++ b/formats/working_group/frontend/examples/with_policies.json
@@ -12,17 +12,6 @@
     "email": "betterregulation@bis.gsi.gov.uk"
   },
   "links": {
-    "policies": [
-      {
-        "content_id": "ec736c24-aed1-4635-8f3c-389222ca312d",
-        "title": "Transport security",
-        "api_path": "/api/content/government/policies/transport-security",
-        "base_path": "/government/policies/transport-security",
-        "api_url": "https://www.gov.uk/api/content/government/policies/transport-security",
-        "web_url": "https://www.gov.uk/government/policies/transport-security",
-        "locale": "en"
-      }
-    ]
   },
   "schema_name": "working_group",
   "document_type": "working_group"


### PR DESCRIPTION
This link type isn't used anywhere. It was probably introduced to capture a policy - document relationship, but we use `related_policies` for that now.

We've confirmed on staging that there are no links with this link type.

Thanks @boffbowsh for finding it.