### PR TITLE
Add CMA case type and outcomes for competition disqualifications

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -820,6 +820,7 @@
           "type": "string",
           "enum": [
             "ca98-and-civil-cartels",
+            "competition-disqualification",
             "criminal-cartels",
             "markets",
             "mergers",
@@ -880,6 +881,9 @@
             "ca98-infringement-chapter-ii",
             "ca98-administrative-priorities",
             "ca98-commitment",
+            "competition-disqualification-order-granted",
+            "competition-disqualification-undertaking-given",
+            "competition-disqualification-no-order-granted-or-undertaking-given",
             "criminal-cartels-verdict",
             "markets-phase-1-no-enforcement-action",
             "markets-phase-1-undertakings-in-lieu-of-reference",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -822,6 +822,7 @@
           "type": "string",
           "enum": [
             "ca98-and-civil-cartels",
+            "competition-disqualification",
             "criminal-cartels",
             "markets",
             "mergers",
@@ -882,6 +883,9 @@
             "ca98-infringement-chapter-ii",
             "ca98-administrative-priorities",
             "ca98-commitment",
+            "competition-disqualification-order-granted",
+            "competition-disqualification-undertaking-given",
+            "competition-disqualification-no-order-granted-or-undertaking-given",
             "criminal-cartels-verdict",
             "markets-phase-1-no-enforcement-action",
             "markets-phase-1-undertakings-in-lieu-of-reference",

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -774,6 +774,7 @@
           "type": "string",
           "enum": [
             "ca98-and-civil-cartels",
+            "competition-disqualification",
             "criminal-cartels",
             "markets",
             "mergers",
@@ -834,6 +835,9 @@
             "ca98-infringement-chapter-ii",
             "ca98-administrative-priorities",
             "ca98-commitment",
+            "competition-disqualification-order-granted",
+            "competition-disqualification-undertaking-given",
+            "competition-disqualification-no-order-granted-or-undertaking-given",
             "criminal-cartels-verdict",
             "markets-phase-1-no-enforcement-action",
             "markets-phase-1-undertakings-in-lieu-of-reference",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -712,6 +712,7 @@
           "type": "string",
           "enum": [
             "ca98-and-civil-cartels",
+            "competition-disqualification",
             "criminal-cartels",
             "markets",
             "mergers",
@@ -772,6 +773,9 @@
             "ca98-infringement-chapter-ii",
             "ca98-administrative-priorities",
             "ca98-commitment",
+            "competition-disqualification-order-granted",
+            "competition-disqualification-undertaking-given",
+            "competition-disqualification-no-order-granted-or-undertaking-given",
             "criminal-cartels-verdict",
             "markets-phase-1-no-enforcement-action",
             "markets-phase-1-undertakings-in-lieu-of-reference",

--- a/formats/finder/frontend/examples/cma-cases.json
+++ b/formats/finder/frontend/examples/cma-cases.json
@@ -21,6 +21,10 @@
             "value": "ca98-and-civil-cartels"
           },
           {
+            "label": "Competition disqualification",
+            "value": "competition-disqualification"
+          },
+          {
             "label": "Criminal cartels",
             "value": "criminal-cartels"
           },
@@ -217,6 +221,18 @@
           {
             "label": "CA98 - commitments",
             "value": "ca98-commitment"
+          },
+          {
+            "label": "Competition disqualification - order granted",
+            "value": "competition-disqualification-order-granted"
+          },
+          {
+            "label": "Competition disqualification - undertaking given",
+            "value": "competition-disqualification-undertaking-given"
+          },
+          {
+            "label": "Competition disqualification - no order granted or undertaking given",
+            "value": "competition-disqualification-no-order-granted-or-undertaking-given"
           },
           {
             "label": "Criminal cartels - verdict",

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -237,6 +237,7 @@
           "type": "string",
           "enum": [
             "ca98-and-civil-cartels",
+            "competition-disqualification",
             "criminal-cartels",
             "markets",
             "mergers",
@@ -297,6 +298,9 @@
             "ca98-infringement-chapter-ii",
             "ca98-administrative-priorities",
             "ca98-commitment",
+            "competition-disqualification-order-granted",
+            "competition-disqualification-undertaking-given",
+            "competition-disqualification-no-order-granted-or-undertaking-given",
             "criminal-cartels-verdict",
             "markets-phase-1-no-enforcement-action",
             "markets-phase-1-undertakings-in-lieu-of-reference",


### PR DESCRIPTION
This has been requested by the CMA.

Trello: https://trello.com/c/60QIKF6z/393-cma-case-finder-adding-1-extra-case-type-3-extra-outcomes