### PR TITLE
Add assesment_date to Service Standard Report

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1670,6 +1670,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "assessment_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
     },

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -1672,6 +1672,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "assessment_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -1624,6 +1624,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "assessment_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1562,6 +1562,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "assessment_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
     },

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -1087,6 +1087,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "assessment_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
     },


### PR DESCRIPTION
The service standard reports need to have the date of when the assessment was held.

We are adding it to the metadata field to allow the editors to fill this field on Specialist Publisher and allow our visitors to read it in the document page.

Trello:
https://trello.com/c/ADPnDXsE/385-add-assessment-date-to-service-standard-specialist-document