### PR TITLE
Basic .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+README.md
+LICENSE


### PR DESCRIPTION
This just ignores the most standard stuff for docker. In theory for this
repo it could probably ignore everything except `dist/*` but that seems
a bit drastic at this point.