### PR TITLE
Include `change_history` in frontend & notification details blocks where appropriate

### DIFF
--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -233,6 +233,9 @@
         "public_updated_at": {
           "type": "string",
           "format": "date-time"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -235,6 +235,9 @@
         "public_updated_at": {
           "type": "string",
           "format": "date-time"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -425,6 +425,9 @@
         },
         "language": {
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -424,6 +424,9 @@
         },
         "language": {
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -295,6 +295,9 @@
         },
         "govdelivery_title": {
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -297,6 +297,9 @@
         },
         "govdelivery_title": {
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -384,6 +384,9 @@
               "type": "null"
             }
           ]
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -380,6 +380,9 @@
               "type": "null"
             }
           ]
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -287,6 +287,9 @@
               "type": "string"
             }
           ]
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -286,6 +286,9 @@
               "type": "string"
             }
           ]
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -223,6 +223,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -225,6 +225,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -240,6 +240,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -242,6 +242,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -338,6 +338,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -340,6 +340,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -328,6 +328,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -330,6 +330,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -241,6 +241,9 @@
         },
         "first_published_version": {
           "type": "boolean"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -243,6 +243,9 @@
         },
         "first_published_version": {
           "type": "boolean"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -270,6 +270,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -260,6 +260,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -321,6 +321,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -320,6 +320,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -274,6 +274,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -273,6 +273,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -289,6 +289,9 @@
         "yearly_user_contacts": {
           "type": "string",
           "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -291,6 +291,9 @@
         "yearly_user_contacts": {
           "type": "string",
           "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -323,6 +323,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -325,6 +325,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -355,6 +355,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -342,6 +342,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -222,6 +222,9 @@
     "details": {
       "type": "object",
       "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -224,6 +224,9 @@
     "details": {
       "type": "object",
       "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -229,6 +229,9 @@
         "body": {
           "type": "string",
           "description": "A single line of text that serves as a second, less prominent introduction."
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -228,6 +228,9 @@
         "body": {
           "type": "string",
           "description": "A single line of text that serves as a second, less prominent introduction."
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -268,6 +268,9 @@
               "format": "date-time"
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -261,6 +261,9 @@
               "format": "date-time"
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -258,6 +258,9 @@
             "national",
             "official"
           ]
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -260,6 +260,9 @@
             "national",
             "official"
           ]
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -232,6 +232,9 @@
         },
         "image": {
           "$ref": "#/definitions/image"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -234,6 +234,9 @@
         },
         "image": {
           "$ref": "#/definitions/image"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -233,6 +233,9 @@
         "notes_for_editors": {
           "type": "string",
           "description": "Usage notes for editors when tagging content to a taxon."
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -232,6 +232,9 @@
         "notes_for_editors": {
           "type": "string",
           "description": "Usage notes for editors when tagging content to a taxon."
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -267,6 +267,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -266,6 +266,9 @@
               }
             }
           }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -232,6 +232,9 @@
         },
         "body": {
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -234,6 +234,9 @@
         },
         "body": {
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -312,6 +312,9 @@
         "publishing_request_id": {
           "description": "A unique identifier used to track publishing requests to rendered content",
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -311,6 +311,9 @@
         "publishing_request_id": {
           "description": "A unique identifier used to track publishing requests to rendered content",
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -281,6 +281,9 @@
         "publishing_request_id": {
           "description": "A unique identifier used to track publishing requests to rendered content",
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -280,6 +280,9 @@
         "publishing_request_id": {
           "description": "A unique identifier used to track publishing requests to rendered content",
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -246,6 +246,9 @@
         "public_updated_at": {
           "type": "string",
           "format": "date-time"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -248,6 +248,9 @@
         "public_updated_at": {
           "type": "string",
           "format": "date-time"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -228,6 +228,9 @@
         },
         "body": {
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -230,6 +230,9 @@
         },
         "body": {
           "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         }
       }
     },

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -124,7 +124,7 @@ private
   def converted_definitions
     resolve_multiple_content_types(publisher_definitions.reject { |k| k == "links" }).tap do |converted|
       if change_history_required?
-        converted['details']['required'] << 'change_history'
+        converted["details"]["required"] << "change_history"
       end
     end
   end

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -126,11 +126,20 @@ private
       if change_history_required?
         converted["details"]["required"] << "change_history"
       end
-    end
+
+      if details_should_contain_change_history?(converted)
+        converted["details"]["properties"]["change_history"] = { "$ref"=>"#/definitions/change_history" }
+      end
+   end
   end
 
   def change_history_required?
     CHANGE_HISTORY_REQUIRED.include?(format_name)
+  end
+
+  def details_should_contain_change_history?(definition)
+    return if !definition.dig("details", "properties") || definition["details"]["properties"]["change_history"]
+    publisher_properties.has_key?("change_note")
   end
 
   def frontend_definitions


### PR DESCRIPTION
A large number of formats can submit a `change_note` to the Publishing API and the result of this will be that the Publishing API presents `change_history` within the `details` hash of a content item representation.

The lack of this field has caused intermittent errors on the Publishing API. When generating a random item to be published, a `change_note` can exist however the schema does not expect a `change_history` in the details.

As this isn't present in the publisher schema we have to add this in a somewhat ungraceful method.

Incidentally I don't really think `change_history` belongs inside the details hash. The horse has already bolted on this somewhat since it's used on specialist_frontend, and allows it to be a drop-in for a previously passed `details->content_history` but it is quite weird that we have `change_note` at root level but `change_history` in details. I've put together a [trello card](https://trello.com/c/Q02rlwjk/394-change-history-doesn-t-belong-in-the-details-hash-of-a-presented-contentitem) on this - do shout if you think that's superfluous 