### PR TITLE
Add service toolkit format

### DIFF
--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -1,0 +1,624 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "links",
+    "title",
+    "details",
+    "locale",
+    "content_id",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content received a major or minor update."
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "taxons": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_toolkit"
+      ]
+    },
+    "format": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collections": {
+          "type": "array",
+          "description": "Collections of links grouped under a title and description",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "links"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Collection title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Collection description"
+              },
+              "links": {
+                "type": "array",
+                "description": "Array of links in this collection",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "title",
+                    "url"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "description": "Link Title"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Link URL (absolute)"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Link description"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -1,0 +1,626 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "base_path",
+    "content_id",
+    "details",
+    "document_type",
+    "expanded_links",
+    "govuk_request_id",
+    "links",
+    "locale",
+    "redirects",
+    "routes",
+    "schema_name",
+    "title",
+    "update_type"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content received a major or minor update."
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_toolkit"
+      ]
+    },
+    "format": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collections": {
+          "type": "array",
+          "description": "Collections of links grouped under a title and description",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "links"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Collection title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Collection description"
+              },
+              "links": {
+                "type": "array",
+                "description": "Array of links in this collection",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "title",
+                    "url"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "description": "Link Title"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Link URL (absolute)"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Link description"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/dist/formats/service_manual_service_toolkit/publisher/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher/schema.json
@@ -1,0 +1,576 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "content_id",
+    "update_type",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content received a major or minor update."
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_toolkit"
+      ]
+    }
+  },
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collections": {
+          "type": "array",
+          "description": "Collections of links grouped under a title and description",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "links"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Collection title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Collection description"
+              },
+              "links": {
+                "type": "array",
+                "description": "Array of links in this collection",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "title",
+                    "url"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "description": "Link Title"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Link URL (absolute)"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Link description"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Panopticon.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -1,0 +1,394 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "previous_version": {
+      "type": "string"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Panopticon.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -1,0 +1,533 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "details",
+    "publishing_app",
+    "rendering_app",
+    "locale",
+    "routes",
+    "base_path",
+    "document_type",
+    "schema_name"
+  ],
+  "properties": {
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "public_updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/application_name"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "users"
+      ],
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    },
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "last_edited_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last time when the content received a major or minor update."
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "document_type": {
+      "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_toolkit"
+      ]
+    }
+  },
+  "definitions": {
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collections": {
+          "type": "array",
+          "description": "Collections of links grouped under a title and description",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "links"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Collection title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Collection description"
+              },
+              "links": {
+                "type": "array",
+                "description": "Array of links in this collection",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "title",
+                    "url"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "type": "string",
+                      "description": "Link Title"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Link URL (absolute)"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Link description"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "absolute_path": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+      "description": "A path only. Query string and/or fragment are not allowed."
+    },
+    "absolute_fullpath": {
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
+      "description": "A path with optional query string and/or fragment."
+    },
+    "analytics_identifier": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    },
+    "government": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
+        },
+        "current": {
+          "type": "boolean",
+          "description": "Is the government that published this document still the current government."
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "application_name": {
+      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+      "type": "string",
+      "pattern": "[a-z-]"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "political": {
+      "type": "boolean",
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "segments_mode": {
+          "enum": [
+            "preserve",
+            "ignore"
+          ],
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "asset_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "updated_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "A summary of the change"
+          },
+          "reason_for_change": {
+            "type": "string",
+            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
+          }
+        },
+        "required": [
+          "public_timestamp",
+          "note"
+        ]
+      }
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        },
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    }
+  }
+}

