### PR TITLE
Add fact_check_ids list to access_limited hash

### DIFF
--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/publisher/schema.json
+++ b/dist/formats/consultation/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/publisher/schema.json
+++ b/dist/formats/generic/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/publisher/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/publisher/schema.json
+++ b/dist/formats/need/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/publisher/schema.json
+++ b/dist/formats/service_manual_homepage/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/publisher/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/publisher/schema.json
+++ b/dist/formats/speech/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher/schema.json
+++ b/dist/formats/statistical_data_set/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/publisher/schema.json
+++ b/dist/formats/world_location_news_article/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },
@@ -211,7 +212,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Panopticon.",
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -24,7 +24,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Panopticon.",
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -66,13 +66,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [ "users" ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },


### PR DESCRIPTION
The field will contain a list of GUIDs that will be accepted when requesting access to this item for fact checking.

(This will be used in content-store to compare to a value extracted from a JWT token in the URL.)