### PR TITLE
Remove required items for links schemas 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ begin
 rescue LoadError
 end
 
-task build: [:validate_source_schemas, :clean, :combine_schemas, :validate_dist_schemas, :validate_uniqueness_of_frontend_example_base_paths, :validate_examples]
+task build: [:validate_source_schemas, :clean, :combine_schemas, :validate_dist_schemas, :validate_uniqueness_of_frontend_example_base_paths, :validate_links, :validate_examples]
 
 desc "creates the folders and files for adding a new format"
 task :new_format, [:format_name] do |_task, args|

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -81,10 +81,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "documents",
-        "organisations"
-      ],
       "properties": {
         "documents": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -228,10 +228,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "documents",
-        "organisations"
-      ],
       "properties": {
         "documents": {
           "description": "An unordered list of all documents in this collection",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -9,10 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "documents",
-        "organisations"
-      ],
       "properties": {
         "documents": {
           "description": "An unordered list of all documents in this collection",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -81,9 +81,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "field_of_operation"
-      ],
       "properties": {
         "field_of_operation": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -167,9 +167,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "field_of_operation"
-      ],
       "properties": {
         "field_of_operation": {
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -9,9 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "field_of_operation"
-      ],
       "properties": {
         "field_of_operation": {
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -81,10 +81,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "related",
-        "organisations"
-      ],
       "properties": {
         "related": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -206,10 +206,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "related",
-        "organisations"
-      ],
       "properties": {
         "related": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -9,10 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "related",
-        "organisations"
-      ],
       "properties": {
         "related": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -81,10 +81,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "parent",
-        "organisations"
-      ],
       "properties": {
         "taxons": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -163,10 +163,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "parent",
-        "organisations"
-      ],
       "properties": {
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -9,10 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "parent",
-        "organisations"
-      ],
       "properties": {
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -81,10 +81,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "organisations",
-        "related"
-      ],
       "properties": {
         "people": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -266,10 +266,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "organisations",
-        "related"
-      ],
       "properties": {
         "people": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -9,10 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "organisations",
-        "related"
-      ],
       "properties": {
         "people": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -81,10 +81,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "organisations",
-        "policy_areas"
-      ],
       "properties": {
         "organisations": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -180,10 +180,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "organisations",
-        "policy_areas"
-      ],
       "properties": {
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -9,10 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "organisations",
-        "policy_areas"
-      ],
       "properties": {
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -81,9 +81,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "parent"
-      ],
       "properties": {
         "taxons": {
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -154,9 +154,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "parent"
-      ],
       "properties": {
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -9,9 +9,6 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "parent"
-      ],
       "properties": {
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/formats/document_collection/publisher/links.json
+++ b/formats/document_collection/publisher/links.json
@@ -2,10 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "documents",
-    "organisations"
-  ],
   "properties": {
     "documents": {
       "description": "An unordered list of all documents in this collection",

--- a/formats/fatality_notice/publisher/links.json
+++ b/formats/fatality_notice/publisher/links.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "field_of_operation"
-  ],
   "properties": {
     "field_of_operation": {
       "$ref": "#/definitions/guid_list",

--- a/formats/finder_email_signup/publisher/links.json
+++ b/formats/finder_email_signup/publisher/links.json
@@ -2,10 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "related",
-    "organisations"
-  ],
   "properties": {
     "related": {
       "$ref": "#/definitions/guid_list"

--- a/formats/html_publication/publisher/links.json
+++ b/formats/html_publication/publisher/links.json
@@ -2,9 +2,5 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "parent",
-    "organisations"
-  ],
   "properties": {}
 }

--- a/formats/policy/publisher/links.json
+++ b/formats/policy/publisher/links.json
@@ -2,10 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "organisations",
-    "related"
-  ],
   "properties": {
     "people": {
       "$ref": "#/definitions/guid_list"

--- a/formats/statistics_announcement/publisher/links.json
+++ b/formats/statistics_announcement/publisher/links.json
@@ -2,10 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "organisations",
-    "policy_areas"
-  ],
   "properties": {
     "organisations": {
       "$ref": "#/definitions/guid_list"

--- a/formats/topical_event_about_page/publisher/links.json
+++ b/formats/topical_event_about_page/publisher/links.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "parent"
-  ],
   "properties": {
   }
 }

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -57,3 +57,15 @@ task :validate_uniqueness_of_frontend_example_base_paths, :files do |_, args|
     abort
   end
 end
+
+task :validate_links, :files do |_, args|
+  link_schemas = args[:files] || Rake::FileList.new("formats/*/*/links.json")
+  link_schemas.each do |filename|
+    schema = JSON.parse(File.read(filename))
+    if schema["required"]
+      $stderr.puts "ERROR: #{filename} has required links (#{schema["required"].inspect})"
+      $stderr.puts "This is disallowed because the publishing-api wouldn't be able to validate partial payloads when sending a PATCH links request."
+      abort
+    end
+  end
+end


### PR DESCRIPTION
Because we use "patch" to set links it's not possible to use `required` links. If we would, we'd never be able to validate payload to the publishing-api (like https://github.com/alphagov/publishing-api/pull/597).

cc @dougdroper 