### PR TITLE
Fix document collection scoping

### DIFF
--- a/formats/document_collection/frontend/examples/document_collection_with_missing_links_documents.json
+++ b/formats/document_collection/frontend/examples/document_collection_with_missing_links_documents.json
@@ -1,0 +1,65 @@
+{
+  "content_id": "f846586e-c787-4d53-9350-312a1c55b4e3",
+  "base_path": "/government/collections/group-with-all-missing-document-links",
+  "description": "The standards set out a group with documents that are all missing",
+  "public_updated_at": "2016-02-29T09:24:10.000+00:00",
+  "title": "Empty group caused by missing documents",
+  "updated_at": "2016-05-17T11:27:14.152Z",
+  "schema_name": "document_collection",
+  "document_type": "document_collection",
+  "format": "document_collection",
+  "locale": "en",
+  "withdrawn_notice": {},
+  "details": {
+    "collection_groups": [
+      {
+        "title": "All documents missing from links",
+        "body": "<div class=\"govspeak\">\n<p>All the documents in this group are missing from the links</p>\n</div>",
+        "documents": [
+          "796b3d80-a663-4324-8a05-2b81ed216420",
+          "43bb79da-0bb7-4f01-8930-c6db1930479f",
+          "0f7f39de-b5ab-4af6-9b0b-9ff6d1f5b97e"
+        ]
+      }
+    ],
+    "first_public_at": "2016-02-29T09:24:10.000+00:00",
+    "tags": {
+      "browse_pages": [],
+      "topics": [],
+      "policies": []
+    },
+    "government": {
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "current": false
+    },
+    "political": false,
+    "emphasised_organisations": ["d39237a5-678b-4bb5-a372-eb2cb036933d"]
+  },
+  "links": {
+    "documents": [],
+    "organisations": [
+      {
+        "content_id": "d39237a5-678b-4bb5-a372-eb2cb036933d",
+        "title": "Driver and Vehicle Standards Agency",
+        "api_path": "/api/content/government/organisations/driver-and-vehicle-standards-agency",
+        "base_path": "/government/organisations/driver-and-vehicle-standards-agency",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/driver-and-vehicle-standards-agency",
+        "web_url": "https://www.gov.uk/government/organisations/driver-and-vehicle-standards-agency",
+        "locale": "en",
+        "analytics_identifier": "EA570"
+      }
+    ],
+    "policy_areas": [
+      {
+        "content_id": "8034be95-4ac2-4fff-93c5-e7514ed9504a",
+        "title": "Tax and revenue",
+        "api_path": "/api/content/government/topics/tax-and-revenue",
+        "base_path": "/government/topics/tax-and-revenue",
+        "api_url": "https://www.gov.uk/api/content/government/world/topics/tax-and-revenue",
+        "web_url": "https://www.gov.uk/government/world/topics/tax-and-revenue",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/document_collection/frontend/examples/document_collection_with_no_documents.json
+++ b/formats/document_collection/frontend/examples/document_collection_with_no_documents.json
@@ -1,0 +1,61 @@
+{
+  "content_id": "cf95b73b-1d9d-456d-b66e-914d6ce155a7",
+  "base_path": "/government/collections/group-with-no-documents",
+  "description": "The standards set out a group that contains no documents",
+  "public_updated_at": "2016-02-29T09:24:10.000+00:00",
+  "title": "Group containing no documents",
+  "updated_at": "2016-05-17T11:27:14.152Z",
+  "schema_name": "document_collection",
+  "document_type": "document_collection",
+  "format": "document_collection",
+  "locale": "en",
+  "withdrawn_notice": {},
+  "details": {
+    "collection_groups": [
+      {
+        "title": "No documents",
+        "body": "<div class=\"govspeak\">\n<p>The standard sets out what you must be able to do and what you must know and understand to show developed driving competence.</p>\n</div>",
+        "documents": []
+      }
+    ],
+    "first_public_at": "2016-02-29T09:24:10.000+00:00",
+    "tags": {
+      "browse_pages": [],
+      "topics": [],
+      "policies": []
+    },
+    "government": {
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "current": false
+    },
+    "political": false,
+    "emphasised_organisations": ["d39237a5-678b-4bb5-a372-eb2cb036933d"]
+  },
+  "links": {
+    "documents": [],
+    "organisations": [
+      {
+        "content_id": "d39237a5-678b-4bb5-a372-eb2cb036933d",
+        "title": "Driver and Vehicle Standards Agency",
+        "api_path": "/api/content/government/organisations/driver-and-vehicle-standards-agency",
+        "base_path": "/government/organisations/driver-and-vehicle-standards-agency",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/driver-and-vehicle-standards-agency",
+        "web_url": "https://www.gov.uk/government/organisations/driver-and-vehicle-standards-agency",
+        "locale": "en",
+        "analytics_identifier": "EA570"
+      }
+    ],
+    "policy_areas": [
+      {
+        "content_id": "8034be95-4ac2-4fff-93c5-e7514ed9504a",
+        "title": "Tax and revenue",
+        "api_path": "/api/content/government/topics/tax-and-revenue",
+        "base_path": "/government/topics/tax-and-revenue",
+        "api_url": "https://www.gov.uk/api/content/government/world/topics/tax-and-revenue",
+        "web_url": "https://www.gov.uk/government/world/topics/tax-and-revenue",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/document_collection/frontend/examples/document_collection_with_single_missing_document.json
+++ b/formats/document_collection/frontend/examples/document_collection_with_single_missing_document.json
@@ -1,0 +1,79 @@
+{
+  "content_id": "723486cc-1b5a-4ba4-867b-8ef02ae4e30c",
+  "base_path": "/government/collections/group-with-missing-document-link",
+  "description": "The standards set out a group that contains a missing link",
+  "public_updated_at": "2016-02-29T09:24:10.000+00:00",
+  "title": "Group containing a missing document",
+  "updated_at": "2016-05-17T11:27:14.152Z",
+  "schema_name": "document_collection",
+  "document_type": "document_collection",
+  "format": "document_collection",
+  "locale": "en",
+  "withdrawn_notice": {},
+  "details": {
+    "collection_groups": [
+      {
+        "title": "One document missing from links",
+        "body": "<div class=\"govspeak\">\n<p>The standard sets out what you must be able to do and what you must know and understand to show developed driving competence.</p>\n</div>",
+        "documents": [
+          "5e5dc159-7631-11e4-a3cb-005056011aef",
+          "0f7f39de-b5ab-4af6-9b0b-9ff6d1f5b97e"
+        ]
+      }
+    ],
+    "first_public_at": "2016-02-29T09:24:10.000+00:00",
+    "tags": {
+      "browse_pages": [],
+      "topics": [],
+      "policies": []
+    },
+    "government": {
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "current": false
+    },
+    "political": false,
+    "emphasised_organisations": ["d39237a5-678b-4bb5-a372-eb2cb036933d"]
+  },
+  "links": {
+    "documents": [
+      {
+        "content_id": "5e5dc159-7631-11e4-a3cb-005056011aef",
+        "public_updated_at": "2001-07-09T15:00:02+00:00",
+        "title": "National standard for developed driving competence",
+        "api_path": "/api/content/government/publications/national-standard-for-developed-driving-competence",
+        "base_path": "/government/publications/national-standard-for-developed-driving-competence",
+        "description": "What you must be able to do and what you must know and understand to show developed driving competence.",
+        "api_url": "https://www.gov.uk/api/content/government/publications/national-standard-for-developed-driving-competence",
+        "web_url": "https://www.gov.uk/government/publications/national-standard-for-developed-driving-competence",
+        "locale": "en",
+        "schema_name": "placeholder_publication",
+        "document_type": "guidance",
+        "analytics_identifier": null
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "d39237a5-678b-4bb5-a372-eb2cb036933d",
+        "title": "Driver and Vehicle Standards Agency",
+        "api_path": "/api/content/government/organisations/driver-and-vehicle-standards-agency",
+        "base_path": "/government/organisations/driver-and-vehicle-standards-agency",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/driver-and-vehicle-standards-agency",
+        "web_url": "https://www.gov.uk/government/organisations/driver-and-vehicle-standards-agency",
+        "locale": "en",
+        "analytics_identifier": "EA570"
+      }
+    ],
+    "policy_areas": [
+      {
+        "content_id": "8034be95-4ac2-4fff-93c5-e7514ed9504a",
+        "title": "Tax and revenue",
+        "api_path": "/api/content/government/topics/tax-and-revenue",
+        "base_path": "/government/topics/tax-and-revenue",
+        "api_url": "https://www.gov.uk/api/content/government/world/topics/tax-and-revenue",
+        "web_url": "https://www.gov.uk/government/world/topics/tax-and-revenue",
+        "locale": "en"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add some examples to Document Collection frontend examples. This is needed so we can add  functionality to government-frontend to replicate existing functionality in Whitehall.

Mobbed on with @andrewgarner @bevanloon @gpeng @mgrassotti @Rosa-Fox 