### PR TITLE
Make schema generation and validation less obtuse

### DIFF
--- a/lib/tasks/combine_schemas.rake
+++ b/lib/tasks/combine_schemas.rake
@@ -117,4 +117,18 @@ task combine_publisher_schemas: %i{
   combine_publisher_v2_links
 }
 
-task combine_schemas: %i{combine_publisher_schemas combine_frontend_schemas}
+task :announce_combining_schemas do 
+  print "Combining (generating) schemas... "
+end
+
+task :announce_combining_schemas_done do
+  puts "✔︎"
+end
+
+desc 'Combine (generate) schemas'
+task combine_schemas: %i{
+  announce_combining_schemas
+  combine_publisher_schemas
+  combine_frontend_schemas
+  announce_combining_schemas_done
+}

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -22,50 +22,64 @@ def validate_schemas(schema_file_list)
     begin
       JSON::Validator.fully_validate(schema, {}, validate_schema: true)
     rescue JSON::Schema::ValidationError => e
-      validation_errors << "Schema: #{schema}: #{e.message}"
+      validation_errors << "#{schema}: #{e.message}"
     end
   end
-  abort "The following schemas aren't valid:\n" + validation_errors.join("\n") if validation_errors.any?
+  abort "\nThe following schemas aren't valid:\n" + validation_errors.join("\n") if validation_errors.any?
 end
 
+desc 'Validate that source schemas are valid schemas'
 task :validate_source_schemas do
-  schemas = Rake::FileList.new("formats/**/*.json")
-  validate_schemas(schemas)
+  print "Validating source schemas... "
+  validate_schemas(Rake::FileList.new("formats/**/*.json"))
+  puts "✔︎"
 end
 
+desc 'Validate that generated schemas are valid schemas'
 task :validate_dist_schemas do
+  print "Validating generated schemas... "
   validate_schemas(Rake::FileList.new("dist/formats/**/*.json"))
+  puts "✔︎"
 end
 
+desc 'Validate examples against generated schemas'
 task :validate_examples do
+  print "Validating examples... "
   examples = Rake::FileList.new("formats/**/examples/*.json")
   failed_examples = examples.reject { |example| valid?(example) }
-  abort "The following examples don't validate against their schemas:\n" + failed_examples.join("\n") if failed_examples.any?
+  abort "\nThe following examples don't validate against their schemas:\n" + failed_examples.join("\n") if failed_examples.any?
+  puts "✔︎"
 end
 
+desc 'Validate uniqueness of frontend example base paths'
 task :validate_uniqueness_of_frontend_example_base_paths, :files do |_, args|
+  print "Checking that all frontend examples have unique base paths... "
   frontend_examples = args[:files] || Rake::FileList.new("formats/*/frontend/examples/*.json")
   grouped = frontend_examples.group_by { |file| base_path(file) }
   duplicates = grouped.select { |_, group| group.count > 1 }
 
   if duplicates.any?
-    $stderr.puts "#{duplicates.count} duplicate(s) found:"
+    $stderr.puts "\n#{duplicates.count} duplicate(s) found:"
 
     duplicates.each do |_, group|
       group.each { |filename| $stderr.puts "  #{filename}" }
     end
     abort
   end
+  puts "✔︎"
 end
 
+desc 'Validate links'
 task :validate_links, :files do |_, args|
+  print "Validating links... "
   link_schemas = args[:files] || Rake::FileList.new("formats/*/*/links.json")
   link_schemas.each do |filename|
     schema = JSON.parse(File.read(filename))
     if schema["required"]
-      $stderr.puts "ERROR: #{filename} has required links (#{schema["required"].inspect})"
+      $stderr.puts "\nERROR: #{filename} has required links (#{schema["required"].inspect})"
       $stderr.puts "This is disallowed because the publishing-api wouldn't be able to validate partial payloads when sending a PATCH links request."
       abort
     end
   end
+  puts "✔︎"
 end


### PR DESCRIPTION
It’s not clear what’s going on when you run rake to validate and generate the schemas, so:

- Provide some output to explain what’s going on rather than exiting with no output on a successful run.
- Add descriptions to some of the important rake tasks so that they’re listed when you run rake -T

## Example output
```
$ bundle exec rake
Validating source schemas... ✔︎
Combining (generating) schemas... ✔︎
Validating generated schemas... ✔︎
Checking that all frontend examples have unique base paths... ✔︎
Validating links... ✔︎
Validating examples... ✔︎
```

## Rake task list
```
$ bundle exec rake -T
rake clean                                                      # Remove any temporary products
rake clobber                                                    # Remove any generated file
rake combine_schemas                                            # Combine (generate) schemas
rake new_format[format_name]                                    # creates the folders and files for adding a new format
rake spec                                                       # Run RSpec code examples
rake validate_dist_schemas                                      # Validate that generated schemas are valid schemas
rake validate_examples                                          # Validate examples against generated schemas
rake validate_links[files]                                      # Validate links
rake validate_source_schemas                                    # Validate that source schemas are valid schemas
rake validate_uniqueness_of_frontend_example_base_paths[files]  # Validate uniqueness of frontend example base paths
```