### PR TITLE
Add attachment Statistical Data Set example

### DIFF
--- a/formats/statistical_data_set/frontend/examples/statistical_data_set_with_block_attachments.json
+++ b/formats/statistical_data_set/frontend/examples/statistical_data_set_with_block_attachments.json
@@ -1,0 +1,204 @@
+{
+  "base_path": "/government/statistical-data-sets/fe-data-library-apprenticeship-vacancies",
+  "content_id": "602ccb2f-7631-11e4-a3cb-005056011aef",
+  "title": "FE data library: apprenticeship vacancies",
+  "description": "Information on apprenticeship vacancies.",
+  "format": "statistical_data_set",
+  "locale": "en",
+  "updated_at": "2016-11-17T10:29:08.552Z",
+  "public_updated_at": "2016-11-09T09:24:10.000+00:00",
+  "schema_name": "statistical_data_set",
+  "document_type": "statistical_data_set",
+  "details": {
+    "body": "<div class=\"govspeak\"><p>This statistical data set provides information through a number of reports on the number of apprenticeship vacancies and traineeship opportunities for 2008/09 to 2014/15 year-to-date.</p>\n\n<p>Applications stated are for those made online through Find An Apprentice, and do not include those made offline directly to employers.</p>\n\n<p>‘Recruit an apprentice’, will replace Apprenticeship vacancies (Av) in August with the following changes:</p>\n\n<ul>\n  <li>recruitment agents will not be able to use the new service - the small number of providers that use recruitment agents will therefore have to manage their own vacancies</li>\n  <li>subcontractors will no longer need lead provider authorisation to post and manage vacancies</li>\n</ul>\n\n<section class=\"attachment embedded\" id=\"attachment_1718807\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/552946/AV_Number_of_Vacancies_Posted_Sep16.xls\"><img alt=\"\" src=\"https://assets.publishing.service.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png\"></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a aria-describedby=\"attachment-1718807-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/552946/AV_Number_of_Vacancies_Posted_Sep16.xls\">Number of vacancies posted:  September 2016</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">50.5KB</span>\n    </p>\n\n\n      <div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-1718807-accessibility-help\">\n        <h2>This file may not be suitable for users of assistive technology.\n          <a class=\"toggler\" href=\"#attachment-1718807-accessibility-request\" data-controls=\"attachment-1718807-accessibility-request\" data-expanded=\"false\">Request an accessible format.</a>\n        </h2>\n        <p id=\"attachment-1718807-accessibility-request\" class=\"js-hidden\">\n          If you use assistive technology (eg a screen reader) and need a\nversion of this document in a more accessible format, please email <a href=\"mailto:?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Number%20of%20vacancies%20posted%3A%20%20September%202016%0A%20%20Original%20format%3A%20xls%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Number%20of%20vacancies%20posted%3A%20%20September%202016%27%20in%20an%20alternative%20format\"></a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n        </p>\n      </div>\n  </div>\n</section>\n\n<section class=\"attachment embedded\" id=\"attachment_1718808\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/552947/AV_NumberofapplicationsbyAgeGenderEthnicitySSAProgrammeLevel_Sep16.xls\"><img alt=\"\" src=\"https://assets.publishing.service.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png\"></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a aria-describedby=\"attachment-1718808-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/552947/AV_NumberofapplicationsbyAgeGenderEthnicitySSAProgrammeLevel_Sep16.xls\">Number of applications by age, gender, ethnicity or ssa (T1) or programme level: September 2016</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">85.5KB</span>\n    </p>\n\n\n      <div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-1718808-accessibility-help\">\n        <h2>This file may not be suitable for users of assistive technology.\n          <a class=\"toggler\" href=\"#attachment-1718808-accessibility-request\" data-controls=\"attachment-1718808-accessibility-request\" data-expanded=\"false\">Request an accessible format.</a>\n        </h2>\n        <p id=\"attachment-1718808-accessibility-request\" class=\"js-hidden\">\n          If you use assistive technology (eg a screen reader) and need a\nversion of this document in a more accessible format, please email <a href=\"mailto:?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Number%20of%20applications%20by%20age%2C%20gender%2C%20ethnicity%20or%20ssa%20%28T1%29%20or%20programme%20level%3A%20September%202016%0A%20%20Original%20format%3A%20xls%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Number%20of%20applications%20by%20age%2C%20gender%2C%20ethnicity%20or%20ssa%20%28T1%29%20or%20programme%20level%3A%20September%202016%27%20in%20an%20alternative%20format\"></a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n        </p>\n      </div>\n  </div>\n</section>\n\n<section class=\"attachment embedded\" id=\"attachment_1718809\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/552948/AV_Number_of_Live_Vacancies_Sep16.xls\"><img alt=\"\" src=\"https://assets.publishing.service.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png\"></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a aria-describedby=\"attachment-1718809-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/552948/AV_Number_of_Live_Vacancies_Sep16.xls\">Number of live vacancies: September 2016</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">40KB</span>\n    </p>\n\n\n      <div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-1718809-accessibility-help\">\n        <h2>This file may not be suitable for users of assistive technology.\n          <a class=\"toggler\" href=\"#attachment-1718809-accessibility-request\" data-controls=\"attachment-1718809-accessibility-request\" data-expanded=\"false\">Request an accessible format.</a>\n        </h2>\n        <p id=\"attachment-1718809-accessibility-request\" class=\"js-hidden\">\n          If you use assistive technology (eg a screen reader) and need a\nversion of this document in a more accessible format, please email <a href=\"mailto:?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Number%20of%20live%20vacancies%3A%20September%202016%0A%20%20Original%20format%3A%20xls%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Number%20of%20live%20vacancies%3A%20September%202016%27%20in%20an%20alternative%20format\"></a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n        </p>\n      </div>\n  </div>\n</section>\n\n<section class=\"attachment embedded\" id=\"attachment_1718810\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/552854/AV_3_CANDIDATES_WITH_APPLICATIONS_AREA_Sep16.xls\"><img alt=\"\" src=\"https://assets.publishing.service.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png\"></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a aria-describedby=\"attachment-1718810-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/552854/AV_3_CANDIDATES_WITH_APPLICATIONS_AREA_Sep16.xls\">Number of applications by area and age: September 2016</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">55.9KB</span>\n    </p>\n\n\n      <div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-1718810-accessibility-help\">\n        <h2>This file may not be suitable for users of assistive technology.\n          <a class=\"toggler\" href=\"#attachment-1718810-accessibility-request\" data-controls=\"attachment-1718810-accessibility-request\" data-expanded=\"false\">Request an accessible format.</a>\n        </h2>\n        <p id=\"attachment-1718810-accessibility-request\" class=\"js-hidden\">\n          If you use assistive technology (eg a screen reader) and need a\nversion of this document in a more accessible format, please email <a href=\"mailto:?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Number%20of%20applications%20by%20area%20and%20age%3A%20September%202016%0A%20%20Original%20format%3A%20xls%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Number%20of%20applications%20by%20area%20and%20age%3A%20September%202016%27%20in%20an%20alternative%20format\"></a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n        </p>\n      </div>\n  </div>\n</section>\n\n<section class=\"attachment embedded\" id=\"attachment_1718811\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/552856/AV_4_NUMBER_OF_APPLICATIONS_MADE_Sep16.xls\"><img alt=\"\" src=\"https://assets.publishing.service.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png\"></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a aria-describedby=\"attachment-1718811-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/552856/AV_4_NUMBER_OF_APPLICATIONS_MADE_Sep16.xls\">Number of applications made by month and age: September 2016</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">39.9KB</span>\n    </p>\n\n\n      <div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-1718811-accessibility-help\">\n        <h2>This file may not be suitable for users of assistive technology.\n          <a class=\"toggler\" href=\"#attachment-1718811-accessibility-request\" data-controls=\"attachment-1718811-accessibility-request\" data-expanded=\"false\">Request an accessible format.</a>\n        </h2>\n        <p id=\"attachment-1718811-accessibility-request\" class=\"js-hidden\">\n          If you use assistive technology (eg a screen reader) and need a\nversion of this document in a more accessible format, please email <a href=\"mailto:?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Number%20of%20applications%20made%20by%20month%20and%20age%3A%20September%202016%0A%20%20Original%20format%3A%20xls%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Number%20of%20applications%20made%20by%20month%20and%20age%3A%20September%202016%27%20in%20an%20alternative%20format\"></a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n        </p>\n      </div>\n  </div>\n</section>\n\n<section class=\"attachment embedded\" id=\"attachment_1718812\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/552949/AV_Number_of_Activated_Candidates_by_Age_at_Registration_Sep16.xls\"><img alt=\"\" src=\"https://assets.publishing.service.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png\"></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a aria-describedby=\"attachment-1718812-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/552949/AV_Number_of_Activated_Candidates_by_Age_at_Registration_Sep16.xls\">Age at registration: September 2016</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">44.5KB</span>\n    </p>\n\n\n      <div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-1718812-accessibility-help\">\n        <h2>This file may not be suitable for users of assistive technology.\n          <a class=\"toggler\" href=\"#attachment-1718812-accessibility-request\" data-controls=\"attachment-1718812-accessibility-request\" data-expanded=\"false\">Request an accessible format.</a>\n        </h2>\n        <p id=\"attachment-1718812-accessibility-request\" class=\"js-hidden\">\n          If you use assistive technology (eg a screen reader) and need a\nversion of this document in a more accessible format, please email <a href=\"mailto:?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Age%20at%20registration%3A%20September%202016%0A%20%20Original%20format%3A%20xls%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Age%20at%20registration%3A%20September%202016%27%20in%20an%20alternative%20format\"></a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n        </p>\n      </div>\n  </div>\n</section>\n\n<section class=\"attachment embedded\" id=\"attachment_1718813\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/552858/AV_8_EMPLOYERS_Sep16.xls\"><img alt=\"\" src=\"https://assets.publishing.service.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png\"></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a aria-describedby=\"attachment-1718813-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/552858/AV_8_EMPLOYERS_Sep16.xls\">Employers posting vacancies by month: September 2016</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">39.9KB</span>\n    </p>\n\n\n      <div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-1718813-accessibility-help\">\n        <h2>This file may not be suitable for users of assistive technology.\n          <a class=\"toggler\" href=\"#attachment-1718813-accessibility-request\" data-controls=\"attachment-1718813-accessibility-request\" data-expanded=\"false\">Request an accessible format.</a>\n        </h2>\n        <p id=\"attachment-1718813-accessibility-request\" class=\"js-hidden\">\n          If you use assistive technology (eg a screen reader) and need a\nversion of this document in a more accessible format, please email <a href=\"mailto:?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Employers%20posting%20vacancies%20by%20month%3A%20September%202016%0A%20%20Original%20format%3A%20xls%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Employers%20posting%20vacancies%20by%20month%3A%20September%202016%27%20in%20an%20alternative%20format\"></a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n        </p>\n      </div>\n  </div>\n</section>\n\n<section class=\"attachment embedded\" id=\"attachment_1718814\">\n  <div class=\"attachment-thumb\">\n      <a aria-hidden=\"true\" class=\"thumbnail\" href=\"/government/uploads/system/uploads/attachment_data/file/552861/AV_7_VACANCIES_Sep16.xls\"><img alt=\"\" src=\"https://assets.publishing.service.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png\"></a>\n  </div>\n  <div class=\"attachment-details\">\n    <h2 class=\"title\"><a aria-describedby=\"attachment-1718814-accessibility-help\" href=\"/government/uploads/system/uploads/attachment_data/file/552861/AV_7_VACANCIES_Sep16.xls\">Vacancies posted by area: September 2016</a></h2>\n    <p class=\"metadata\">\n        <span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">39.9KB</span>\n    </p>\n\n\n      <div data-module=\"toggle\" class=\"accessibility-warning\" id=\"attachment-1718814-accessibility-help\">\n        <h2>This file may not be suitable for users of assistive technology.\n          <a class=\"toggler\" href=\"#attachment-1718814-accessibility-request\" data-controls=\"attachment-1718814-accessibility-request\" data-expanded=\"false\">Request an accessible format.</a>\n        </h2>\n        <p id=\"attachment-1718814-accessibility-request\" class=\"js-hidden\">\n          If you use assistive technology (eg a screen reader) and need a\nversion of this document in a more accessible format, please email <a href=\"mailto:?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Vacancies%20posted%20by%20area%3A%20September%202016%0A%20%20Original%20format%3A%20xls%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Vacancies%20posted%20by%20area%3A%20September%202016%27%20in%20an%20alternative%20format\"></a>.\nPlease tell us what format you need. It will help us if you say what assistive technology you use.\n\n        </p>\n      </div>\n  </div>\n</section>\n\n</div>",
+    "first_public_at": "2014-11-07T09:59:00.000+00:00",
+    "government": {
+      "current": false,
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government"
+    },
+    "political": false,
+    "tags": {
+      "browse_pages": [],
+      "policies": [],
+      "topics": []
+    },
+    "change_history": [
+      {
+        "public_timestamp": "2016-11-09T03:14:00.000+00:00",
+        "note": "November 2016 apprenticeship vacancy files uploaded on 9 November 2016."
+      },
+      {
+        "public_timestamp": "2016-10-28T09:19:00.000+00:00",
+        "note": "October 2016 apprenticeship vacancy files uploaded on 28 October 2016."
+      },
+      {
+        "public_timestamp": "2016-09-14T10:55:39.000+01:00",
+        "note": "Apprenticeship vacancy files for September 2016 uploaded on 14 September 2016."
+      },
+      {
+        "public_timestamp": "2016-08-08T12:52:21.000+01:00",
+        "note": "August 2016 apprenticeship vacancy files uploaded on 04 August 2016."
+      },
+      {
+        "public_timestamp": "2016-07-05T15:09:36.000+01:00",
+        "note": "July 2016 apprenticeship vacancy files uploaded on 5 July 2016."
+      },
+      {
+        "public_timestamp": "2016-06-03T09:52:28.000+01:00",
+        "note": "Apprenticeship vacancy files for June 2016 uploaded on 3 June 2016."
+      },
+      {
+        "public_timestamp": "2016-05-06T15:51:57.000+01:00",
+        "note": "Files updated for May 2016 on 6 May 2016."
+      },
+      {
+        "public_timestamp": "2016-04-05T07:52:05.000+01:00",
+        "note": "All eight files on this page update on 5 April 2016."
+      },
+      {
+        "public_timestamp": "2016-03-04T13:25:39.000+00:00",
+        "note": "Apprenticeship vacancies data for March 2016 uploaded on 4 March 2016."
+      },
+      {
+        "public_timestamp": "2016-02-11T07:16:01.000+00:00",
+        "note": "Apprenticeship vacancy files updated on 9 February 2016. Four new files added to the page:\r\n* Number of applications made by area and age\r\n* Number of applications made by month and age\r\n* Employers posting vacancies by month\r\n* Vacancies posted by area\r\n "
+      },
+      {
+        "public_timestamp": "2016-01-05T13:25:02.000+00:00",
+        "note": "Four new files uploaded on 05 January 2016:\r\n * Apprenticeship vacancy report - number of vacancies posted: January 2016\r\n * Apprenticeship vacancy report - number of applications by age, gender, ethnicity or ssa (T1) or programme level: January 2016\r\n * Number of live vacancies posted by sector subject area (T1) or programme level: January 2016\r\n * Apprenticeship vacancy report - age at registration: January 2016 "
+      },
+      {
+        "public_timestamp": "2015-12-02T13:16:29.000+00:00",
+        "note": "Four new versions of apprenticeship vacancy files uploaded on 2 December 2015."
+      },
+      {
+        "public_timestamp": "2015-11-03T08:33:26.000+00:00",
+        "note": "Four new files uploaded on 03 November 2015:\r\n* Age at Registration\r\n* Number of Live Vacancies Posted by Sector Subject Area and Programme Level\r\n* Number of applications by Age Gender Ethnicity SSA and Programme Level\r\n* Number of Vacancies Posted"
+      },
+      {
+        "public_timestamp": "2015-10-08T11:20:19.000+01:00",
+        "note": "Four new apprenticeship vacancy reports uploaded on 08 October 2015."
+      },
+      {
+        "public_timestamp": "2015-09-03T09:41:15.000+01:00",
+        "note": "New version of Apprenticeship Vacancy reports uploaded on 3 September 2015."
+      },
+      {
+        "public_timestamp": "2015-08-11T07:15:35.000+01:00",
+        "note": "New versions on three files uploaded on 11 August 2015:\r\n* Apprenticeship vacancy report - number of vacancies posted: August 2015\r\n* Apprenticeship vacancy report - number of applications by age, gender, ethnicity or ssa (T1) or programme level: August 2015\r\n* Number of live vacancies posted by sector subject area (T1) or programme level: August 2015"
+      },
+      {
+        "public_timestamp": "2015-07-02T14:29:16.000+01:00",
+        "note": "11 new apprenticeship vacancy files uploaded on 02 July 2015."
+      },
+      {
+        "public_timestamp": "2015-06-08T08:02:29.000+01:00",
+        "note": "11 apprenticeship vacancy files uploaded on 8 June 2015."
+      },
+      {
+        "public_timestamp": "2015-06-04T08:12:58.000+01:00",
+        "note": "Published: updated data in June 2015."
+      },
+      {
+        "public_timestamp": "2015-05-07T10:44:10.000+01:00",
+        "note": "Four file updated on 7 May 2015:\r\n* Apprenticeship age at registration\r\n* Apprenticeship number of vacancies posted\r\n* Apprenticeship number of applications by age, gender, ethnicity or SSA or programme level\r\n* Number of live vacancies"
+      },
+      {
+        "public_timestamp": "2015-04-07T11:04:44.000+01:00",
+        "note": "A further 11 April vacancy reports uploaded 7 April 2015."
+      },
+      {
+        "public_timestamp": "2015-04-07T10:34:53.000+01:00",
+        "note": "Four April apprenticeship vacancy reports uploaded on 7 April 2015"
+      },
+      {
+        "public_timestamp": "2015-03-11T14:26:31.000+00:00",
+        "note": "All 15 files on this page updated on 11 March 2015."
+      },
+      {
+        "public_timestamp": "2015-03-11T09:37:55.000+00:00",
+        "note": "New March vacancy files - age and gender, age at registration, number of vacancies posted, number of live vacancies - uploaded on 11 March 2015."
+      },
+      {
+        "public_timestamp": "2015-02-03T14:58:39.000+00:00",
+        "note": "Four new apprenticeship vacancy reports uploaded on 3 February 2015."
+      },
+      {
+        "public_timestamp": "2015-02-02T10:11:25.000+00:00",
+        "note": "11 new Apprenticeship Vacancy February 2015 file uploaded on 2 February 2015."
+      },
+      {
+        "public_timestamp": "2015-01-14T08:30:33.000+00:00",
+        "note": "11 new apprenticeship vacancy January 2015 files uploaded on 14 January 2015."
+      },
+      {
+        "public_timestamp": "2015-01-07T14:53:03.000+00:00",
+        "note": "Four new files dated January 2015 uploaded on 7 January 2015."
+      },
+      {
+        "public_timestamp": "2014-12-10T09:07:38.000+00:00",
+        "note": "Eleven new apprenticeship vacancy reports uploaded 10 December 2014."
+      },
+      {
+        "public_timestamp": "2014-12-03T13:10:02.000+00:00",
+        "note": "New files uploaded 3 December 2014:\r\nApprenticeship Vacancy - Age at Registration: December 2014, Apprenticeship Vacancy Report - Number of Vacancies Posted: December 2014, Apprenticeship Vacancy Report - Number of applications by Age, Gender, Ethnicity or SSA (T1) or Programme Level December 2014,\r\nNumber of Live Vacancies Posted by Sector Subject Area (T1) or Programme Level: December 2014."
+      },
+      {
+        "public_timestamp": "2014-11-07T10:52:50.000+00:00",
+        "note": "Apprenticeship vacancy tables for November 2014 uploaded on 7 November."
+      },
+      {
+        "public_timestamp": "2014-11-07T09:59:00.000+00:00",
+        "note": "First published."
+      }
+    ],
+    "emphasised_organisations": ["4c717efc-f47b-478e-a76d-ce1ae0af1946"]
+  },
+  "links": {
+    "organisations": [
+      {
+        "analytics_identifier": "D3",
+        "api_path": "/api/content/government/organisations/department-for-business-innovation-skills",
+        "base_path": "/government/organisations/department-for-business-innovation-skills",
+        "content_id": "569a9ee5-c195-4b7f-b9dc-edc17a09113f",
+        "locale": "en",
+        "title": "Department for Business, Innovation & Skills",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-business-innovations-skills",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-business-innovations-skills"
+      },
+      {
+        "analytics_identifier": "EA86",
+        "api_path": "/api/content/government/organisations/skills-funding-agency",
+        "base_path": "/government/organisations/skills-funding-agency",
+        "content_id": "3e5a6924-b369-4eb3-8b06-3c0814701de4",
+        "locale": "en",
+        "title": "Skills Funding Agency",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/skills-funding-agency",
+        "web_url": "https://www.gov.uk/government/organisations/skills-funding-agency"
+        }
+    ],
+    "document_collections": [
+      {
+        "content_id": "5f1ad52e-7631-11e4-a3cb-005056011aef",
+        "description": "Data and information on learners, learning programmes and learner achivement.",
+        "title": "FE data library",
+        "api_path": "/api/content/government/collections/transport-statistics-great-britain",
+        "base_path": "/government/collections/fe-data-library",
+        "api_url": "https://www.gov.uk/api/content/government/collections/fe-data-library",
+        "web_url": "https://www.gov.uk/government/collections/fe-data-library",
+        "locale": "en"
+      },
+      {
+        "analytics_identifier": null,
+        "content_id": "5f47b104-7631-11e4-a3cb-005056011aef",
+        "document_type": "document_collection",
+        "public_updated_at": "2015-03-25T11:56:25Z",
+        "title": "Further education and skills: official statistics",
+        "base_path": "/government/collections/further-education-and-skills-official-statistics",
+        "api_path": "/api/content/government/collections/further-education-and-skills-official-statistics",
+        "locale": "en"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
[Trello](https://trello.com/c/3OZ36DPk/511-statistical-dataset-migration-basic-content-schema-examples-and-front-end-work-medium)

This adds an example that includes normal attachments as opposed to the
inline attachments that were included in previous examples.

Paired with @Rosa-Fox 