### PR TITLE
Tweak example text for the CMA finder content item

### DIFF
--- a/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
+++ b/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
@@ -126,8 +126,8 @@
     ],
     "email_filter_by": "case_type",
     "subscription_list_title_prefix": {
-      "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
-      "plural": "Competition and Markets Authority (CMA) cases with the following case types: "
+      "singular": "CMA cases with the following case type: ",
+      "plural": "CMA cases with the following case types: "
     }
   }
 }

--- a/formats/finder_email_signup/publisher_v2/examples/finder_email_signup.json
+++ b/formats/finder_email_signup/publisher_v2/examples/finder_email_signup.json
@@ -19,8 +19,8 @@
     "beta": false,
     "email_filter_by": "case_type",
     "subscription_list_title_prefix": {
-      "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
-      "singular": "Competition and Markets Authority (CMA) cases with the following case type: "
+      "plural": "CMA cases with the following case types: ",
+      "singular": "CMA cases with the following case type: "
     },
     "email_signup_choice": [
       {


### PR DESCRIPTION
When a new email alert subscription is created, a short name is generated describing the subscription. If enough subscription items are chosen by the user, the short name becomes longer than 255 characters, which is the GovDelivery limit for this field.

This commit tweaks the text for the finder content item examples to reflect changes made to the CMA case finder to keep the short text under 255 characters.

Trello: https://trello.com/c/KTHRa4a0/422-fix-email-alert-api-errors-when-the-email-alert-short-name-is-longer-than-255-characters