### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'govuk-content-schemas'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '50')
+      ),
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    [$class: 'ThrottleJobProperty',
+      categories: [],
+      limitOneJobWithMatchingParams: true,
+      maxConcurrentPerNode: 1,
+      maxConcurrentTotal: 0,
+      paramsToUseForLimit: 'govuk-content-schemas',
+      throttleEnabled: true,
+      throttleOption: 'category'],
+  ])
+
+  try {
+    stage("Checkout") {
+      checkout scm
+    }
+
+    stage("Run jenkins.sh") {
+      sh('./jenkins.sh')
+    }
+
+    stage("Push release tag") {
+      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+    }
+
+    govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,13 +6,6 @@ export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 export REPO_NAME="alphagov/govuk-content-schemas"
 env
 
-function github_status {
-  REPO_NAME="$1"
-  STATUS="$2"
-  MESSAGE="$3"
-  gh-status "$REPO_NAME" "$GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" >/dev/null
-}
-
 function error_handler {
   trap - ERR # disable error trap to avoid recursion.
   local parent_lineno="$1"
@@ -23,12 +16,10 @@ function error_handler {
   else
     echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
   fi
-  github_status "$REPO_NAME" failure "failed on Jenkins"
   exit "${code}"
 }
 
 trap "error_handler ${LINENO}" ERR
-github_status "$REPO_NAME" pending "is running on Jenkins"
 
 # Try to merge master into the current branch, and abort if it doesn't exit
 # cleanly (ie there are conflicts). This will be a noop if the current branch
@@ -44,12 +35,6 @@ export EXIT_STATUS=$?
 if ! git diff --exit-code; then
   echo "Changes to checked-in files detected after running 'rake clean' and 'rake build'. If these are generated files, you might need to 'rake clean build' to ensure they are regenerated and push the changes"
   export EXIT_STATUS=1
-fi
-
-if [ "$EXIT_STATUS" == "0" ]; then
-  github_status "$REPO_NAME" success "succeeded on Jenkins"
-else
-  github_status "$REPO_NAME" failure "failed on Jenkins"
 fi
 
 exit $EXIT_STATUS


### PR DESCRIPTION
Add Jenkins configuration file to enable pipeline builds on the Jenkins 2 CI server.

This file currently does NOT trigger any downstream builds of which depend on the content schemas. Triggers for those should be added to this file as the projects themselves are migrated to Jenkins 2.

**Once this is merged to master, we'll need to make a few manual config changes:**
- [x] Remove `default` from the required checks in GitHub. This is the Jenkins 1 build, which will no longer report to GitHub.
- [ ] Add `continuous-integration/jenkins/branch` to the required checks in GitHub. This is the Jenkins 2 build.
- [ ] Edit the [Jenkins 1 config for master](https://ci.dev.publishing.service.gov.uk/job/govuk_content_schemas/) to delete the Git Publisher post-build step, because this will now be handled by the Jenkins 2 build.

Note that the Jenkins 1 build will still _run_, because we will leave the old Jenkins webhook in place. This means that the Jenkins 1 will continue to trigger all of the dependent builds until we've migrated each of them to Jenkins 2.

I think the process for updating a dependent project will then be:

1. Add a Jenkinsfile to the dependent project, but leave the old jenkins.sh in place. This will ensure that the build can temporarily be run on both Jenkins servers.
2. Follow the instructions in the Ops manual for triggering the build in new Jenkins (i.e. adding a webhook and running branch indexing)
3. Merge that change to master
4. Update the project's merge checks so that the Jenkins 2 build is required but the Jenkins 1 change is not
5. Deploy the project
    - At this point, all new PRs for the project will be built by Jenkins 2. All new PRs for _govuk-content-schemas_ will trigger a build of this project in _Jenkins 1_. So all the downstream checks will happen on Jenkins 1 until the next steps are finished.
6. Add the project to the list of dependent projects in the govuk-content-schemas Jenkinsfile
7. Merge that change to govuk-content-schemas master
8. Delete the project from the list of downstream projects in the Jenkins 1 govuk-content-schemas builds ([master](https://ci.dev.publishing.service.gov.uk/job/govuk_content_schemas/) and [branch](https://ci.dev.publishing.service.gov.uk/job/govuk_content_schemas_branches/) builds)
9. Delete jenkins-schema.sh from the dependent project

Once that's been done for every downstream project, we can remove the webhook for Jenkins 1 from the govuk-content-schemas GitHub settings.