### PR TITLE
Update generated files to fix CI build

### DIFF
--- a/dist/formats/world_location_news_article/publisher/schema.json
+++ b/dist/formats/world_location_news_article/publisher/schema.json
@@ -211,7 +211,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Panopticon.",
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -24,7 +24,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Panopticon.",
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {


### PR DESCRIPTION
The schema.json and links.json files were not up-to-date, probably because a merged PR overwrote some changes from an earlier PR.

The correct schema have been generated by running 'bundle exec rake'.