### PR TITLE
Add external related links to generic schema

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -223,6 +223,24 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "external_related_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -225,6 +225,24 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "external_related_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/generic/publisher/schema.json
+++ b/dist/formats/generic/publisher/schema.json
@@ -139,6 +139,24 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "external_related_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
     },
     "links": {

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -135,6 +135,24 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "external_related_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
     },
     "absolute_path": {

--- a/formats/generic/publisher/details.json
+++ b/formats/generic/publisher/details.json
@@ -3,5 +3,20 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["title", "url"],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
We are in the process of stopping Publisher using Panopticon to register routes for it's documents. At the same time we are changing the schema that Publisher formats use to `generic`. External related links are currently used by all the formats.

[Trello card](https://trello.com/c/sZyeX2Ul/570-preparatory-work-fix-content-item-routes-for-publisher-formats-3)