### PR TITLE
Use new document type for official and national stats announcement examples

### DIFF
--- a/formats/statistics_announcement/frontend/examples/cancelled_official_statistics.json
+++ b/formats/statistics_announcement/frontend/examples/cancelled_official_statistics.json
@@ -43,5 +43,5 @@
   "title": "Diagnostic imaging dataset for September 2015",
   "updated_at": "2016-01-17T14:19:42.460Z",
   "schema_name": "statistics_announcement",
-  "document_type": "statistics_announcement"
+  "document_type": "official_statistics_announcement"
 }

--- a/formats/statistics_announcement/frontend/examples/national_statistics.json
+++ b/formats/statistics_announcement/frontend/examples/national_statistics.json
@@ -41,5 +41,5 @@
   "title": "UK armed forces quarterly personnel report: 1 October 2015",
   "updated_at": "2014-11-17T14:19:42.460Z",
   "schema_name": "statistics_announcement",
-  "document_type": "statistics_announcement"
+  "document_type": "national_statistics_announcement"
 }

--- a/formats/statistics_announcement/frontend/examples/official_statistics.json
+++ b/formats/statistics_announcement/frontend/examples/official_statistics.json
@@ -41,5 +41,5 @@
   "title": "Diagnostic imaging dataset for September 2015",
   "updated_at": "2016-01-17T14:19:42.460Z",
   "schema_name": "statistics_announcement",
-  "document_type": "statistics_announcement"
+  "document_type": "official_statistics_announcement"
 }

--- a/formats/statistics_announcement/frontend/examples/release_date_changed.json
+++ b/formats/statistics_announcement/frontend/examples/release_date_changed.json
@@ -43,5 +43,5 @@
   "title": "Diagnostic imaging dataset for September 2015",
   "updated_at": "2016-01-17T14:19:42.460Z",
   "schema_name": "statistics_announcement",
-  "document_type": "statistics_announcement"
+  "document_type": "official_statistics_announcement"
 }


### PR DESCRIPTION
The document type for these examples was updated:
https://github.com/alphagov/whitehall/pull/2783

I needed an official statistics announcement example to test:
https://github.com/alphagov/government-frontend/pull/226