### PR TITLE
Complete need content schema

### DIFF
--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -230,7 +230,7 @@
       "properties": {
         "role": {
           "type": "string",
-          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner."
+          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner"
         },
         "goal": {
           "type": "string",
@@ -239,6 +239,56 @@
         "benefit": {
           "type": "string",
           "description": "Why the user wants to do it"
+        },
+        "applies_to_all_organisations": {
+          "type": "boolean",
+          "description": "Whether all linked organisations meet this need"
+        },
+        "impact": {
+          "type": "string",
+          "description": "Impact of GOV.UK not doing this"
+        },
+        "justifications": {
+          "description": "How this need fits in the proposition for GOV.UK",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "legislation": {
+          "type": "string",
+          "description": "Legislation that underpins this need"
+        },
+        "met_when": {
+          "description": "Provides criteria that define when this user need has been met",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "other_evidence": {
+          "type": "string",
+          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
+        },
+        "status": {
+          "type": "string",
+          "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"
+        },
+        "yearly_need_views": {
+          "type": "string",
+          "description": "Number of pageviews specific to this need generated each year"
+        },
+        "yearly_searches": {
+          "type": "string",
+          "description": "Number of searches specific to this need carried out each year"
+        },
+        "yearly_site_views": {
+          "type": "string",
+          "description": "Number of yearly pageviews of the whole site of the requester"
+        },
+        "yearly_user_contacts": {
+          "type": "string",
+          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
         }
       }
     },

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -232,7 +232,7 @@
       "properties": {
         "role": {
           "type": "string",
-          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner."
+          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner"
         },
         "goal": {
           "type": "string",
@@ -241,6 +241,56 @@
         "benefit": {
           "type": "string",
           "description": "Why the user wants to do it"
+        },
+        "applies_to_all_organisations": {
+          "type": "boolean",
+          "description": "Whether all linked organisations meet this need"
+        },
+        "impact": {
+          "type": "string",
+          "description": "Impact of GOV.UK not doing this"
+        },
+        "justifications": {
+          "description": "How this need fits in the proposition for GOV.UK",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "legislation": {
+          "type": "string",
+          "description": "Legislation that underpins this need"
+        },
+        "met_when": {
+          "description": "Provides criteria that define when this user need has been met",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "other_evidence": {
+          "type": "string",
+          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
+        },
+        "status": {
+          "type": "string",
+          "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"
+        },
+        "yearly_need_views": {
+          "type": "string",
+          "description": "Number of pageviews specific to this need generated each year"
+        },
+        "yearly_searches": {
+          "type": "string",
+          "description": "Number of searches specific to this need carried out each year"
+        },
+        "yearly_site_views": {
+          "type": "string",
+          "description": "Number of yearly pageviews of the whole site of the requester"
+        },
+        "yearly_user_contacts": {
+          "type": "string",
+          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
         }
       }
     },

--- a/dist/formats/need/publisher/schema.json
+++ b/dist/formats/need/publisher/schema.json
@@ -146,7 +146,7 @@
       "properties": {
         "role": {
           "type": "string",
-          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner."
+          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner"
         },
         "goal": {
           "type": "string",
@@ -155,6 +155,56 @@
         "benefit": {
           "type": "string",
           "description": "Why the user wants to do it"
+        },
+        "applies_to_all_organisations": {
+          "type": "boolean",
+          "description": "Whether all linked organisations meet this need"
+        },
+        "impact": {
+          "type": "string",
+          "description": "Impact of GOV.UK not doing this"
+        },
+        "justifications": {
+          "description": "How this need fits in the proposition for GOV.UK",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "legislation": {
+          "type": "string",
+          "description": "Legislation that underpins this need"
+        },
+        "met_when": {
+          "description": "Provides criteria that define when this user need has been met",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "other_evidence": {
+          "type": "string",
+          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
+        },
+        "status": {
+          "type": "string",
+          "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"
+        },
+        "yearly_need_views": {
+          "type": "string",
+          "description": "Number of pageviews specific to this need generated each year"
+        },
+        "yearly_searches": {
+          "type": "string",
+          "description": "Number of searches specific to this need carried out each year"
+        },
+        "yearly_site_views": {
+          "type": "string",
+          "description": "Number of yearly pageviews of the whole site of the requester"
+        },
+        "yearly_user_contacts": {
+          "type": "string",
+          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
         }
       }
     },

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -142,7 +142,7 @@
       "properties": {
         "role": {
           "type": "string",
-          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner."
+          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner"
         },
         "goal": {
           "type": "string",
@@ -151,6 +151,56 @@
         "benefit": {
           "type": "string",
           "description": "Why the user wants to do it"
+        },
+        "applies_to_all_organisations": {
+          "type": "boolean",
+          "description": "Whether all linked organisations meet this need"
+        },
+        "impact": {
+          "type": "string",
+          "description": "Impact of GOV.UK not doing this"
+        },
+        "justifications": {
+          "description": "How this need fits in the proposition for GOV.UK",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "legislation": {
+          "type": "string",
+          "description": "Legislation that underpins this need"
+        },
+        "met_when": {
+          "description": "Provides criteria that define when this user need has been met",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "other_evidence": {
+          "type": "string",
+          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
+        },
+        "status": {
+          "type": "string",
+          "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"
+        },
+        "yearly_need_views": {
+          "type": "string",
+          "description": "Number of pageviews specific to this need generated each year"
+        },
+        "yearly_searches": {
+          "type": "string",
+          "description": "Number of searches specific to this need carried out each year"
+        },
+        "yearly_site_views": {
+          "type": "string",
+          "description": "Number of yearly pageviews of the whole site of the requester"
+        },
+        "yearly_user_contacts": {
+          "type": "string",
+          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
         }
       }
     },

--- a/formats/need/publisher/details.json
+++ b/formats/need/publisher/details.json
@@ -10,7 +10,7 @@
   "properties": {
     "role": {
       "type": "string",
-      "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner."
+      "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner"
     },
     "goal": {
       "type": "string",
@@ -19,6 +19,56 @@
     "benefit": {
       "type": "string",
       "description": "Why the user wants to do it"
+    },
+    "applies_to_all_organisations": {
+      "type": "boolean",
+      "description": "Whether all linked organisations meet this need"
+    },
+    "impact": {
+      "type": "string",
+      "description": "Impact of GOV.UK not doing this"
+    },
+    "justifications": {
+      "description": "How this need fits in the proposition for GOV.UK",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "legislation": {
+      "type": "string",
+      "description": "Legislation that underpins this need"
+    },
+    "met_when": {
+      "description": "Provides criteria that define when this user need has been met",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "other_evidence": {
+      "type": "string",
+      "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
+    },
+    "status": {
+      "type": "string",
+      "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"
+    },
+    "yearly_need_views": {
+      "type": "string",
+      "description": "Number of pageviews specific to this need generated each year"
+    },
+    "yearly_searches": {
+      "type": "string",
+      "description": "Number of searches specific to this need carried out each year"
+    },
+    "yearly_site_views": {
+      "type": "string",
+      "description": "Number of yearly pageviews of the whole site of the requester"
+    },
+    "yearly_user_contacts": {
+      "type": "string",
+      "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
     }
   }
 }


### PR DESCRIPTION
This adds the remaining fields to the Needs content schemas, to allow to publish all Needs from the Need-API to the Publishing-API.

Relates to [this Trello card](https://trello.com/c/jlXiAdmQ/7-add-needs-to-publishing-api)