### PR TITLE
Add more text options for email alerts

### DIFF
--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -270,6 +270,27 @@
             }
           ]
         },
+        "email_filter_name": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "plural": {
+                  "type": "string"
+                },
+                "singular": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "subscription_list_title_prefix": {
           "oneOf": [
             {
@@ -279,6 +300,9 @@
                   "type": "string"
                 },
                 "singular": {
+                  "type": "string"
+                },
+                "many": {
                   "type": "string"
                 }
               }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -269,6 +269,27 @@
             }
           ]
         },
+        "email_filter_name": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "plural": {
+                  "type": "string"
+                },
+                "singular": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "subscription_list_title_prefix": {
           "oneOf": [
             {
@@ -278,6 +299,9 @@
                   "type": "string"
                 },
                 "singular": {
+                  "type": "string"
+                },
+                "many": {
                   "type": "string"
                 }
               }

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -183,6 +183,27 @@
             }
           ]
         },
+        "email_filter_name": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "plural": {
+                  "type": "string"
+                },
+                "singular": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "subscription_list_title_prefix": {
           "oneOf": [
             {
@@ -192,6 +213,9 @@
                   "type": "string"
                 },
                 "singular": {
+                  "type": "string"
+                },
+                "many": {
                   "type": "string"
                 }
               }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -179,6 +179,27 @@
             }
           ]
         },
+        "email_filter_name": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "plural": {
+                  "type": "string"
+                },
+                "singular": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "subscription_list_title_prefix": {
           "oneOf": [
             {
@@ -188,6 +209,9 @@
                   "type": "string"
                 },
                 "singular": {
+                  "type": "string"
+                },
+                "many": {
                   "type": "string"
                 }
               }

--- a/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
+++ b/formats/finder_email_signup/frontend/examples/cma-cases-email-signup.json
@@ -125,9 +125,14 @@
       }
     ],
     "email_filter_by": "case_type",
+    "email_filter_name": {
+      "singular": "case type",
+      "plural": "case types"
+    },
     "subscription_list_title_prefix": {
-      "singular": "CMA cases with the following case type: ",
-      "plural": "CMA cases with the following case types: "
+      "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
+      "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
+      "many": "Competition and Markets Authority (CMA) cases: "
     }
   }
 }

--- a/formats/finder_email_signup/frontend/examples/raib-report-email-signup.json
+++ b/formats/finder_email_signup/frontend/examples/raib-report-email-signup.json
@@ -96,9 +96,14 @@
       }
     ],
     "email_filter_by": "railway_type",
+    "email_filter_name": {
+      "singular": "railway type",
+      "plural": "railway types"
+    },
     "subscription_list_title_prefix": {
       "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",
-      "plural": "Rail Accident Investigation Branch (RAIB) reports with the following railway types: "
+      "plural": "Rail Accident Investigation Branch (RAIB) reports with the following railway types: ",
+      "many": "Rail Accident Investigation Branch (RAIB) reports: "
     }
   }
 }

--- a/formats/finder_email_signup/publisher/details.json
+++ b/formats/finder_email_signup/publisher/details.json
@@ -47,6 +47,27 @@
         }
       ]
     },
+    "email_filter_name": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "plural": {
+              "type": "string"
+            },
+            "singular": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "subscription_list_title_prefix": {
       "oneOf": [
         {
@@ -56,6 +77,9 @@
               "type": "string"
             },
             "singular": {
+              "type": "string"
+            },
+            "many": {
               "type": "string"
             }
           }

--- a/formats/finder_email_signup/publisher_v2/examples/finder_email_signup.json
+++ b/formats/finder_email_signup/publisher_v2/examples/finder_email_signup.json
@@ -18,9 +18,14 @@
   "details": {
     "beta": false,
     "email_filter_by": "case_type",
+    "email_filter_name": {
+      "singular": "case type",
+      "plural": "case types"
+    },
     "subscription_list_title_prefix": {
-      "plural": "CMA cases with the following case types: ",
-      "singular": "CMA cases with the following case type: "
+      "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
+      "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
+      "many": "Competition and Markets Authority (CMA) cases: "
     },
     "email_signup_choice": [
       {


### PR DESCRIPTION
This commit adds the ability to define a separate email alert list title text which will be used when the normally generated string is too long (> 255 characters). It will be appended with a string of the form “x items”, where “x” is the number of selected topics and “items” is either the singular or plural string defined as `email_filter_name`.

Also reverts https://github.com/alphagov/govuk-content-schemas/pull/482 since this is a more comprehensive solution.

Trello: https://trello.com/c/KTHRa4a0/422-fix-email-alert-api-errors-when-the-email-alert-short-name-is-longer-than-255-characters