### PR TITLE
Add need id to Need details

### DIFF
--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -270,6 +270,10 @@
           "type": "string",
           "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
         },
+        "need_id": {
+          "type": "string",
+          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future."
+        },
         "status": {
           "type": "string",
           "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -272,6 +272,10 @@
           "type": "string",
           "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
         },
+        "need_id": {
+          "type": "string",
+          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future."
+        },
         "status": {
           "type": "string",
           "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"

--- a/dist/formats/need/publisher/schema.json
+++ b/dist/formats/need/publisher/schema.json
@@ -186,6 +186,10 @@
           "type": "string",
           "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
         },
+        "need_id": {
+          "type": "string",
+          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future."
+        },
         "status": {
           "type": "string",
           "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -182,6 +182,10 @@
           "type": "string",
           "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
         },
+        "need_id": {
+          "type": "string",
+          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future."
+        },
         "status": {
           "type": "string",
           "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"

--- a/formats/need/publisher/details.json
+++ b/formats/need/publisher/details.json
@@ -50,6 +50,10 @@
       "type": "string",
       "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
     },
+    "need_id": {
+      "type": "string",
+      "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future."
+    },
     "status": {
       "type": "string",
       "description": "Validation status of the need, ie. proposed, valid, not valid or valid with conditions"


### PR DESCRIPTION
Maslow needs to display the need_id so it must be stored in the Publishing API.
This adds it to the details - another option would have been to store it in the
need_ids array, which is in the base schema, but that's used for tagging
content items to needs, so not relevant for storing the need_id of needs
themselves.

https://trello.com/c/jlXiAdmQ/7-add-needs-to-publishing-api