### PR TITLE
Add speeches schema and examples

### DIFF
--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -1,0 +1,654 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "links",
+    "title",
+    "details",
+    "locale",
+    "content_id",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content received a major or minor update."
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "speaker": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ministers": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "speech"
+      ]
+    },
+    "format": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body",
+        "government",
+        "political",
+        "delivered_on"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "speech_type_explanation": {
+          "description": "Details about the type of speech",
+          "type": "string"
+        },
+        "speaker_without_profile": {
+          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "delivered_on": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -1,0 +1,644 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "content_id",
+    "details",
+    "document_type",
+    "expanded_links",
+    "govuk_request_id",
+    "links",
+    "locale",
+    "redirects",
+    "routes",
+    "schema_name",
+    "title",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content received a major or minor update."
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "speech"
+      ]
+    },
+    "format": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body",
+        "government",
+        "political",
+        "delivered_on"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "speech_type_explanation": {
+          "description": "Details about the type of speech",
+          "type": "string"
+        },
+        "speaker_without_profile": {
+          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "delivered_on": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/dist/formats/speech/publisher/schema.json
+++ b/dist/formats/speech/publisher/schema.json
@@ -1,0 +1,614 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content received a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "speech"
+      ]
+    }
+  },
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body",
+        "government",
+        "political",
+        "delivered_on"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "speech_type_explanation": {
+          "description": "Details about the type of speech",
+          "type": "string"
+        },
+        "speaker_without_profile": {
+          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "delivered_on": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "speaker": {
+          "description": "A speaker that has a GOV.UK profile",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Panopticon.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -1,0 +1,411 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "previous_version": {
+      "type": "string"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "speaker": {
+          "description": "A speaker that has a GOV.UK profile",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Panopticon.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -1,0 +1,554 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content received a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "speech"
+      ]
+    }
+  },
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body",
+        "government",
+        "political",
+        "delivered_on"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "first_public_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "speech_type_explanation": {
+          "description": "Details about the type of speech",
+          "type": "string"
+        },
+        "speaker_without_profile": {
+          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "delivered_on": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "browse_pages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "topics": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/formats/speech/frontend/examples/speech-authored-article.json
+++ b/formats/speech/frontend/examples/speech-authored-article.json
@@ -1,0 +1,91 @@
+{
+  "base_path": "/government/speeches/britains-choice-economic-security-with-the-eu-or-a-leap-into-the-dark",
+  "content_id": "be015d1b-2de4-4d5a-9f52-9f05ef15fdad",
+  "schema_name": "speech",
+  "document_type": "authored_article",
+  "first_published_at": "2016-04-05T14:38:00+01:00",
+  "title": "Britain's choice: economic security with the EU, or a leap into the dark (Archived)",
+  "description": "Prime Minister David Cameron wrote an article on the UK's economic security within the EU for The Telegraph.",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "updated_at": "2016-08-11T16:58:10.474Z",
+  "public_updated_at": "2016-04-05T14:38:00+01:00",
+  "details": {
+    "first_public_at": "2016-04-05T14:38:00+01:00",
+    "body": "<div class=\"govspeak\"><p>Imagine a world where a British airline wasn’t allowed to fly between Rome and Paris; where British farmers were slapped with a tariff if they wanted to export more beef to Europe; and where great British telecoms companies and car manufacturers faced new barriers when trying to sell their goods and services to customers in Europe.</p>\n\n<p>This is the world we could wake up in if we leave Europe – with the massive knock-on effect on jobs, prices and living standards in our country. Because the longer this referendum campaign goes on, the clearer it becomes: those campaigning to leave Europe are inviting the British people to make an extraordinary choice – to be the first major economy in history to deliberately choose a second-rate, more restrictive trading relationship for its biggest market. They want to rip up our membership of the single market – a market that Britain practically invented – in the hope of renegotiating a new arrangement.</p>\n\n<p>We are duty bound to take this proposition very seriously. So let us properly examine the consequences for our economy.  What would a new tailored arrangement, of the sort Canada or Switzerland have with Europe, mean for us?</p>\n\n<p>If we take the Canada free trade deal as a guide, we know it would be damaging for agriculture and manufacturing. Our beef and pork exports would face tariffs, and our car manufacturers forced to comply with rules imposing additional costs based on where they buy their components. And of course, there is British steel. We are doing everything we can to help British steel in these difficult times, but the idea that leaving Europe is the answer is a dangerous fallacy: more than half of our steel exports go to Europe. As Stephen Kinnock, the local MP has said, the last thing his constituents in Port Talbot need is to be cut off from Europe.</p>\n\n<p>Leaving the single market would also hit our service industries hard – and this is where our economy faces the biggest risk. Today, British brainpower and ingenuity are in demand. We’re the country that designs the building, advises on the deal, arranges the finance, insures the business, draws up the contracts, produces the film, creates the advertising campaign, sells the product and audits the accounts. All these are service industries.</p>\n\n<p>The figures speak for themselves. Our service industries are growing at a rate of nearly 3% a year on average. They account for almost 80% of our economy. And they amount for 40% of all British exports – with Europe being by far our biggest exporting market. Indeed, an extraordinary 116,000 small businesses export services to the EU.  And new analysis shows that 2 million jobs are either directly or indirectly linked to these exports.</p>\n\n<p>Each of these jobs represent someone with a pay packet; someone providing for themselves and their families. As politicians, we have a duty to tell them what we think the future holds. I can tell each of them, with certainty, that if we stay in Europe their employer will keep the current guaranteed rights to offer services anywhere in the EU.</p>\n\n<p>Those advocating leave can do no such thing. No real-world alternative to EU membership would come close to what we have now. Even the most ambitious trade deal on services the EU has ever struck – with Canada – falls radically short of single market access.</p>\n\n<p>The latest draft of the Canada deal runs to over 1,500 pages – 800 of which are reservations and barriers. A huge proportion of the deal is about restricting business opportunities, not opening them up. We could see new barriers for British business in every key services sector. Here are just 3 examples.</p>\n\n<p>One: aviation. Currently, UK airlines are free to operate routes both between and within other EU member states. But under their deal, Canadian airlines are only allowed to operate routes in Europe if they start or end at a Canadian airport. If this rule was applied to British airlines, they would have to scrap hundreds of routes.</p>\n\n<p>Two: broadcasting. Under EU rules, once a broadcaster is licensed in 1 member state, it can broadcast in all.  If we replicated Canada’s deal, companies would have to choose between seeking separate licences in all EU states they want to broadcast in, or moving out of the UK altogether.</p>\n\n<p>And of course, there’s our biggest service industry of all: financial services. Half of all international financial firms base their European headquarters in the UK. From their 1 office in the UK, EU membership allows them to do business in all 27 other EU states. If we left, this right would be lost and thousands of firms could be forced to move staff or entire offices out of the UK and into the EU, meaning fewer jobs and less tax revenue for the UK.</p>\n\n<p>People might say, “so what? Surely Britain will get a better deal than Canada or Switzerland? The EU needs Britain more than we need the EU.” That misunderstands the negotiation dynamics that would be at play. The EU buys £21 billion more of services from us – 1 country – than we buy from the 27 countries in the EU. In fact, of everything we sell abroad, 44% goes to the EU, but of everything the EU exports, less than 8% comes to the UK. How can those negotiating dynamics be good for the UK?</p>\n\n<p>Governments in the EU would come under tremendous pressure from their domestic firms to discriminate against the UK. And who is to say they wouldn’t take the opportunity? After all, why wouldn’t the Spanish protect their largest telecoms provider? Why wouldn’t the Germans try to give a leg-up to their insurance companies? Why wouldn’t the French adopt protectionist measures to penalise British banks?</p>\n\n<p>When you look at the consequences of leaving this market, you have to ask: why on earth would we do this to ourselves? I believe it would be needless and reckless – an act of economic and political self-harm.</p>\n\n<p>In June, we can choose Britain’s future. We can choose to shape our world, not to be shaped by others. We can choose to stay in the biggest single market on Earth. We can choose economic security, not an unnecessary leap in the dark. We can choose to be stronger, safer and better-off – and that’s what I hope the British people will do when the moment comes.</p>\n</div>",
+    "delivered_on": "2016-04-05T00:00:00+01:00",
+    "image": {
+      "alt_text": "The Rt Hon David Cameron MP",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/1/s465_David_Cameron.jpg"
+    },
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    },
+    "government": {
+      "title": "2015 Conservative government",
+      "slug": "2015-conservative-government",
+      "current": true
+    },
+    "political": true,
+    "emphasised_organisations": [
+      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+    ]
+  },
+  "links": {
+    "organisations": [
+      {
+        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
+        "locale": "en",
+        "analytics_identifier": "OT532"
+      }
+    ],
+    "speaker": [
+      {
+        "content_id": "8529186b-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon David Cameron MP",
+        "api_path": "/api/content/government/people/david-cameron",
+        "base_path": "/government/people/david-cameron",
+        "api_url": "https://www.gov.uk/api/content/government/people/david-cameron",
+        "web_url": "https://www.gov.uk/government/people/david-cameron",
+        "locale": "en"
+      }
+    ],
+    "topical_events": [
+      {
+        "content_id": "7658ef9d-2f7a-4e4a-aaa7-9d4668c23de0",
+        "title": "EU Referendum",
+        "api_path": "/api/content/government/topical-events/eu-referendum",
+        "base_path": "/government/topical-events/eu-referendum",
+        "api_url": "https://www.gov.uk/api/content/government/topical-events/eu-referendum",
+        "web_url": "https://www.gov.uk/government/topical-events/eu-referendum",
+        "locale": "en"
+      }
+    ],
+    "policies": [
+      {
+        "content_id": "5d278051-7631-11e4-a3cb-005056011aef",
+        "title": "European single market",
+        "api_path": "/api/content/government/policies/european-single-market",
+        "base_path": "/government/policies/european-single-market",
+        "api_url": "https://www.gov.uk/api/content/government/policies/european-single-market",
+        "web_url": "https://www.gov.uk/government/policies/european-single-market",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/speech/frontend/examples/speech-speaker-without-profile.json
+++ b/formats/speech/frontend/examples/speech-speaker-without-profile.json
@@ -1,0 +1,89 @@
+{
+  "base_path": "/government/speeches/queens-speech-2016",
+  "content_id": "82839645-71c4-4298-ae39-e3cef17fcba0",
+  "schema_name": "speech",
+  "document_type": "speech",
+  "first_published_at": "2016-05-18T10:47:49.000+00:00",
+  "title": "Queen's Speech 2016",
+  "description": "Her Majesty’s most gracious speech to both Houses of Parliament at the State Opening of Parliament 2016.",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "updated_at": "2016-08-11T16:56:58.090Z",
+  "public_updated_at": "2016-05-18T10:47:49.000+00:00",
+  "details": {
+    "first_public_at": "2016-05-18T10:47:49.000+00:00",
+    "body": "<div class=\"govspeak\"><p>My Lords and Members of the House of Commons.</p>\n\n<p>My government will use the opportunity of a strengthening economy to deliver security for working people, to increase life chances for the most disadvantaged and to strengthen national defences.</p>\n\n<p>My ministers will continue to bring the public finances under control so that Britain lives within its means, and to move to a higher wage and lower welfare economy where work is rewarded.</p>\n\n<p>To support the economic recovery, and to create jobs and more apprenticeships, legislation will be introduced to ensure Britain has the infrastructure that businesses need to grow.</p>\n\n<p>Measures will be brought forward to create the right for every household to access high speed broadband.</p>\n\n<p>Legislation will be introduced to improve Britain’s competitiveness and make the United Kingdom a world leader in the digital economy.</p>\n\n<p>My ministers will ensure the United Kingdom is at the forefront of technology for new forms of transport, including autonomous and electric vehicles.</p>\n\n<p>To spread economic prosperity, my government will continue to support the development of a Northern Powerhouse.</p>\n\n<p>In England, further powers will be devolved to directly elected mayors, including powers governing local bus services.</p>\n\n<p>Legislation will also allow local authorities to retain business rates, giving them more freedom to invest in local communities.</p>\n\n<p>My government will support aspiration and promote home ownership through its commitment to build a million new homes.</p>\n\n<p>Following last week’s <a rel=\"external\" href=\"https://www.gov.uk/government/topical-events/anti-corruption-summit-london-2016\">Anti-Corruption Summit</a> in London, legislation will be introduced to tackle corruption, money laundering and tax evasion.</p>\n\n<p>My government will continue work to deliver NHS services over 7 days of the week in England.  Legislation will be introduced to ensure that overseas visitors pay for the health treatment they receive at public expense.</p>\n\n<p>New legislation will be introduced to tackle some of the deepest social problems in society, and improve life chances.</p>\n\n<p>A Bill will be introduced to ensure that children can be adopted by new families without delay, improve the standard of social work and opportunities for young people in care in England.</p>\n\n<p>To tackle poverty and the causes of deprivation, including family instability, addiction and debt, my government will introduce new indicators for measuring life chances.  Legislation will be introduced to establish a soft drinks industry levy to help tackle childhood obesity.</p>\n\n<p>Measures will be introduced to help the lowest-income families save, through a new Help to Save scheme, and to create a Lifetime ISA to help young people save for the long-term.</p>\n\n<p>My government will continue to reform public services so they help the hardest-to-reach.</p>\n\n<p>A Bill will be brought forward to lay foundations for educational excellence in all schools, giving every child the best start in life. There will also be a fairer balance between schools, through the National Funding Formula.</p>\n\n<p>To ensure that more people have the opportunity to further their education, legislation will be introduced to support the establishment of new universities and to promote choice and competition across the higher education sector.</p>\n\n<p>My government will legislate to <a rel=\"external\" href=\"https://www.gov.uk/government/news/biggest-shake-up-of-prison-system-announced-as-part-of-queens-speech\">reform prisons</a> and courts to give individuals a second chance.</p>\n\n<p>Prison Governors will be given unprecedented freedom and they will be able to ensure prisoners receive better education. Old and inefficient prisons will be closed and new institutions built where prisoners can be put more effectively to work.</p>\n\n<p>Action will also be taken to ensure better mental health provision for individuals in the criminal justice system.</p>\n\n<p>My government will continue to work to bring communities together and strengthen society.</p>\n\n<p>Legislation will be introduced to prevent radicalisation, tackle extremism in all its forms, and promote community integration.</p>\n\n<p>National Citizen Service will be placed on a permanent statutory footing.</p>\n\n<p>My government will continue to safeguard national security.</p>\n\n<p>My ministers will invest in Britain’s armed forces, honouring the military covenant and meeting the NATO commitment to spend 2% of national income on defence.</p>\n\n<p>They will also act to secure the long-term future of Britain’s nuclear deterrent.</p>\n\n<p>My government will continue to play a leading role in world affairs, using its global presence to tackle climate change and address major international security, economic and humanitarian challenges.</p>\n\n<p>My government will continue to work to resolve the conflict in Ukraine. It will play a leading role in the campaign against Daesh and to support international efforts to bring peace to Syria through a lasting political settlement.</p>\n\n<p>Britain’s commitment on international development spending will also be honoured, helping to deliver global stability, support the Sustainable Development Goals and prevent new threats to national security.</p>\n\n<p>Prince Philip and I look forward to welcoming His Excellency the President of Colombia on a State Visit in November.</p>\n\n<p>My government will continue with legislation to modernise the law governing the use and oversight of investigatory powers by law enforcement, security and intelligence agencies.</p>\n\n<p>Legislation will strengthen the capability and accountability of the police service in England and Wales.</p>\n\n<p>My government will hold a <a rel=\"external\" href=\"https://www.gov.uk/government/topical-events/eu-referendum\">referendum on membership of the European Union</a>. Proposals will be brought forward for a British Bill of Rights.</p>\n\n<p>My ministers will uphold the sovereignty of Parliament and the primacy of the House of Commons.</p>\n\n<p>My government will continue to work in cooperation with the devolved administrations to implement the extensive new powers in the <a rel=\"external\" href=\"https://www.gov.uk/government/publications/the-scotland-act-2016\">Scotland Act</a> and establish a strong and lasting devolution settlement in Wales. My government will work in Northern Ireland to secure further progress in implementing the <a rel=\"external\" href=\"https://www.gov.uk/government/publications/the-stormont-house-agreement\">Stormont House</a> and <a rel=\"external\" href=\"https://www.gov.uk/government/news/a-fresh-start-for-northern-ireland\">Fresh Start</a> Agreements.</p>\n\n<p>Members of the House of Commons:</p>\n\n<p>Estimates for the public services will be laid before you.</p>\n\n<p>My Lords and Members of the House of Commons:</p>\n\n<p>Other measures will be laid before you.</p>\n\n<p>I pray that the blessing of Almighty God may rest upon your counsels.</p>\n</div>",
+    "delivered_on": "2016-05-18T12:30:00+00:00",
+    "location": "House of Lords, Houses of Parliament",
+    "speech_type_explanation": "Transcript of the speech, exactly as it was delivered",
+    "speaker_without_profile": "Her Majesty the Queen",
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    },
+    "government": {
+      "title": "2015 Conservative government",
+      "slug": "2015-conservative-government",
+      "current": true
+    },
+    "political": true,
+    "emphasised_organisations": [
+      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+    ]
+  },
+  "links": {
+    "organisations": [
+      {
+        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
+        "locale": "en",
+        "analytics_identifier": "OT532"
+      },
+      {
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office",
+        "api_path": "/api/content/government/organisations/cabinet-office",
+        "base_path": "/government/organisations/cabinet-office",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/cabinet-office",
+        "web_url": "https://www.gov.uk/government/organisations/cabinet-office",
+        "locale": "en",
+        "analytics_identifier": "D2"
+      }
+    ],
+    "topical_events": [
+      {
+        "content_id": "f53527d6-2413-4082-880b-a61c824b93a7",
+        "title": "Queen's Speech 2016",
+        "api_path": "/api/content/government/topical-events/queens-speech-2016",
+        "base_path": "/government/topical-events/queens-speech-2016",
+        "api_url": "https://www.gov.uk/api/content/government/topical-events/queens-speech-2016",
+        "web_url": "https://www.gov.uk/government/topical-events/queens-speech-2016",
+        "locale": "en"
+      }
+    ],
+    "policies": [
+      {
+        "content_id": "5d278051-7631-11e4-a3cb-005056011aef",
+        "title": "Government transparency and accountability",
+        "api_path": "/api/content/government/policies/government-transparency-and-accountability",
+        "base_path": "/government/policies/government-transparency-and-accountability",
+        "api_url": "https://www.gov.uk/api/content/government/policies/government-transparency-and-accountability",
+        "web_url": "https://www.gov.uk/government/policies/government-transparency-and-accountability",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/speech/frontend/examples/speech-transcript.json
+++ b/formats/speech/frontend/examples/speech-transcript.json
@@ -1,0 +1,112 @@
+{
+  "base_path": "/government/speeches/anti-corruption-summit-2016-pms-closing-remarks",
+  "content_id": "f1f8bc2e-0e64-46f1-b56d-fe71d79b2ae1",
+  "schema_name": "speech",
+  "document_type": "speech",
+  "first_published_at": "2016-05-12T17:07:00.000+00:00",
+  "title": "Anti-Corruption Summit 2016: PM's closing remarks",
+  "description": "David Cameron closed the anti-corruption summit, calling for an unprecedented global coalition to tackle the cancer of corruption.",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "updated_at": "2016-08-11T16:58:10.474Z",
+  "public_updated_at": "2016-05-12T17:07:00.000+00:00",
+  "details": {
+    "first_public_at": "2016-05-12T17:07:00.000+00:00",
+    "body": "<div class=\"govspeak\"><h2 id=\"introduction\">Introduction</h2>\n\n<p>Today the world has come together in a coalition of the committed to expose, punish and drive out corruption.</p>\n\n<p>This has been the first summit of its kind and the biggest demonstration of the political will to address corruption that we have seen for many, many years.</p>\n\n<p>Frankly we’ve known for years what a problem this is; we’ve known for years it prevents us from achieving so many things we want to fix in our world.</p>\n\n<p>But I’ve really sensed today there is far more political will – not just from words but from actions – that will make a difference.</p>\n\n<p>There’s nothing as powerful than an idea whose time has come and I believe that’s the case with fighting and driving our corruption.</p>\n\n<p>When the UK hosted the G8 in Lough Erne in 2013, we took what many had seen as a series of technical issues around tax, trade and transparency and we showed how political will could begin a concerted effort to get to grips with tax evasion, aggressive tax avoidance and corporate secrecy.</p>\n\n<p>When we first talked about ideas like automatic exchange of tax information and registries of who owns each company, many people, I think, wondered what on earth we were on about, and whether any of these things would actually happen.</p>\n\n<p>But now 129 jurisdictions have committed to implementing the international standard for exchange of tax information on request – and more than 95 have committed to implementing the new global common reporting standard on tax transparency.</p>\n\n<p>And as the Head of the OECD Angel Gurría has said today, this started, in his words, a “dramatic revolution” that has since brought in 50 billion euros in extra tax revenue and has the potential with automatic exchange of information to bring in 200 billion more. Think of the schools, the hospitals, the roads, the services that could be provided and are needlessly lost.</p>\n\n<p>Today’s summit has built on these foundations.</p>\n\n<p>Today it’s not just the G8, but representatives from over 40 countries.</p>\n\n<p>Not just political leaders but leaders from business, civil society and sport too, all working together to produce a series of ground-breaking commitments that can really transform our ability to tackle corruption.</p>\n\n<p>Just as at Lough Erne, many of these agreements are quite technical, but their impact is far reaching.</p>\n\n<h2 id=\"exposing-corruption\">Exposing corruption</h2>\n\n<p>First, we will expose corruption so there is nowhere to hide.</p>\n\n<p>If you don’t know who owns what, you can’t stop people stealing from poor countries and hiding that stolen wealth in rich ones.</p>\n\n<p>That is why it is so important that today 5 countries have agreed to create public registers of beneficial ownership and 6 more will explore similar arrangements.</p>\n\n<p>This will mean that everyone in the world will be able to see who really owns and controls each and every company in these countries.</p>\n\n<p>The EU, Iceland, UAE and most of our Overseas Territories and Crown Dependencies with major financial centres have agreed to automatically exchange their entire registries of beneficial ownership information.</p>\n\n<p>This means that law enforcement agencies across the world will be able to access this data – in many cases for the first time – and use it to expose the corrupt.</p>\n\n<p>Does it need to go further? Yes of course it does, but today is a good start.</p>\n\n<p>It is no good having laws against corruption, if lawyers, accountants and estate agents find ways around the law.</p>\n\n<p>So that is why it is so important that at this summit a new professional services statement of support has shown an unprecedented commitment from these professions to stop the facilitation of corruption.</p>\n\n<p>Again, does this go far enough? Does it need to go further? Of course it does – we need this adopted in every country, not just some countries.</p>\n\n<p>Public procurement and construction have both been massive areas for corruption around the world for years.</p>\n\n<p>So a range of countries including the UK will use open contracting in their government procurement, to keep public money out of corrupt hands.</p>\n\n<p>And here in the UK, we want to clean up our property market and show that there is no home for the corrupt in Britain.</p>\n\n<p>So all foreign companies which own properties in the UK will have to register publicly who really owns them, who really controls them – and no foreign company will be able to buy UK property or bid for central government contracts without joining this register.</p>\n\n<h2 id=\"punish-the-perpetrators\">Punish the perpetrators</h2>\n\n<p>Next, we will do more to punish the perpetrators of corruption and to support those affected by it.</p>\n\n<p>We know that corruption is a global phenomenon, so it’s essential that we share information and pursue the corrupt across borders, joining the dots to identify and prosecute the corrupt and to seize their assets – a point that so many speakers have made today.</p>\n\n<p>So the new International Anti-Corruption Co-ordination Centre we are creating will help police and prosecutors work together to do just that.</p>\n\n<p>But we also need to ensure that when we expose the corrupt, we are able to seize their assets and return them to the countries from which they were stolen.</p>\n\n<p>That’s why our Global Forum for Asset Recovery will be so important – enabling governments and law enforcement agencies around the world to work together to achieve this.</p>\n\n<p>We have also agreed today that 22 countries will introduce new asset recovery legislation, 14 will strengthen their protections for whistle-blowers – a discussion we had in the last session and 11 countries will review the penalties for companies that fail to prevent tax evasion.</p>\n\n<p>Here in Britain we will consult on extending that criminal offence of tax evasion, to other economic crimes such as fraud and money laundering, and we hope others will follow.</p>\n\n<p>We want firms properly held to account for any criminal activity within them.</p>\n\n<p>We are also consulting on Unexplained Wealth Orders, reversing the burden of proof so if someone is suspected of corruption, the onus is on them to prove they acquired their wealth legitimately or they will face having it stripped from them by a court.</p>\n\n<h2 id=\"driving-out-corruption\">Driving out corruption</h2>\n\n<p>Third, we will do more to drive out corruption wherever it is found.</p>\n\n<p>This requires the political leadership we have seen today – and a sustained effort at changing cultures of corruption.</p>\n\n<p>One example of this is the twinning of different countries’ tax inspectors to help build a shared culture of probity and honesty.</p>\n\n<p>And today we’ve seen 17 countries commit to such partnerships between their institutions and professions, and I want to thank Professor Paul Collier for his great work on this.</p>\n\n<p>We have also had a very frank discussion about changing cultures in sport.</p>\n\n<p>The world loves sport – and the world knows that sport is riddled with corruption.</p>\n\n<p>So only when we deal with corruption in sport will people really believe that we are dealing with corruption more broadly.</p>\n\n<p>Today we have taken an important step towards an International Sport Integrity Partnership that would restore integrity to the games we love and we will be keeping up the pressure to land this at a meeting with the IOC in February.</p>\n\n<p>We are also raising our own standards of governance and transparency to the highest possible levels here in the UK through the new Sports Charter.</p>\n\n<h2 id=\"next-steps\">Next steps</h2>\n\n<p>But today’s summit hasn’t just been about securing these agreements.</p>\n\n<p>We have also held, I think you’ll agree, a different kind of event.</p>\n\n<p>Instead of simply having speeches talking to ourselves about we have agreed and we have had open, honest and challenging conversations.</p>\n\n<p>We have asked tough questions about the challenges in implementing these agreements and explored new ideas and next steps that can really raise the ambition further.</p>\n\n<p>We have been asked whether we could enforce action against corruption in the same way that we enforce action against terrorism?</p>\n\n<p>We have been challenged to protect the freedom of the press and the whistleblowers who are so vital in helping them to expose the corrupt.</p>\n\n<p>We have talked about the need for more action from multinational companies.</p>\n\n<p>There was a great challenge for anti-corruption organisations to work more closely together – to deliver a more co-ordinated effort.</p>\n\n<p>We’ve talked about the need for every country to ultimately reach what I call the gold standard of a having a public register of beneficial ownership.</p>\n\n<p>And I am clear that I include all the Overseas Territories and Crown Dependencies in that. But it was encouraging to hear praise for what the head of the OECD described as, and I quote, the “exemplary delivery” of our crown dependencies in the steps they have taken so far.</p>\n\n<p>Finally, we have been clear that this summit will not be a single one-off moment.</p>\n\n<p>We are building a global movement against corruption.</p>\n\n<p>As President Ghani said – this cannot be a fashion – we have stay the course on this for the next 10 years and beyond.</p>\n\n<p>We welcome the commitment from Japan to include this issue and the learnings of this summit in its G7 Presidency.</p>\n\n<p>We have agreed that we will meet again at the UN General Assembly next year.</p>\n\n<p>And in the meantime we will continue to track the implementation of everything we have agreed today.</p>\n\n<p>And let’s just be clear what all these agreements really add up to.</p>\n\n<p>As I said, some of them are very technical.</p>\n\n<p>But what we are talking about is stopping the corrupt hiding their loot from the authorities.</p>\n\n<p>So as John Kerry said – there are “no more safe harbours” for the corrupt.</p>\n\n<p>It means that when people steal money from your country and hide it in mine – we can expose them and return the money to you.</p>\n\n<p>It means getting stolen assets returned to people like President Buhari and President Ghani, so they can be reinvested in the future of their countries.</p>\n\n<p>It means cleaning up our property market right here in London.</p>\n\n<p>It means helping to secure for all our economies some of the trillions in potential economic growth that is so needlessly lost to corruption.</p>\n\n<p>It means building an unprecedented global coalition to tackle this cancer of corruption which destroys jobs, traps the poorest in poverty and as Sarah Chayes has argued so powerfully today – even undermines our security.</p>\n\n<p>It means quite simply – winning the battle against one of the greatest enemies of progress in our time.</p>\n\n<p>And I say again, if we want to beat poverty, if we want to beat extremism and narrow the gap between the richest countries in the world and the poorest countries in the world, we have to tackle corruption.</p>\n\n<p>That is our mission. And that is the vital work that we have begun today and I want to thank everyone for their contributions.</p>\n</div>",
+    "location": "Anti-Corruption Summit, Lancaster House, London",
+    "delivered_on": "2016-05-12T12:30:00+00:00",
+    "speech_type_explanation": "Transcript of the speech, exactly as it was delivered",
+    "image": {
+      "alt_text": "The Rt Hon David Cameron MP",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/1/s465_David_Cameron.jpg"
+    },
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    },
+    "government": {
+      "title": "2015 Conservative government",
+      "slug": "2015-conservative-government",
+      "current": true
+    },
+    "political": true,
+    "emphasised_organisations": [
+      "d65d4203-01f5-4920-a3b1-f614bfd8e83e"
+    ]
+  },
+  "links": {
+    "organisations": [
+      {
+        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
+        "locale": "en",
+        "analytics_identifier": "OT532"
+      },
+      {
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office",
+        "api_path": "/api/content/government/organisations/cabinet-office",
+        "base_path": "/government/organisations/cabinet-office",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/cabinet-office",
+        "web_url": "https://www.gov.uk/government/organisations/cabinet-office",
+        "locale": "en",
+        "analytics_identifier": "D2"
+      }
+    ],
+    "speaker": [
+      {
+        "content_id": "8529186b-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon David Cameron MP",
+        "api_path": "/api/content/government/people/david-cameron",
+        "base_path": "/government/people/david-cameron",
+        "api_url": "https://www.gov.uk/api/content/government/people/david-cameron",
+        "web_url": "https://www.gov.uk/government/people/david-cameron",
+        "locale": "en"
+      }
+    ],
+    "topical_events": [
+      {
+        "content_id": "7dbb1a8b-2149-4aba-bd87-87bd929d3635",
+        "title": "Anti-Corruption Summit: London 2016",
+        "api_path": "/api/content/government/topical-events/anti-corruption-summit-london-2016",
+        "base_path": "/government/topical-events/anti-corruption-summit-london-2016",
+        "api_url": "https://www.gov.uk/api/content/government/topical-events/anti-corruption-summit-london-2016",
+        "web_url": "https://www.gov.uk/government/topical-events/anti-corruption-summit-london-2016",
+        "locale": "en"
+      }
+    ],
+    "policies": [
+      {
+        "content_id": "5d278051-7631-11e4-a3cb-005056011aef",
+        "title": "Government transparency and accountability",
+        "api_path": "/api/content/government/policies/government-transparency-and-accountability",
+        "base_path": "/government/policies/government-transparency-and-accountability",
+        "api_url": "https://www.gov.uk/api/content/government/policies/government-transparency-and-accountability",
+        "web_url": "https://www.gov.uk/government/policies/government-transparency-and-accountability",
+        "locale": "en"
+      },
+      {
+        "content_id": "5d3bf736-7631-11e4-a3cb-005056011aef",
+        "title": "Tax evasion and avoidance",
+        "api_path": "/api/content/government/policies/tax-evasion-and-avoidance",
+        "base_path": "/government/policies/tax-evasion-and-avoidance",
+        "api_url": "https://www.gov.uk/api/content/government/policies/tax-evasion-and-avoidance",
+        "web_url": "https://www.gov.uk/government/policies/tax-evasion-and-avoidance",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/speech/frontend/examples/speech-written-statement-parliament.json
+++ b/formats/speech/frontend/examples/speech-written-statement-parliament.json
@@ -1,0 +1,91 @@
+{
+  "base_path": "/government/speeches/school-revenue-funding-settlement-for-2017-to-2018",
+  "content_id": "d89435af-d77e-41f7-a945-4c63878007fd",
+  "schema_name": "speech",
+  "document_type": "written_statement",
+  "first_published_at": "2016-05-12T17:07:00.000+00:00",
+  "title": "School revenue funding settlement for 2017 to 2018",
+  "description": "Written ministerial statement by Nick Gibb MP about funding arrangements for schools in 2017 to 2018.",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "updated_at": "2016-12-20T16:58:18.370Z",
+  "public_updated_at": "2016-12-20T16:58:14+00:00",
+  "details": {
+    "first_public_at": "2016-12-20T16:58:14+00:00",
+    "body": "<div class=\"govspeak\"><p>Today I am announcing details of schools revenue funding for 2017-18. This announcement includes the dedicated schools grant (<abbr title=\"dedicated schools grant\">DSG</abbr>), the education services grant (<abbr title=\"education services grant\">ESG</abbr>) transitional grant and the pupil premium.</p><p>The distribution of the <abbr title=\"dedicated schools grant\">DSG</abbr> to local authorities will continue to be set out in 3 spending blocks for each authority: a schools block, a high needs block and an early years block.</p><p>The schools block has been allocated on the basis of the schools block units of funding announced in the <a href=\"https://www.gov.uk/government/speeches/schools-funding\">Secretary of State’s statement to the House on 21 July 2016</a>. To protect schools from significant budget reductions, we will continue with a minimum funding guarantee that ensures no school loses more than 1.5% per pupil in its 2017-18 budget (excluding sixth form funding and <abbr title=\"education services grant\">ESG</abbr>) compared to 2016-17, and before the pupil premium is added.</p><p>We have been able to provide an additional £130 million for the <abbr title=\"dedicated schools grant\">DSG</abbr> high needs block. The high needs block supports provision for pupils and students with special educational needs and disabilities (SEND), up to the age of 25, and alternative provision for pupils who cannot receive their education in schools.</p><p>The <abbr title=\"dedicated schools grant\">DSG</abbr> early years block comprises funding for the 15 hours entitlement for 3- and 4-year-olds: the additional 15 hours for 3- and 4-year-old children of eligible working parents from September 2017; participation funding for 2-year-olds from the most disadvantaged backgrounds; the early years pupil premium; and the disability access fund. The provisional allocations for this block were announced in the Secretary of State’s statement of 1 December 2016.</p><p>The <abbr title=\"education services grant\">ESG</abbr> transitional grant for local authorities will be set at a financial year rate of £66 per pupil and paid for the period April to August 2017. We will also continue to provide a protection to limit the reduction of academies’ budgets as a result of the ending of <abbr title=\"education services grant\">ESG</abbr> from September 2017.</p><p>The pupil premium per pupil amounts for 2017-18 will be protected at the current rates, which are:</p><table>  <thead>    <tr>      <th>Pupils</th>      <th>Per pupil rate</th>    </tr>  </thead>  <tbody>    <tr>      <td>Disadvantaged pupils: primary</td>      <td>£1,320</td>    </tr>    <tr>      <td>Disadvantaged pupils: secondary</td>      <td>£935</td>    </tr>    <tr>      <td>Pupil premium plus: looked-after children (<abbr title=\"looked-after children\">LAC</abbr>) and those adopted from care or who leave care under a special guardianship order or child arrangements order (formally known as a residence order)</td>      <td>£1,900</td>    </tr>    <tr>      <td>Service children</td>      <td>£300</td>    </tr>  </tbody></table><p>A looked-after child is defined in the Children Act 1989 as one who is in the care if, or provided accommodation by, and English or Welsh local authority.</p><p>Pupil premium allocations for financial year 2017-18 will be published in June 2017 following the receipt of pupil number data from the spring 2017 <a href=\"https://www.gov.uk/topic/schools-colleges-childrens-services/data-collection-statistical-returns\">schools and alternative provision censuses</a>.</p><p>Details of these arrangements have been published on GOV.UK.</p></div>",
+    "location": "House of Commons",
+    "delivered_on": "2016-12-20T15:00:00+00:00",
+    "image": {
+      "alt_text": "Nick Gibb MP",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/50/s465_Nick_Gibb_v2.jpg"
+    },
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    },
+    "government": {
+      "title": "2015 Conservative government",
+      "slug": "2015-conservative-government",
+      "current": true
+    },
+    "political": true,
+    "emphasised_organisations": [
+      "ebd15ade-73b2-4eaf-b1c3-43034a42eb37"
+    ]
+  },
+  "links": {
+    "organisations": [
+      {
+        "content_id": "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
+        "title": "Department for Education",
+        "api_path": "/api/content/government/organisations/department-for-education",
+        "base_path": "/government/organisations/department-for-education",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-education",
+        "locale": "en",
+        "analytics_identifier": "D6"
+      },
+      {
+        "content_id": "b9fc8528-81d1-419b-8748-6c00be71044b",
+        "title": "Education Funding Agency",
+        "api_path": "/api/content/government/organisations/education-funding-agency",
+        "base_path": "/government/organisations/education-funding-agency",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/education-funding-agency",
+        "web_url": "https://www.gov.uk/government/organisations/education-funding-agency",
+        "locale": "en",
+        "analytics_identifier": "EA242"
+      }
+    ],
+    "speaker": [
+      {
+        "content_id": "852930e9-c0f1-11e4-8223-005056011aef",
+        "title": "Nick Gibb MP",
+        "api_path": "/api/content/government/people/nick-gibb",
+        "base_path": "/government/people/nick-gibb",
+        "api_url": "https://www.gov.uk/api/content/government/people/nick-gibb",
+        "web_url": "https://www.gov.uk/government/people/nick-gibb",
+        "locale": "en"
+      }
+    ],
+    "policies": [
+      {
+        "content_id": "5d278051-7631-11e4-a3cb-005056011aef",
+        "title": "School and college funding",
+        "api_path": "/api/content/government/policies/school-and-college-funding",
+        "base_path": "/government/policies/school-and-college-funding",
+        "api_url": "https://www.gov.uk/api/content/government/policies/school-and-college-funding",
+        "web_url": "https://www.gov.uk/government/policies/school-and-college-funding",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/speech/frontend/examples/speech.json
+++ b/formats/speech/frontend/examples/speech.json
@@ -1,0 +1,71 @@
+{
+  "base_path": "/government/speeches/andrea-leadsoms-speech-at-women-in-nuclear-uk-conference",
+  "content_id": "b22d5555-096a-4793-9f4d-779644191054",
+  "schema_name": "speech",
+  "document_type": "speech",
+  "first_published_at": "2016-03-08T10:31:22.000+00:00",
+  "title": "Andrea Leadsom's speech at Women in Nuclear UK Conference",
+  "description": "Addressing the Gender Imbalance in the Nuclear Industry.",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "updated_at": "2016-08-11T16:50:59.535Z",
+  "public_updated_at": "2016-03-08T10:31:22.000+00:00",
+  "details": {
+    "first_public_at": "2016-03-08T10:31:22.000+00:00",
+    "body": "<div class=\"govspeak\"><h2 id=\"introduction\">Introduction</h2>\n\n<p>I am very pleased to be here today supporting Women in Nuclear UK’s mission to address the gender imbalance in the nuclear sector and delighted to speak to you as part of the only all women Commons Ministerial team!</p>\n\n<p>I have worked in a number of male dominated sectors so, for me, this issue has a deep, personal resonance.</p>\n\n<p>We can send people to the moon. We can explore the vast depths of our oceans. We can build great cities and towering structures. We can even talk to our computers. We have achieved greatness in many areas. But on the issue of gender imbalance, while there has been progress in the UK and around the world, far more needs to be done.</p>\n\n<p>It is imperative that we empower women now and for the future.  A great number of British women have inspired us throughout history, succeeding against all the odds, to blaze a trail for future generations to follow.</p>\n\n<p>Down through the centuries, British women have made their mark; in areas such as politics, literature, medicine, and social reform.</p>\n\n<p>Jane Austen the great novelist, Dorothy Hodgkin won the Nobel Prize in Chemistry in 1964, and Helen Sharman was the first British woman in space.</p>\n\n<p>We look to them, and many others, with pride and revel in their legacy that changed our society forever.</p>\n\n<p>These women serve as a reminder as to what can be achieved when women are given the opportunity to reach their full potential.</p>\n\n<p>I want the nuclear industry to be a launch pad for the next generation of world changing women pioneers, I want the nuclear industry to provide strong female role models, strong female leaders and a strong female presence in the sector’s workforce.</p>\n\n<p>Today I want to set out why it is imperative that we address the gender imbalance, what initiatives are in place within the nuclear industry and what more can be done.</p>\n\n<h2 id=\"gender-balance-globally-and-the-uk\">Gender balance globally and the UK</h2>\n\n<p>The World Economic Forum’s 2015 Global Gender Gap Report ranks 145 economies according to how well they leverage their female talent pool. The UK is in 18th place, up from 26th place in 2014. Iceland holds the top spot, 5 years in a row, with three Nordic countries following close behind.</p>\n\n<p>What is the reason behind these countries’ success?  Among other equitable policies, it is the combination of high female labour force participation, salary gaps between men and women being among the lowest in the world and abundant opportunities for women to rise to positions of leadership. We must learn from these countries leading in the area of gender balance.</p>\n\n<p>However, according to PwC, more than two thirds of the UK’s biggest 100 energy companies fail to count a single woman on their boards. In the nuclear industry, only 8 women hold board positions out of the 100 positions available.  Additionally, the NIA reports that of its members’ - 64,000 employees - only 17% are female.  In engineering, IT and technical sectors, women earn on average £10K less than their male colleagues.</p>\n\n<p>The nuclear industry can and must do much better than this.</p>\n\n<h2 id=\"benefits-of-gender-equality-in-the-nuclear-sector\">Benefits of gender equality in the nuclear sector</h2>\n\n<p>So, why should the industry concern itself with gender imbalance?  The simple answer is that a nuclear industry which is equally appealing to both women and men will provide nuclear sector companies with access to the entire pool of talent the UK has to offer.</p>\n\n<p>Conversely, an industry that is not attractive to women risks losing the best talent to competitors.</p>\n\n<p>The fact remains that companies with a gender balance perform better because diversity brings together varied perspectives. Simply put, the nuclear sector cannot reach its full potential without maximising all available talents.</p>\n\n<h2 id=\"the-skills-gap-challenge\">The skills gap challenge</h2>\n\n<p>So, as we deliver the UK’s nuclear programme over the decades to come, it is imperative that we address the skills gap. In 2015 the total demand for skilled nuclear workers was approximately 77,000 Full Time Equivalents. This number is expected to rise as both the civil and defence nuclear new build programmes gather pace. Demand is forecast to peak in 2021 at over 111,000.</p>\n\n<p>The nuclear industry thrives on innovation in areas such as decommissioning and small modular reactors.  A diverse workforce is therefore far more likely to support innovation.</p>\n\n<p>And the fact remains, we are going to need a more skilled workforce across the civil and defence nuclear sectors. By not attracting women to the sector, we will be, by default, recruiting from a much smaller pool than we need to. So it therefore makes absolute sense to attract more women to these sectors.</p>\n\n<h2 id=\"current-initiatives\">Current initiatives</h2>\n\n<p>We are making progress.</p>\n\n<p>The new MentorSet scheme, co-ordinated by the Women’s Engineering Society, will help women in Science, Technology, Engineering and Maths by providing independent mentors who understand the challenges faced in the engineering and allied sectors.</p>\n\n<p>The Department for Energy and Climate Change is already a member and I encourage you all to join as well. By participating in the MentorSet scheme you will be demonstrating a clear commitment to your female employees and to the Women’s Engineering Society’s vision of a better and more diverse world.</p>\n\n<p>Additionally, Women in Nuclear launched an Industry Charter that lays out 10 points which business leaders signing up to must address. 30 companies have already signed up to the Industry Charter.</p>\n\n<p>In 2014, EDF Energy more than doubled the female proportion of its new intake of graduate engineers to 32% within a year. At EDF, women now account for 20% of the company’s apprentices, up from 6% and I was delighted to meet some of those apprentices on my recent visit to EDF’s Cannington Court at the end of last year.</p>\n\n<p>Also, the Nuclear Industry Association’s “Regeneration” campaign seeks to engage young people on issues relating to energy and provides information about jobs and skills available to them in the industry. This initiative encourages young people, especially girls to continue to study STEM subjects.</p>\n\n<h2 id=\"encouraging-women-to-pursue-stem-subjects\">Encouraging women to pursue STEM subjects</h2>\n\n<p>These subjects are of course crucial.  But in the UK, only 1 woman to every 7 men works in science, technology, engineering and maths.  We need to get more girls interested and excited about STEM subjects.</p>\n\n<p>The nuclear industry has some great STEM initiatives. WiN UK have done a terrific job in getting the message to young girls that they can have a successful career by pursuing these subjects. In 2015, WiN UK spoke to over 1,000 students about the fulfilling careers the nuclear sector has to offer.</p>\n\n<p>Also, EDF’s “Pretty Curious” campaign is helping to change perceptions of STEM by sparking the imagination of young girls and inspiring them to continue to pursue science-based subjects at school and in their careers.</p>\n\n<p>There are already success stories. Amy, without wanting to copy the leader of the opposition too much, I just wanted to mention, is 21 and an electrical maintenance technician at Hinkley Point B. Bethany who is a 23 year old reactor chemistry engineer at Heysham 2 Nuclear Power Station. Also, on a visit to Sellafield, I met Dorothy, who has a key role leading innovative Sellafield decommissioning.</p>\n\n<p>There could be countless more women just like Amy, Bethany and Dorothy, but we need to create the right environment, provide the right tools and not expect girls to fit into the existing framework for achieving success.</p>\n\n<h2 id=\"prominent-women-in-nuclear-and-the-need-for-more-women-in-senior-positions\">Prominent women in nuclear and the need for more women in senior positions</h2>\n\n<p>In more senior, leadership roles we have Dame Sue Ion, Chair of the Nuclear Innovation and Research Advisory Board and an expert advisor on the nuclear power industry.</p>\n\n<p>Ann McCall is the waste management director at RWM and Kinna Kintrea, the assurance director at the NDA has a long history of working in manufacturing and male dominated environments.</p>\n\n<p>And of course, my congratulations go to Miranda Kirschel, the chair of Women in Nuclear UK, who was just recently awarded an MBE for services to promote equal opportunities in the nuclear industry.</p>\n\n<p>I am also delighted that the Office for Nuclear Regulation has hired its first female Chief Executive.  I know you heard from Adriènne Kelbie earlier today and I’m sure she will do a fantastic job.</p>\n\n<p>It is through these high profile appointments that we really will start to effect change. We need to see more women in positions of leadership, and the only way to achieve this is for leaders in the nuclear industry, whether they be male or female, to enable and champion this change. Change must come not only from the top, but at the grassroots level as well. I want women in senior and high profile positions to be the norm, not the exception.</p>\n\n<p>All these women demonstrate it is possible to be successful in what are currently male dominated sectors.  I worked in the banking and finance industry for 25 years, then went into politics and now I am a Government Minister – all typically male dominated arenas. I know from my own experience that Women can succeed in these areas given the right opportunities.</p>\n\n<h2 id=\"what-more-can-be-done\">What more can be done</h2>\n\n<p>But more needs to be done. The Industry Charter, that I mentioned earlier, is a great way to get you, the business leaders in the nuclear sector to take a look at your own organisations and your recruitment practices. I urge you to review the targets you have set for your organisations on the recruitment of women and set new, more ambitious goals.</p>\n\n<p>Also, we must continue to break the perception that STEM subjects are just for boys and encourage more girls to take up these subjects.</p>\n\n<p>We need businesses to step up their game. We need to see more females in adverts that send a clear message that women are not only welcome but will be given the same opportunities as men.  And we need to hear from more female scientists about the work they do. We need to roll out a different set of role models so that girls and women know that science and the nuclear sector are areas which they can work in, successfully and equally.</p>\n\n<h2 id=\"conclusion\">Conclusion</h2>\n\n<p>The transition towards a low carbon economy through our commitment to building a new generation of nuclear power plants represents a fresh opportunity for the nuclear industry to embrace gender equality. We have an opportunity to be a world class leader in narrowing the gender imbalance. How we address this issue may well set a precedent for other industries and countries.</p>\n\n<p>It is imperative that companies in the nuclear sector take individual ownership of tackling the issue of gender imbalance, and place diversity firmly at the heart of their recruitment, retention and progression.</p>\n\n<p>We want a sector that welcomes women and one that provides the same opportunities as to their male counterparts. Let us chart a new and better path for the women of this country.</p>\n</div>",
+    "location": "Women in Nuclear UK Conference, Church House Conference Centre, Dean's Yard, Westminster, London",
+    "delivered_on": "2016-02-02T00:00:00+00:00",
+    "speech_type_explanation": "Original script, may differ from delivered version",
+    "image": {
+      "alt_text": "The Rt Hon Andrea Leadsom MP",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/1557/s465_TME_3767TME_3767_960_Leadsom.JPG"
+    },
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    },
+    "government": {
+      "title": "2015 Conservative government",
+      "slug": "2015-conservative-government",
+      "current": true
+    },
+    "political": true,
+    "emphasised_organisations": [
+      "d65d4203-01f5-4920-a3b1-f614bfd8e83e"
+    ]
+  },
+  "links": {
+    "organisations": [
+      {
+        "content_id": "d65d4203-01f5-4920-a3b1-f614bfd8e83e",
+        "title": "Department of Energy & Climate Change",
+        "api_path": "/api/content/government/organisations/department-of-energy-climate-change",
+        "base_path": "/government/organisations/department-of-energy-climate-change",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-of-energy-climate-change",
+        "web_url": "https://www.gov.uk/government/organisations/department-of-energy-climate-change",
+        "locale": "en",
+        "analytics_identifier": "D11"
+      }
+    ],
+    "speaker": [
+      {
+        "content_id": "853df7fd-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon Andrea Leadsom MP",
+        "api_path": "/api/content/government/people/andrea-leadsom",
+        "base_path": "/government/people/andrea-leadsom",
+        "api_url": "https://www.gov.uk/api/content/government/people/andrea-leadsom",
+        "web_url": "https://www.gov.uk/government/people/andrea-leadsom",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/formats/speech/publisher/details.json
+++ b/formats/speech/publisher/details.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+    "required": [
+      "body",
+      "government",
+      "political",
+      "delivered_on"
+    ],
+  "properties": {
+    "body": {
+      "type": "string"
+    },
+    "first_public_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "speech_type_explanation": {
+      "description": "Details about the type of speech",
+      "type": "string"
+    },
+    "speaker_without_profile": {
+      "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
+      "type": "string"
+    },
+    "location": {
+      "type": "string"
+    },
+    "delivered_on": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "$ref": "#/definitions/government"
+    },
+    "political": {
+      "$ref": "#/definitions/political"
+    },
+    "image": {
+      "$ref": "#/definitions/image"
+    },
+    "change_history": {
+      "$ref": "#/definitions/change_history"
+    },
+    "emphasised_organisations": {
+      "$ref": "#/definitions/emphasised_organisations"
+    },
+    "tags": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    }
+  }
+}

--- a/formats/speech/publisher/links.json
+++ b/formats/speech/publisher/links.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "speaker": {
+      "description": "A speaker that has a GOV.UK profile",
+      "$ref": "#/definitions/guid_list",
+      "maxItems": 1
+    },
+    "policies": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "ministers": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "topical_events": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "world_locations": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}


### PR DESCRIPTION
* Add details and links schema for speeches
* Add examples for draft transcript, transcript, written to parliament and authored article types of speech
* Add example where speaker doesn't have a GOV.UK page (eg The Queen)

There are no known features missing from the schema.

## Speaker images

The images are pulled from the profile of the assigned speaker. For now the frontend expects this to come from the `image` property in the details. It may in future make more sense for it to come via an image property in the links hash of the speaker – as that's the dependency.

Story: https://trello.com/c/TWsLTRzc/547-10-speech-migration-mvp-content-schema-examples-and-front-end-work