### PR TITLE
Don't allow `expanded_links` from frontend

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -138,9 +138,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -138,9 +138,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -136,9 +136,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -135,9 +135,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/financial_release/frontend/schema.json
+++ b/dist/formats/financial_release/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/financial_release/notification/schema.json
+++ b/dist/formats/financial_release/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/financial_releases_campaign/frontend/schema.json
+++ b/dist/formats/financial_releases_campaign/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/financial_releases_campaign/notification/schema.json
+++ b/dist/formats/financial_releases_campaign/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/financial_releases_geoblocker/frontend/schema.json
+++ b/dist/formats/financial_releases_geoblocker/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/financial_releases_geoblocker/notification/schema.json
+++ b/dist/formats/financial_releases_geoblocker/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/financial_releases_index/frontend/schema.json
+++ b/dist/formats/financial_releases_index/frontend/schema.json
@@ -132,9 +132,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/financial_releases_index/notification/schema.json
+++ b/dist/formats/financial_releases_index/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/financial_releases_success/frontend/schema.json
+++ b/dist/formats/financial_releases_success/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/financial_releases_success/notification/schema.json
+++ b/dist/formats/financial_releases_success/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -132,9 +132,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -133,9 +133,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -130,9 +130,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -138,9 +138,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -125,9 +125,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -102,14 +102,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -139,6 +131,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -145,9 +145,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -144,9 +144,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -132,9 +132,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -135,9 +135,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -144,9 +144,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -121,14 +121,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -158,6 +150,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -130,9 +130,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -129,9 +129,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -126,9 +126,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object"
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -103,14 +103,6 @@
     "format": {
       "type": "string"
     },
-    "expanded_links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
-    },
     "updated_at": {
       "type": "string",
       "format": "date-time"
@@ -140,6 +132,14 @@
         "string",
         "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {

--- a/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
+++ b/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
@@ -3,50 +3,6 @@
   "base_path": "/cma-cases/email-signup",
   "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "document_type": "finder_email_signup",
-  "expanded_links": {
-    "related": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/cma-cases",
-        "api_url": "https://www.gov.uk/api/content/cma-cases",
-        "base_path": "/cma-cases",
-        "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
-        "description": "Find reports and updates on current and historical CMA investigations",
-        "locale": "en",
-        "public_updated_at": "2016-06-13T14:30:40.000Z",
-        "title": "Competition and Markets Authority cases",
-        "web_url": "https://www.gov.uk/cma-cases"
-      }
-    ],
-    "organisations": [
-      {
-        "analytics_identifier": "D550",
-        "api_path": "/api/content/government/organisations/competition-and-markets-authority",
-        "api_url": "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
-        "base_path": "/government/organisations/competition-and-markets-authority",
-        "content_id": "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
-        "description": null,
-        "locale": "en",
-        "public_updated_at": "2015-03-10T16:23:14.000Z",
-        "title": "Competition and Markets Authority",
-        "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority"
-      }
-    ],
-    "available_translations": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/cma-cases/email-signup",
-        "api_url": "https://www.gov.uk/api/content/cma-cases/email-signup",
-        "base_path": "/cma-cases/email-signup",
-        "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
-        "description": "You'll get an email each time a case is updated or a new case is published.",
-        "locale": "en",
-        "public_updated_at": "2016-06-13T14:30:40.000Z",
-        "title": "Competition and Markets Authority cases",
-        "web_url": "https://www.gov.uk/cma-cases/email-signup"
-      }
-    ]
-  },
   "first_published_at": "2016-02-29T09:24:10.000+00:00",
   "format": "finder_email_signup",
   "locale": "en",

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -66,7 +66,6 @@ private
     properties = properties.merge(
       "links" => frontend_links,
       "format" => { "type" => "string" },
-      "expanded_links" => { "type" => "object" },
       "updated_at" => updated_at,
       "base_path" => { "$ref" => "#/definitions/absolute_path" }
     )


### PR DESCRIPTION
The content store used to return a `expanded_links` attribute. It doesn't anymore. This commit removes the attribute from the frontend representation. It keeps the `expanded_links` in the notification schema because that's still correct.
