### PR TITLE
Add parent to service manual topic example

### DIFF
--- a/formats/service_manual_topic/frontend/examples/service_manual_topic.json
+++ b/formats/service_manual_topic/frontend/examples/service_manual_topic.json
@@ -10,6 +10,20 @@
   "phase": "alpha",
   "analytics_identifier": null,
   "links": {
+    "parent": [
+      {
+        "content_id": "053d245d-b1cd-4807-9dbc-ce78654121d1",
+        "title": "Service manual",
+        "base_path": "/service-manual",
+        "description": "Helping government teams create and run great digital services that meet the Digital Service Standard.",
+        "api_url": "https://www.gov.uk/api/content/service-manual",
+        "web_url": "https://www.gov.uk/service-manual",
+        "locale": "en",
+        "schema_name": "service_manual_homepage",
+        "document_type": "service_manual_homepage",
+        "analytics_identifier": null
+      }
+    ],
     "content_owners": [
       {
         "content_id": "fb87cca9-311e-4fd3-af42-03616164a407",


### PR DESCRIPTION
Service manual topics will usually have the service manual homepage as a parent, so include it in the example.

The exception to this is when the topic should not be included on the list of topics on the homepage. A current use case for this is the ‘communities’ topic, which is linked separately.