--- a/formats/service_manual_service_toolkit/frontend/examples/service_manual_service_toolkit.json
+++ b/formats/service_manual_service_toolkit/frontend/examples/service_manual_service_toolkit.json
@@ -6,27 +6,27 @@
   "details": {
     "collections": [
       {
-        "name": "Standards",
+        "title": "Standards",
         "description": "Meet the standards for government services",
         "links": [
           {
-            "name": "The Digital Service Standard",
+            "title": "The Digital Service Standard",
             "url": "https://www.gov.uk/service-manual/service-standard",
             "description": "Learn about the 18 point standard that government services must meet"
           },
           {
-            "name": "Service Manual",
+            "title": "Service Manual",
             "url": "https://www.gov.uk/service-manual",
             "description": "How to build a service that meets the standard: agile delivery, technology, user research, accessibility, training options and more"
           }
         ]
       },
       {
-        "name": "Buying",
+        "title": "Buying",
         "description": "Extra skills, people and technology to help build your service",
         "links": [
           {
-            "name": "Digital Marketplace",
+            "title": "Digital Marketplace",
             "url": "https://www.gov.uk/digital-marketplace",
             "description": "Buy cloud technology and specialist services for digital projects"
           }

--- a/formats/service_manual_service_toolkit/frontend/examples/service_manual_service_toolkit.json
+++ b/formats/service_manual_service_toolkit/frontend/examples/service_manual_service_toolkit.json
@@ -1,0 +1,45 @@
+{
+  "content_id": "648b0f5d-a3f7-44bb-95bc-87e0d16c69bf",
+  "public_updated_at": "2017-01-04T08:17:10+00:00",
+  "format": "service_manual_service_toolkit",
+  "locale": "en",
+  "details": {
+    "collections": [
+      {
+        "name": "Standards",
+        "description": "Meet the standards for government services",
+        "links": [
+          {
+            "name": "The Digital Service Standard",
+            "url": "https://www.gov.uk/service-manual/service-standard",
+            "description": "Learn about the 18 point standard that government services must meet"
+          },
+          {
+            "name": "Service Manual",
+            "url": "https://www.gov.uk/service-manual",
+            "description": "How to build a service that meets the standard: agile delivery, technology, user research, accessibility, training options and more"
+          }
+        ]
+      },
+      {
+        "name": "Buying",
+        "description": "Extra skills, people and technology to help build your service",
+        "links": [
+          {
+            "name": "Digital Marketplace",
+            "url": "https://www.gov.uk/digital-marketplace",
+            "description": "Buy cloud technology and specialist services for digital projects"
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+  },
+  "base_path": "/service-toolkit",
+  "description": "All you need to design, build and run services that meet government standards.",
+  "title": "Service Toolkit",
+  "updated_at": "2017-01-04T08:54:30+00:00",
+  "schema_name": "service_manual_service_toolkit",
+  "document_type": "service_manual_service_toolkit"
+}

--- a/formats/service_manual_service_toolkit/publisher/details.json
+++ b/formats/service_manual_service_toolkit/publisher/details.json
@@ -1,32 +1,44 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "collections": {
       "type": "array",
+      "description": "Collections of links grouped under a title and description",
       "items": {
         "type": "object",
+        "required": ["title", "links"],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
+          "title": {
+            "type": "string",
+            "description": "Collection title"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Collection description"
           },
           "links": {
             "type": "array",
+            "description": "Array of links in this collection",
             "items": {
               "type": "object",
+              "required": ["title", "url"],
+              "additionalProperties": false,
               "properties": {
-                "name": {
-                  "type": "string"
+                "title": {
+                  "type": "string",
+                  "description": "Link Title"
                 },
                 "url": {
                   "type": "string",
-                  "format": "uri"
+                  "format": "uri",
+                  "description": "Link URL (absolute)"
                 },
                 "description": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Link description"
                 }
               }
             }

--- a/formats/service_manual_service_toolkit/publisher/details.json
+++ b/formats/service_manual_service_toolkit/publisher/details.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "collections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/formats/service_manual_service_toolkit/publisher/links.json
+++ b/formats/service_manual_service_toolkit/publisher/links.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {}
+}

--- a/formats/service_manual_service_toolkit/publisher_v2/examples/service_manual_service_toolkit.json
+++ b/formats/service_manual_service_toolkit/publisher_v2/examples/service_manual_service_toolkit.json
@@ -1,0 +1,17 @@
+{
+  "publishing_app": "service-manual-publisher",
+  "rendering_app": "service-manual-frontend",
+  "locale": "en",
+  "details": {},
+  "base_path": "/service-toolkit",
+  "description": "All you need to design, build and run services that meet government standards.",
+  "title": "Service Toolkit",
+  "routes": [
+    {
+      "path": "/service-toolkit",
+      "type": "exact"
+    }
+  ],
+  "document_type": "service_manual_service_toolkit",
+  "schema_name": "service_manual_service_toolkit"
+}

--- a/formats/service_manual_service_toolkit/publisher_v2/examples/service_manual_service_toolkit.json
+++ b/formats/service_manual_service_toolkit/publisher_v2/examples/service_manual_service_toolkit.json
@@ -2,7 +2,37 @@
   "publishing_app": "service-manual-publisher",
   "rendering_app": "service-manual-frontend",
   "locale": "en",
-  "details": {},
+  "details": {
+    "collections": [
+      {
+        "title": "Standards",
+        "description": "Meet the standards for government services",
+        "links": [
+          {
+            "title": "The Digital Service Standard",
+            "url": "https://www.gov.uk/service-manual/service-standard",
+            "description": "Learn about the 18 point standard that government services must meet"
+          },
+          {
+            "title": "Service Manual",
+            "url": "https://www.gov.uk/service-manual",
+            "description": "How to build a service that meets the standard: agile delivery, technology, user research, accessibility, training options and more"
+          }
+        ]
+      },
+      {
+        "title": "Buying",
+        "description": "Extra skills, people and technology to help build your service",
+        "links": [
+          {
+            "title": "Digital Marketplace",
+            "url": "https://www.gov.uk/digital-marketplace",
+            "description": "Buy cloud technology and specialist services for digital projects"
+          }
+        ]
+      }
+    ]
+  },
   "base_path": "/service-toolkit",
   "description": "All you need to design, build and run services that meet government standards.",
   "title": "Service Toolkit",


### PR DESCRIPTION
We're building a new page as part of the service manual called the "service toolkit", which is a list of links to government products that looks [like this](https://govuk-product-page-prototypes.herokuapp.com/govuk-service-manual/index).

This adds a schema called `service_manual_service_toolkit` which will support that page.

https://trello.com/c/GHY41UJi/546-create-service-toolkit-page