### PR TITLE
Remove Government requirement for Consultations and Speeches

### DIFF
--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -230,7 +230,6 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "government",
         "political"
       ],
       "properties": {

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -226,7 +226,6 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "government",
         "political"
       ],
       "properties": {

--- a/dist/formats/consultation/publisher/schema.json
+++ b/dist/formats/consultation/publisher/schema.json
@@ -140,7 +140,6 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "government",
         "political"
       ],
       "properties": {

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -136,7 +136,6 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "government",
         "political"
       ],
       "properties": {

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -236,7 +236,6 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "government",
         "political",
         "delivered_on"
       ],

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -226,7 +226,6 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "government",
         "political",
         "delivered_on"
       ],

--- a/dist/formats/speech/publisher/schema.json
+++ b/dist/formats/speech/publisher/schema.json
@@ -140,7 +140,6 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "government",
         "political",
         "delivered_on"
       ],

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -136,7 +136,6 @@
       "additionalProperties": false,
       "required": [
         "body",
-        "government",
         "political",
         "delivered_on"
       ],

--- a/formats/consultation/publisher/details.json
+++ b/formats/consultation/publisher/details.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "body",
-    "government",
     "political"
   ],
   "properties": {

--- a/formats/speech/publisher/details.json
+++ b/formats/speech/publisher/details.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
     "required": [
       "body",
-      "government",
       "political",
       "delivered_on"
     ],


### PR DESCRIPTION
The publishing applications are able to create draft documents for Consultations and Speeches that will happen in the future. We are not able to determine what the Government of the future will be so we can not require it be provided if we are to persist drafts.

This will be reviewed when the publishing applications are upgraded.

Some additional context can be found in the current publishing application Whitehall: https://github.com/alphagov/whitehall/commit/06a3a30fe7306825d84b01cce9bcd29fa556443e