### PR TITLE
Remove document collection from publisher schemas

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -91,9 +91,6 @@
         "worldwide_organisations": {
           "$ref": "#/definitions/frontend_links"
         },
-        "document_collections": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -122,6 +119,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -233,9 +233,6 @@
         "worldwide_organisations": {
           "$ref": "#/definitions/guid_list"
         },
-        "document_collections": {
-          "$ref": "#/definitions/guid_list"
-        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -19,9 +19,6 @@
         "worldwide_organisations": {
           "$ref": "#/definitions/guid_list"
         },
-        "document_collections": {
-          "$ref": "#/definitions/guid_list"
-        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -82,9 +82,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "document_collections": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "related_guides": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -122,6 +119,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -223,9 +223,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "document_collections": {
-          "$ref": "#/definitions/guid_list"
-        },
         "related_guides": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -10,9 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "document_collections": {
-          "$ref": "#/definitions/guid_list"
-        },
         "related_guides": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -121,6 +121,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -120,6 +120,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -118,6 +118,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -115,6 +115,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -123,6 +123,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -130,6 +130,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -82,9 +82,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "document_collections": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "ministers": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -128,6 +125,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -211,9 +211,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "document_collections": {
-          "$ref": "#/definitions/guid_list"
-        },
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -10,9 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "document_collections": {
-          "$ref": "#/definitions/guid_list"
-        },
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -120,6 +120,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -115,6 +115,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -111,6 +111,9 @@
         },
         "policies": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -11,9 +11,6 @@
     },
     "worldwide_organisations": {
       "$ref": "#/definitions/guid_list"
-    },
-    "document_collections": {
-      "$ref": "#/definitions/guid_list"
     }
   }
 }

--- a/formats/case_study/publisher_v2/examples/case_study_links.json
+++ b/formats/case_study/publisher_v2/examples/case_study_links.json
@@ -9,9 +9,6 @@
     ],
     "worldwide_organisations": [
       "f1ec569a-3471-4de0-947c-a4f3bcccb983"
-    ],
-    "document_collections": [
-      "def40c5f-52d0-4dca-80ea-b0da5caeebcd"
     ]
   },
   "previous_version": "2"

--- a/formats/detailed_guide/publisher/links.json
+++ b/formats/detailed_guide/publisher/links.json
@@ -3,9 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "document_collections": {
-      "$ref": "#/definitions/guid_list"
-    },
     "related_guides": {
       "$ref": "#/definitions/guid_list"
     },

--- a/formats/publication/publisher/links.json
+++ b/formats/publication/publisher/links.json
@@ -3,9 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "document_collections": {
-      "$ref": "#/definitions/guid_list"
-    },
     "ministers": {
       "$ref": "#/definitions/guid_list"
     },

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -32,6 +32,10 @@ class GovukContentSchemas::FrontendSchemaGenerator
     # Working groups have a `policies` link type containing the policies it is
     # tagged to.
     "policies",
+
+    # Content items that are members of a collection will have a `document_collections`
+    # link type
+    "document_collections",
   ].freeze
 
   CHANGE_HISTORY_REQUIRED = ['specialist_document'].freeze


### PR DESCRIPTION
`document_collections` is now added to the content store payload by Publishing API based on `documents` links sent with the `DocumentCollection` format so is no longer required.

/cc @dougdroper 