### PR TITLE
Exclude more link types that are automatically generated

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -123,6 +123,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -123,6 +123,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -124,6 +124,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -123,6 +123,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -120,6 +120,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -121,6 +121,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -118,6 +118,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -126,6 +126,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -133,6 +133,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -129,6 +129,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -120,6 +120,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -123,6 +123,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -118,6 +118,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -117,6 +117,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -114,6 +114,9 @@
         },
         "document_collections": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -36,6 +36,10 @@ class GovukContentSchemas::FrontendSchemaGenerator
     # Content items that are members of a collection will have a `document_collections`
     # link type
     "document_collections",
+
+    # Content items that are linked to with a `parent_taxon` link type will automatically
+    # have a `child_taxon` link type with those items.
+    "child_taxons",
   ].freeze
 
   CHANGE_HISTORY_REQUIRED = ['specialist_document'].freeze


### PR DESCRIPTION
`child_taxons` are automatically generated in the publishing API.

This excludes them from the publishing schemas, but allows them in
the frontend schemas.