### PR TITLE
Add schema & examples for Service Standard Reports

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -136,6 +136,7 @@
         "maib_report",
         "medical_safety_alert",
         "raib_report",
+        "service_standard_report",
         "tax_tribunal_decision",
         "utaac_decision",
         "vehicle_recalls_and_faults_alert"
@@ -651,6 +652,9 @@
         },
         {
           "$ref": "#/definitions/raib_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/service_standard_report_metadata"
         },
         {
           "$ref": "#/definitions/tax_tribunal_decision_metadata"
@@ -1650,6 +1654,15 @@
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "service_standard_report_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
         }
       }
     },

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -107,6 +107,7 @@
         "maib_report",
         "medical_safety_alert",
         "raib_report",
+        "service_standard_report",
         "tax_tribunal_decision",
         "utaac_decision",
         "vehicle_recalls_and_faults_alert"
@@ -656,6 +657,9 @@
         },
         {
           "$ref": "#/definitions/raib_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/service_standard_report_metadata"
         },
         {
           "$ref": "#/definitions/tax_tribunal_decision_metadata"
@@ -1655,6 +1659,15 @@
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "service_standard_report_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -140,6 +140,7 @@
         "maib_report",
         "medical_safety_alert",
         "raib_report",
+        "service_standard_report",
         "tax_tribunal_decision",
         "utaac_decision",
         "vehicle_recalls_and_faults_alert"
@@ -608,6 +609,9 @@
         },
         {
           "$ref": "#/definitions/raib_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/service_standard_report_metadata"
         },
         {
           "$ref": "#/definitions/tax_tribunal_decision_metadata"
@@ -1607,6 +1611,15 @@
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "service_standard_report_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -553,6 +553,9 @@
           "$ref": "#/definitions/raib_report_metadata"
         },
         {
+          "$ref": "#/definitions/service_standard_report_metadata"
+        },
+        {
           "$ref": "#/definitions/tax_tribunal_decision_metadata"
         },
         {
@@ -1550,6 +1553,15 @@
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "service_standard_report_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
         }
       }
     },

--- a/formats/finder/frontend/examples/service-standard-reports.json
+++ b/formats/finder/frontend/examples/service-standard-reports.json
@@ -1,0 +1,39 @@
+{
+  "content_id": "da025a9f-8293-4fef-869c-12445d364696",
+  "base_path": "/service-standard-reports",
+  "title": "Service Standard Reports",
+  "description": "A list of service standard reports",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "updated_at": "2015-07-21T12:45:18.202Z",
+  "public_updated_at": "2015-04-29T09:22:41.000+00:00",
+  "details": {
+    "facets": [
+
+    ],
+    "document_noun": "report",
+    "filter": {
+      "document_type": "service_standard_report"
+    },
+    "format_name": "Service Standard Report",
+    "show_summaries": true
+  },
+  "links": {
+    "available_translations": [
+      {
+        "content_id": "da025a9f-8293-4fef-869c-12445d364696",
+        "title": "Service Standard Reports",
+        "api_path": "/api/content/service-standard-reports",
+        "base_path": "/service-standard-reports",
+        "description": "A list of service standard reports",
+        "api_url": "https://www.gov.uk/api/content/service-standard-reports",
+        "web_url": "https://www.gov.uk/service-assessments",
+        "locale": "en"
+      }
+    ]
+  },
+  "schema_name": "finder",
+  "document_type": "finder"
+}

--- a/formats/specialist_document/frontend/examples/service-standard-report.json
+++ b/formats/specialist_document/frontend/examples/service-standard-report.json
@@ -1,0 +1,28 @@
+{
+  "content_id": "fb81a47b-7c89-4280-b6c7-b6fa258b1931",
+  "public_updated_at": "2015-07-09T08:17:10+00:00",
+  "locale": "en",
+  "details": {
+    "body": "<div class=\"entry-content\">\n\n<h2>Assessment Report</h2> \n<p>The Digital National Insurance &amp; State Pension service has been reviewed against the 26 points of the Service Standard at the end of alpha development.</p> \n<h2>Digital by Default Service Standard criteria</h2> \n<table> \n<tbody> \n<tr> \n<td><strong>Criteria</strong></td> \n<td><strong>Passed</strong></td> \n<td><strong>Criteria</strong></td> \n<td><strong>Passed</strong></td> \n</tr> \n<tr> \n<td>1</td> \n<td>Yes</td> \n<td>2</td> \n<td>Yes</td> \n</tr> \n<tr> \n<td>3</td> \n<td>Yes</td> \n<td>4</td> \n<td>Yes</td> \n</tr> \n</tbody> \n</table>\n\n</div>",
+    "attachments": [
+
+    ],
+    "metadata": {
+    },
+    "max_cache_time": 10,
+    "change_history": [
+      {
+        "note": "First published.",
+        "public_timestamp": "2015-07-09T08:17:10+00:00"
+      }
+    ]
+  },
+  "base_path": "/service-standard-reports/check-your-state-pension-alpha",
+  "description": "The Check Your State Pension (previously Digital National Insurance & State Pension) service provides individuals with a view of their State Pension entitlement and when it can be claimed from, and will allow individuals to understand where they have missed National Insurance qualifying years, and the consequences of this. It will help individuals to understand the impact of paying additional National Insurance Contributions (NICs) on their State Pension, and will allow them to pay additional NICs to make up missed qualifying years if they so chose.",
+  "title": "Check Your State Pension - Alpha Assessment",
+  "updated_at": "2015-07-09T08:54:30+00:00",
+  "schema_name": "specialist_document",
+  "document_type": "service_standard_report",
+  "links": {
+  }
+}

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -78,6 +78,9 @@
           "$ref": "#/definitions/raib_report_metadata"
         },
         {
+          "$ref": "#/definitions/service_standard_report_metadata"
+        },
+        {
           "$ref": "#/definitions/tax_tribunal_decision_metadata"
         },
         {
@@ -1075,6 +1078,15 @@
         "date_of_occurrence": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "service_standard_report_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
         }
       }
     },

--- a/formats/specialist_document/publisher/document_types.json
+++ b/formats/specialist_document/publisher/document_types.json
@@ -27,6 +27,7 @@
         "maib_report",
         "medical_safety_alert",
         "raib_report",
+        "service_standard_report",
         "tax_tribunal_decision",
         "utaac_decision",
         "vehicle_recalls_and_faults_alert"


### PR DESCRIPTION
Finding Things team is moving the Service Assessments & Self Certification documents from the [GDS Data blog](https://gdsdata.blog.gov.uk/all-service-assessments-and-self-certification/) into finders.

This commit adds examples of those schemas.

- Added example for finder-frontend
- Added example for specialist-frontend

Trello: https://trello.com/c/lFZnNhs4/349-create-a-service-assessment-finder

## Look & Feel

![screen shot 2016-12-07 at 17 37 57](https://cloud.githubusercontent.com/assets/136777/21005421/a30146f2-bd2c-11e6-8cf4-b0a079729b9e.png)
![screen shot 2016-12-07 at 17 37 42](https://cloud.githubusercontent.com/assets/136777/21005422/a3164278-bd2c-11e6-89e4-1b546043fc57.png)
