### PR TITLE
Allow format filtering on finder publisher schemas

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -272,6 +272,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "format": {
+              "type": "string"
             }
           }
         },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -277,6 +277,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "format": {
+              "type": "string"
             }
           }
         },

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -189,6 +189,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "format": {
+              "type": "string"
             }
           }
         },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -185,6 +185,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "format": {
+              "type": "string"
             }
           }
         },

--- a/formats/finder/publisher/details.json
+++ b/formats/finder/publisher/details.json
@@ -51,6 +51,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "format": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
We are moving the rendering app of the people page from whitehall to finder-frontend. In doing so, we are writing a JSON file to represent the new finder page. In that schema, we have to describe how are we going to filter the data for the finder page.

In rummager, we need to use the `format` so that the finder page gets populated with people (this is because the `document_type` of a person is an `edition` and the format is `person`).

Here is an example query: https://www.gov.uk/api/search.json?filter_format=person

This PR make is possible to filter data by format in finders.

Trello: https://trello.com/c/reCVyzpg/259-migrate-the-people-page-to-a-finder