### PR TITLE
Configure more dependent CI builds in Jenkins 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,12 @@ def dependentApplications = [
   'businesssupportfinder',
   'collections',
   'collections-publisher',
+  'content-tagger',
   'finder-frontend',
   'policy-publisher',
   'rummager',
   'specialist-publisher',
+  'whitehall',
 ]
 
 node {


### PR DESCRIPTION
Trigger the builds of several content-tagger and whitehall, to test the production version of those against the latest changes to the content schema.

This is still not the full list of dependent projects - this is just the subset which have been recently configured in puppet to handle builds of 'deployed-to-production' correctly in alphagov/govuk-puppet#5335. Other downstream builds will be migrated from Jenkins 1 once they have also
been updated in Puppet.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration