### PR TITLE
Add news article schema and examples

### DIFF
--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -3,13 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "base_path",
+    "links",
     "title",
     "details",
-    "publishing_app",
-    "rendering_app",
     "locale",
-    "routes",
-    "base_path",
+    "content_id",
     "document_type",
     "schema_name"
   ],
@@ -53,34 +52,6 @@
         "type": "string"
       }
     },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "users"
-      ],
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
@@ -99,26 +70,67 @@
     "withdrawn_notice": {
       "$ref": "#/definitions/withdrawn_notice"
     },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "last_edited_at": {
       "type": "string",
       "format": "date-time",
       "description": "Last time when the content received a major or minor update."
     },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ministers": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     },
     "document_type": {
       "type": "string"
@@ -126,11 +138,96 @@
     "schema_name": {
       "type": "string",
       "enum": [
-        "world_location_news_article"
+        "news_article"
       ]
+    },
+    "format": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
     }
   },
   "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -177,6 +274,9 @@
               }
             }
           }
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
         },
         "government": {
           "$ref": "#/definitions/government"

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -3,15 +3,19 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "title",
-    "details",
-    "publishing_app",
-    "rendering_app",
-    "locale",
-    "routes",
     "base_path",
+    "content_id",
+    "details",
     "document_type",
-    "schema_name"
+    "expanded_links",
+    "govuk_request_id",
+    "links",
+    "locale",
+    "redirects",
+    "routes",
+    "schema_name",
+    "title",
+    "update_type"
   ],
   "properties": {
     "base_path": {
@@ -53,34 +57,6 @@
         "type": "string"
       }
     },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "users"
-      ],
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "analytics_identifier": {
       "$ref": "#/definitions/analytics_identifier"
     },
@@ -99,19 +75,50 @@
     "withdrawn_notice": {
       "$ref": "#/definitions/withdrawn_notice"
     },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "last_edited_at": {
       "type": "string",
       "format": "date-time",
       "description": "Last time when the content received a major or minor update."
     },
-    "previous_version": {
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "document_type": {
       "type": "string"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "news_article"
+      ]
+    },
+    "format": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/route"
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
     },
     "update_type": {
       "enum": [
@@ -120,17 +127,100 @@
         "republish"
       ]
     },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "world_location_news_article"
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
       ]
+    },
+    "expanded_links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
     }
   },
   "definitions": {
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "properties": {
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -177,6 +267,9 @@
               }
             }
           }
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
         },
         "government": {
           "$ref": "#/definitions/government"

--- a/dist/formats/news_article/publisher/schema.json
+++ b/dist/formats/news_article/publisher/schema.json
@@ -9,7 +9,8 @@
     "rendering_app",
     "locale",
     "routes",
-    "base_path",
+    "content_id",
+    "update_type",
     "document_type",
     "schema_name"
   ],
@@ -105,13 +106,13 @@
         "string"
       ]
     },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
     "last_edited_at": {
       "type": "string",
       "format": "date-time",
       "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
     },
     "update_type": {
       "enum": [
@@ -120,13 +121,16 @@
         "republish"
       ]
     },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
     "document_type": {
       "type": "string"
     },
     "schema_name": {
       "type": "string",
       "enum": [
-        "world_location_news_article"
+        "news_article"
       ]
     }
   },
@@ -178,11 +182,65 @@
             }
           }
         },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
         "government": {
           "$ref": "#/definitions/government"
         },
         "political": {
           "$ref": "#/definitions/political"
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -2,190 +2,63 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "title",
-    "details",
-    "publishing_app",
-    "rendering_app",
-    "locale",
-    "routes",
-    "base_path",
-    "document_type",
-    "schema_name"
-  ],
   "properties": {
-    "base_path": {
-      "$ref": "#/definitions/absolute_path"
-    },
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "public_updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/application_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/application_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "users"
-      ],
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
-    "details": {
-      "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
     "previous_version": {
       "type": "string"
     },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "document_type": {
-      "type": "string"
-    },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "world_location_news_article"
-      ]
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "type": "string"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "first_public_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "browse_pages": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "topics": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "policies": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        }
-      }
-    },
     "absolute_path": {
       "type": "string",
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -126,7 +126,7 @@
     "schema_name": {
       "type": "string",
       "enum": [
-        "world_location_news_article"
+        "news_article"
       ]
     }
   },
@@ -177,6 +177,9 @@
               }
             }
           }
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
         },
         "government": {
           "$ref": "#/definitions/government"

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -301,9 +301,6 @@
               }
             }
           }
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -291,9 +291,6 @@
               }
             }
           }
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/speech/publisher/schema.json
+++ b/dist/formats/speech/publisher/schema.json
@@ -205,9 +205,6 @@
               }
             }
           }
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -201,9 +201,6 @@
               }
             }
           }
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -280,9 +280,6 @@
         },
         "political": {
           "$ref": "#/definitions/political"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -273,9 +273,6 @@
         },
         "political": {
           "$ref": "#/definitions/political"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/world_location_news_article/publisher/schema.json
+++ b/dist/formats/world_location_news_article/publisher/schema.json
@@ -187,9 +187,6 @@
         },
         "political": {
           "$ref": "#/definitions/political"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/formats/news_article/frontend/examples/news_article.json
+++ b/formats/news_article/frontend/examples/news_article.json
@@ -64,7 +64,7 @@
     "government": {
       "current": true,
       "slug": "2015-conservative-government",
-      "title": "2015-conservative-government"
+      "title": "2015 Conservative government"
     },
     "emphasised_organisations": [
       "705dbea4-8bd7-422e-ba9c-254557f77f81"

--- a/formats/news_article/frontend/examples/news_article.json
+++ b/formats/news_article/frontend/examples/news_article.json
@@ -1,0 +1,85 @@
+{
+  "base_path": "/government/news/christmas-2016-prime-ministers-message",
+  "content_id": "d0ee80cd-ed7a-4b04-b60f-3be2f03693af",
+  "document_type": "news_story",
+  "first_published_at": "2016-12-25T00:15:06.000+00:00",
+  "locale": "en",
+  "public_updated_at": "2016-12-25T00:15:02.000+00:00",
+  "schema_name": "news_article",
+  "title": "Christmas 2016: Prime Minister's message",
+  "updated_at": "2016-12-25T00:15:07.824Z",
+  "links": {
+    "organisations": [
+      {
+        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
+        "locale": "en",
+        "analytics_identifier": "OT532"
+      }
+    ],
+    "ministers": [
+      {
+        "content_id": "85291e63-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon Theresa May MP",
+        "api_path": "/api/content/government/people/theresa-may",
+        "base_path": "/government/people/theresa-may",
+        "api_url": "https://www.gov.uk/api/content/government/people/theresa-may",
+        "web_url": "https://www.gov.uk/government/people/theresa-may",
+        "locale": "en"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "d0ee80cd-ed7a-4b04-b60f-3be2f03693af",
+        "title": "Christmas 2016: Prime Minister's message",
+        "api_path": "/api/content/government/news/christmas-2016-prime-ministers-message",
+        "base_path": "/government/news/christmas-2016-prime-ministers-message",
+        "api_url": "https://www.gov.uk/api/content/government/news/christmas-2016-prime-ministers-message",
+        "web_url": "https://www.gov.uk/government/news/christmas-2016-prime-ministers-message",
+        "locale": "en"
+      },
+      {
+        "content_id": "d0ee80cd-ed7a-4b04-b60f-3be2f03693af",
+        "title": "کرسمس 2016ء : وزیراعظم کا پیغام",
+        "api_path": "/api/content/government/news/christmas-2016-prime-ministers-message.ur",
+        "base_path": "/government/news/christmas-2016-prime-ministers-message.ur",
+        "api_url": "https://www.gov.uk/api/content/government/news/christmas-2016-prime-ministers-message.ur",
+        "web_url": "https://www.gov.uk/government/news/christmas-2016-prime-ministers-message.ur",
+        "locale": "ur"
+      }
+    ]
+  },
+  "description": "Theresa May sends her best wishes to everyone celebrating Christmas in the UK and around the world.",
+  "details": {
+    "image": {
+      "alt_text": "Christmas",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/59695/s465_Christmas.jpg"
+    },
+    "body": "<div class=\"govspeak\"><p>Prime Minister Theresa May said:</p><blockquote>  <p>This year, the United Kingdom has had much to celebrate. Her Majesty The Queen celebrated her 90th birthday, surrounded by the Royal Family and well-wishers from across our four nations, the Commonwealth, and the world.</p>  <p>Four years after the success of London 2012, our Olympic and Paralympic athletes continued to work and train –  and they were rewarded by coming second in the medal table, <a href=\"https://www.gov.uk/government/news/rio-2016-message-from-prime-minister-theresa-may\">becoming the first team ever to increase its medal haul four years after hosting the Games</a>.  Many of us will have more personal memories too, of happy times with family and friends.  These are precious moments when people from many backgrounds, with different beliefs, come together to celebrate in families and communities.</p>  <p>Coming together is also important for us as a country. As <a href=\"https://www.gov.uk/government/topics/europe\">we leave the European Union</a> we must seize an historic opportunity to forge a bold new role for ourselves in the world and to unite our country as we move forward into the future.  And, with our international partners, we must work together to promote trade, increase prosperity and face the challenges to peace and security around the world.</p>  <p>As we gather with our friends and families at this time of year we proudly celebrate the birth of Christ and the message of forgiveness, love and hope that he brings.  We also think of Christians in other parts of the world who face persecution this Christmas and re-affirm our determination to stand up for the freedom of people of all religions to practise their beliefs in peace and safety.</p>  <p>Having grown up in a vicarage, I know how demanding it can be for those who have to work over the Christmas period.  So it’s right for all of us to express our gratitude to those who will have to spend Christmas away from the people they love in looking after others: those in our health and care services, those who work with the vulnerable, as well as those who will be caring for a loved one.</p>  <p>And <a href=\"https://www.gov.uk/government/news/prime-ministers-christmas-2016-message-to-the-armed-forces\">we thank those in our Armed Forces, security agencies, and emergency services who work all year round to keep our country safe</a> – especially those who will be separated by their duty from their families and friends.</p>  <p class=\"last-child\">Wherever you are this Christmas, I wish you joy and peace in this season of celebration, along with health and happiness in the year ahead.</p></blockquote></div>",
+    "first_public_at": "2016-12-25T00:15:02.000+00:00",
+    "government": {
+      "current": true,
+      "slug": "2015-conservative-government",
+      "title": "2015-conservative-government"
+    },
+    "emphasised_organisations": [
+      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+    ],
+    "political": true,
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    }
+  }
+}

--- a/formats/news_article/frontend/examples/news_article_government_response.json
+++ b/formats/news_article/frontend/examples/news_article_government_response.json
@@ -44,7 +44,7 @@
     "government": {
       "current": true,
       "slug": "2015-conservative-government",
-      "title": "2015-conservative-government"
+      "title": "2015 Conservative government"
     },
     "emphasised_organisations": [
       "8d56bb52-2f79-4b6d-9fc6-6d7dcc4f7586"

--- a/formats/news_article/frontend/examples/news_article_government_response.json
+++ b/formats/news_article/frontend/examples/news_article_government_response.json
@@ -1,0 +1,65 @@
+{
+  "base_path": "/government/news/fish-washed-up-on-cornwall-beach",
+  "content_id": "4ae92ddf-5ba6-4ec4-a7d5-7648ea4c9ffd",
+  "document_type": "government_response",
+  "first_published_at": "2016-12-28T00:00:19.000+00:00",
+  "locale": "en",
+  "public_updated_at": "2016-12-28T00:00:19.000+00:00",
+  "schema_name": "news_article",
+  "title": "Fish washed up on Cornwall beach",
+  "updated_at": "2017-01-10T10:52:47.712Z",
+  "links": {
+    "organisations": [
+      {
+        "content_id": "8d56bb52-2f79-4b6d-9fc6-6d7dcc4f7586",
+        "title": "Marine Management Organisation",
+        "api_path": "/api/content/government/organisations/marine-management-organisation",
+        "base_path": "/government/organisations/marine-management-organisation",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/marine-management-organisation",
+        "web_url": "https://www.gov.uk/government/organisations/marine-management-organisation",
+        "locale": "en",
+        "analytics_identifier": "PB57"
+      }
+    ],
+    "policies": [
+      {
+        "content_id": "5d5e94fa-7631-11e4-a3cb-005056011aef",
+        "title": "Marine environment",
+        "api_path": "/api/content/government/policies/marine-environment",
+        "base_path": "/government/policies/marine-environment",
+        "api_url": "https://www.gov.uk/api/content/government/policies/marine-environment",
+        "web_url": "https://www.gov.uk/government/policies/marine-environment",
+        "locale": "en"
+      }
+    ]
+  },
+  "description": "The Marine Management Organisation response to reports of a large number of dead fish being washed ashore in Cornwall.",
+  "details": {
+    "image": {
+      "alt_text": "St Michael's Mount Cornwall",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/59446/s465_iStock-183412793.jpg"
+    },
+    "body": "<div class=\"govspeak\"><p>We are aware of a large number of dead fish which washed ashore on Marazion beach, Cornwall, on 17 December.</p><p>We are working with others, such as the <a rel=\"external\" href=\"http://www.cornwall-ifca.gov.uk/\">Cornwall Inshore Fisheries and Conservation Authority</a>, to look into this.</p><p>We have discussed the issue with the Marine Conservation Society and are looking at the activity of vessels in the area. It is however too early to say what the cause might be.</p><p>We advise against eating any of the remaining fish as the timing and cause of their death has not been established.</p></div>",
+    "first_public_at": "2016-12-28T00:00:19.000+00:00",
+    "government": {
+      "current": true,
+      "slug": "2015-conservative-government",
+      "title": "2015-conservative-government"
+    },
+    "emphasised_organisations": [
+      "8d56bb52-2f79-4b6d-9fc6-6d7dcc4f7586"
+    ],
+    "political": false,
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    }
+  }
+}

--- a/formats/news_article/frontend/examples/news_article_history_mode.json
+++ b/formats/news_article/frontend/examples/news_article_history_mode.json
@@ -1,0 +1,74 @@
+{
+  "base_path": "/government/news/final-care-act-guidance-published",
+  "content_id": "60267088-7631-11e4-a3cb-005056011aef",
+  "document_type": "news_story",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "locale": "en",
+  "public_updated_at": "2016-02-29T09:24:10.000+00:00",
+  "schema_name": "news_article",
+  "title": "Final Care Act guidance published",
+  "updated_at": "2017-01-10T10:52:47.712Z",
+  "links": {
+    "organisations": [
+      {
+        "content_id": "7cd6bf12-bbe9-4118-8523-f927b0442156",
+        "title": "Department of Health",
+        "api_path": "/api/content/government/organisations/department-of-health",
+        "base_path": "/government/organisations/department-of-health",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-of-health",
+        "web_url": "https://www.gov.uk/government/organisations/department-of-health",
+        "locale": "en",
+        "analytics_identifier": "D12"
+      }
+    ],
+    "policies": [
+      {
+        "content_id": "5d606d99-7631-11e4-a3cb-005056011aef",
+        "title": "Health and social care integration",
+        "api_path": "/api/content/government/policies/health-and-social-care-integration",
+        "base_path": "/government/policies/health-and-social-care-integration",
+        "api_url": "https://www.gov.uk/api/content/government/policies/health-and-social-care-integration",
+        "web_url": "https://www.gov.uk/government/policies/health-and-social-care-integration",
+        "locale": "en"
+      },
+      {
+        "content_id": "5d635d59-7631-11e4-a3cb-005056011aef",
+        "title": "Choice in health and social care",
+        "api_path": "/api/content/government/policies/choice-in-health-and-social-care",
+        "base_path": "/government/policies/choice-in-health-and-social-care",
+        "api_url": "https://www.gov.uk/api/content/government/policies/choice-in-health-and-social-care",
+        "web_url": "https://www.gov.uk/government/policies/choice-in-health-and-social-care",
+        "locale": "en"
+      }
+    ]
+  },
+  "description": "The Care Act regulations and guidance for local authorities have been strengthened as a result of consultation.",
+  "details": {
+    "image": {
+      "alt_text": "placeholder",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/72/s465_RH_Flickr_image_960x640.jpg"
+    },
+    "body": "<div class=\"govspeak\"><p>The <a href=\"https://www.gov.uk/government/consultations/updating-our-care-and-support-system-draft-regulations-and-guidance\">government response</a> explains how the regulations and guidance, which come into effect from April 2015, have been revised as a result of the suggestions we received during the consultation.</p><p>We have made changes that include clarifying the guidance on adult safeguarding and revising the eligibility criteria to focus on outcomes and better address social isolation.</p><p>In addition to the <a href=\"https://www.gov.uk/government/consultations/updating-our-care-and-support-system-draft-regulations-and-guidance\">revised regulations</a> and <a href=\"https://www.gov.uk/government/publications/care-act-2014-statutory-guidance-for-implementation\">guidance for local authorities</a> there will be more materials to help those implementing the Care Act on <a rel=\"external\" href=\"http://www.local.gov.uk/care-support-reform\">the Local Government Association’s website.</a>. The <a href=\"https://www.gov.uk/government/publications/care-act-2014-part-1-factsheets\">Care Act factsheets</a> have also been updated.</p><p>The Care Act aims to make the social care system fairer and help people get better care.</p></div>",
+    "first_public_at": "2016-02-29T09:24:10.000+00:00",
+    "government": {
+      "current": false,
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government"
+    },
+    "emphasised_organisations": [
+      "7cd6bf12-bbe9-4118-8523-f927b0442156"
+    ],
+    "political": true,
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    }
+  }
+}

--- a/formats/news_article/frontend/examples/news_article_news_story_translated_arabic.json
+++ b/formats/news_article/frontend/examples/news_article_news_story_translated_arabic.json
@@ -64,7 +64,7 @@
     "government": {
       "current": true,
       "slug": "2015-conservative-government",
-      "title": "2015-conservative-government"
+      "title": "2015 Conservative government"
     },
     "emphasised_organisations": [
       "705dbea4-8bd7-422e-ba9c-254557f77f81"

--- a/formats/news_article/frontend/examples/news_article_news_story_translated_arabic.json
+++ b/formats/news_article/frontend/examples/news_article_news_story_translated_arabic.json
@@ -1,0 +1,85 @@
+{
+  "base_path": "/government/news/christmas-2016-prime-ministers-message.ur",
+  "content_id": "d0ee80cd-ed7a-4b04-b60f-3be2f03693af",
+  "document_type": "news_story",
+  "first_published_at": "2016-12-25T00:15:06.000+00:00",
+  "locale": "ur",
+  "public_updated_at": "2016-12-25T00:15:02.000+00:00",
+  "schema_name": "news_article",
+  "title": "کرسمس 2016ء : وزیراعظم کا پیغام",
+  "updated_at": "2016-12-25T00:15:07.824Z",
+  "links": {
+    "organisations": [
+      {
+        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
+        "locale": "en",
+        "analytics_identifier": "OT532"
+      }
+    ],
+    "ministers": [
+      {
+        "content_id": "85291e63-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon Theresa May MP",
+        "api_path": "/api/content/government/people/theresa-may",
+        "base_path": "/government/people/theresa-may",
+        "api_url": "https://www.gov.uk/api/content/government/people/theresa-may",
+        "web_url": "https://www.gov.uk/government/people/theresa-may",
+        "locale": "en"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "d0ee80cd-ed7a-4b04-b60f-3be2f03693af",
+        "title": "Christmas 2016: Prime Minister's message",
+        "api_path": "/api/content/government/news/christmas-2016-prime-ministers-message",
+        "base_path": "/government/news/christmas-2016-prime-ministers-message",
+        "api_url": "https://www.gov.uk/api/content/government/news/christmas-2016-prime-ministers-message",
+        "web_url": "https://www.gov.uk/government/news/christmas-2016-prime-ministers-message",
+        "locale": "en"
+      },
+      {
+        "content_id": "d0ee80cd-ed7a-4b04-b60f-3be2f03693af",
+        "title": "کرسمس 2016ء : وزیراعظم کا پیغام",
+        "api_path": "/api/content/government/news/christmas-2016-prime-ministers-message.ur",
+        "base_path": "/government/news/christmas-2016-prime-ministers-message.ur",
+        "api_url": "https://www.gov.uk/api/content/government/news/christmas-2016-prime-ministers-message.ur",
+        "web_url": "https://www.gov.uk/government/news/christmas-2016-prime-ministers-message.ur",
+        "locale": "ur"
+      }
+    ]
+  },
+  "description": "وزیراعظم ٹریزا مے نے برطانیہ اور دنیا بھر میں کرسمس منانے والوں کو پیغام تہنیت بھیجا ہے.",
+  "details": {
+    "image": {
+      "alt_text": "Christmas",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/59695/s465_Christmas.jpg"
+    },
+    "body": "<div class=\"govspeak\"><p>وزیراعظم ٹریزامے نے پیغام میں کہا ہے:</p><blockquote>  <p>اس سال برطانیہ کے پاس خوشی منانے کو بہت کچھ رہا ہے۔ ملکہ عالیہ نے نوے سالہ سالگرہ شاہی خاندان اور ہماری چاروں قوموں، دولت مشترکہ اور دنیا بھرکے خیرخواہوں کے درمیان منائی۔ لندن 2012ء کے بعد چار سال ہمارے اولمپک اور پیرا اولمپک کھلاڑیوں نے مشق اور تربیت جاری رکھی  اوراس کا صلہ انہیں اس اولمپکس میں تمغوں کی فہرست میں دوسرا مقام پانے سے ملا۔ اس طرح وہ دنیا میں وہ پہلی ٹیم بن گئے جس نے اپنے ہاں اولمپکس کی میزبانی کے بعد چارسال میں تمغوں کی تعداد میں اضافہ کر لیا ہو۔ ہم میں سے بہت سوں کو اپنے اہل خانہ اور دوستوں کے ساتھ خوشگوار لمحات بھی ملے ہوں گے اور ملیں گے۔ وہ بڑے قیمتی لمحات ہوتے ہیں جب مختلف پس ہائے منظر، مختلف عقائد کے حامل افراد مل جل کے اہل خانہ اور برادریوں کے ساتھ تہوار مناتے ہیں.</p>  <p>ایک ملک کی حیثیت سے بھی ہم سب کا اکھٹا ہونا بہت اہمیت رکھتا ہے۔ اب جبکہ ہم یورپی یونین چھوڑ رہے ہیں ہمیں دنیا میں ایک نیا کردار اپنانے اور مستقبل کی جانب سفر کرتے ہوئے ملک کو متحد رکھنےکے ایک تاریخی موقع سے فائدہ ضرور اٹھانا چاہئیے۔ اور ہمیں تجارت کے فروغ، خوشحالی میں اضافے اوردنیا میں امن و سلامتی کو درپیش چیلنجزکا سامنا کرنے کے لئے اپنے بین الاقوامی شراکت داروں کے ساتھ مل کر کام کرنا چاہئیے.</p>  <p>سال کے اس موقع پر جب ہم اپنے دوستوں اور اہل خانہ کے ساتھ اکھٹا ہوں تو ہم مسیح) حضرت عیسیٰ( کی پیدائش پر خوشی مناتے ہوئے اس سے حاصل ہونے والےبخشش کے پیغام، محبت اورامید کو یاد رکھنا چاہئیے۔ ہم دنیا کے دوسرے حصوں میں اس کرسمس پرظلم و ستم کا شکار مسیحیوں کے بارے میں بھی سوچتے ہیں اور تمام مذاہب کے ماننے والوں کی آزادی کےلئے کھڑے ہونے کے اپنے عزم کی توثیق کرتے ہیں کہ وہ امن اور سلامتی کے ساتھ اپنے عقائد پرعمل کرسکیں.</p>  <p>.ایک پادری کے گھر میں پلنے بڑھنے کی وجہ سے مجھے معلوم ہے کہ جنہیں کرسمس پر کام کرنا ہوتا ہے ان کے لئے یہ کتنا صبر آزما ہوتا ہے۔ لہذا ہم سب کو چاہئیے کہ ہم ان کے شکر گزار ہوں جو دوسروں کی خدمت کرتے ہوئے کرسمس کے ایام میں اپنے پیاروں سے دور ہوتے ہیں، وہ جو صحت اور دیکھ بھال کی خدمات سر انجام دیتے ہیں، جو کمزور افراد کے ساتھ ہوتے ہیں یا جو کسی عزیز کی دیکھ بھال کرتے ہیں۔ ہم مسلح افواج ، سیکیورٹی ایجنسیز اور ہنگامی سروسزکے شکر گزار ہیں جوملک کی حفاظت کے لئے سال بھر کام کرتے ہیں، خاص طورپرا ن کے جو فرائض کی انجام دہی میں اپنے اہل خانہ اوردوستوں سے دور ہوں</p>  <p class=\"last-child\">آپ اس کرسمس پر جہاں بھی ہوں، میں آپ کے لئے تقریبات کے ان ایام میں خوشی اورامن کی دعا کے ساتھ آنے والے سال میں صحت اورمسرت کی تمنا کرتی ہوں  .</p></blockquote></div>",
+    "first_public_at": "2016-12-25T00:15:02.000+00:00",
+    "government": {
+      "current": true,
+      "slug": "2015-conservative-government",
+      "title": "2015-conservative-government"
+    },
+    "emphasised_organisations": [
+      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+    ],
+    "political": true,
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    }
+  }
+}

--- a/formats/news_article/frontend/examples/news_article_press_release.json
+++ b/formats/news_article/frontend/examples/news_article_press_release.json
@@ -1,0 +1,54 @@
+{
+  "base_path": "/government/news/modern-life-responsible-for-worrying-health-in-middle-aged",
+  "content_id": "4ae92ddf-5ba6-4ec4-a7d5-7648ea4c9ffd",
+  "document_type": "press_release",
+  "first_published_at": "2016-12-28T00:00:19.000+00:00",
+  "locale": "en",
+  "public_updated_at": "2016-12-28T00:00:19.000+00:00",
+  "schema_name": "news_article",
+  "title": "Modern life responsible for ‘worrying’ health in middle aged",
+  "updated_at": "2017-01-10T10:52:47.712Z",
+  "links": {
+    "organisations": [
+      {
+        "content_id": "4ae92ddf-5ba6-4ec4-a7d5-7648ea4c9ffd",
+        "title": "Public Health England",
+        "api_path": "/api/content/government/organisations/public-health-england",
+        "base_path": "/government/organisations/public-health-england",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/public-health-england",
+        "web_url": "https://www.gov.uk/government/organisations/public-health-england",
+        "locale": "en",
+        "analytics_identifier": "OT532"
+      }
+    ]
+  },
+  "description": "PHE’s One You campaign is helping middle age people live more healthily by asking ‘How are you?’ and providing free support and tools.",
+  "details": {
+    "image": {
+      "alt_text": "How are you billboard",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/59771/s465_How_Are_You_billboard_960x640.jpg"
+    },
+    "body": "<div class=\"govspeak\"><p>Eight out of 10 of the middle aged either weigh too much, drink too much or don’t exercise enough, as new analysis from Public Health England (<abbr title=\"Public Health England\">PHE</abbr>) out today (28 December 2016) shows modern life taking its toll on health.</p><p><abbr title=\"Public Health England\">PHE</abbr>’s One You campaign is reaching out to the 83% of 40 to 60 year olds (87% of men and 79% of women) who are either overweight or obese, exceed the Chief Medical Officer’s (CMO) alcohol guidelines or are physically inactive, to provide free support and tools to help them live more healthily in 2017 and beyond.</p><p>Modern life is harming the health of the nation: 77% of men and 63% of women in middle age are overweight or obese. Obesity in adults has shot up 16% in the last 20 years. Many also can’t identify what a ‘healthy’ body looks like, suggesting obesity has become the new normal.</p><p>The diabetes rate among this age group also doubled in this period in England. Obese adults are more than 5 times more likely to develop Type 2 diabetes than those who are a healthy weight (a body mass index between 18.5 and 25). Ninety per cent of adults with diabetes have Type 24.</p><p>People are being urged to take a moment to consider their health and the simple steps they can take to improve it in the run up to the New Year, by taking the One You online quiz. People need to eat better, be more active, stop smoking and consider their drinking.</p><p>The quiz, called <a rel=\"external\" href=\"https://www.nhs.uk/oneyou/how-are-you\">‘How Are You’</a>, takes your lifestyle information, gives you a health score and then links to free localised, personalisable information, apps and tools.</p><p>More than 1.1 million people have taken the quiz so far and where appropriate, been directed to download our apps like Couch to 5K, Alcohol Checker and Easy Meals. Nearly a quarter of a million people have subsequently downloaded Couch to 5K.</p><p>These sit alongside <abbr title=\"Public Health England\">PHE</abbr>’s other online tools like the Heart Age tool which gives you your ‘heart age’ based on you age and lifestyle and we would also encourage people to take up their NHS Health Check invitation when they receive it.</p><p>Professor Kevin Fenton, Director of Health and Wellbeing at <abbr title=\"Public Health England\">PHE</abbr>, said:</p><blockquote>  <p>People are busy with work, with families, with the daily grind and sometimes their own health is the least of their priorities.</p>  <p class=\"last-child\">The How Are You Quiz will help anyone who wants to take a few minutes to take stock and find out quickly where they can take a little action to make a big difference to their health.</p></blockquote><p>Professor Sir Muir Gray, Clinical Adviser for the One You campaign, said:</p><blockquote>  <p class=\"last-child\">The demands of modern day living are taking their toll on the health of the nation, and it’s those in middle age that are suffering the consequences most, as their health reaches worrying new levels.</p></blockquote><blockquote>  <p class=\"last-child\">Over 15 million Britons are living with a long term health condition , and busy lives and desk jobs make it difficult to live healthily. But just making a few small changes will have significant benefits to people’s health now and in later life.</p></blockquote><p>Dan Howarth, Head of Care at Diabetes UK, said:</p><blockquote>  <p>We know that people often bury their heads in the sand when it comes to their general health but the consequences of doing nothing can be catastrophic. There are an estimated 11.9 million people at increased risk of developing Type 2 diabetes in the UK because of their lifestyle and more than one million who already have the condition but have not yet been diagnosed.</p>  <p class=\"last-child\">Type 2 diabetes can lead to serious complications such as amputation, blindness, heart attack, stroke and kidney disease. We know how hard it is to change the habits of a lifetime but we want people to seek the help they need to lose weight, stop smoking and take more exercise.</p></blockquote><p>Dr Ellie Cannon, NHS Doctor and media medic, said:</p><blockquote>  <p class=\"last-child\">Lots of us spend our lives working very hard, not sleeping enough and not always having time to exercise, so it can be really difficult to prioritise our health. But it’s vital to find out how you really are, so that you can get the advice and support you need. It’s never too late to improve your health and making small changes now can have a huge impact on your health in the future: it can even help to reverse preventable diseases. With the new year just around the corner, there’s no better time to start living better and enjoy the health benefits that will bring.</p></blockquote><h2 id=\"background\">Background</h2><ol>  <li>Search ‘One You’ online to take the <a rel=\"external\" href=\"https://www.nhs.uk/oneyou/how-are-you\">‘How Are You’</a> quiz.</li>  <li>Download content including <a rel=\"external\" href=\"https://www.dropbox.com/sh/97up7yizoracyd2/AAAx5SaUT_p0jJbKA6zuTuBka?dl=0\">images and a short animated film</a>.</li>  <li>Access the <a rel=\"external\" href=\"https://www.nhs.uk/tools/pages/heartage.aspx\">Heart Age tool</a>.</li>  <li>Find out more information on <a rel=\"external\" href=\"http://www.healthcheck.nhs.uk/\">NHS Health Checks</a>.</li>  <li><a href=\"https://www.gov.uk/government/organisations/public-health-england\"><abbr title=\"Public Health England\">PHE</abbr></a> exists to protect and improve the nation’s health and wellbeing and reduce health inequalities. It does this through advocacy, partnerships, world-class science, knowledge and intelligence, and the delivery of specialist public health services. <abbr title=\"Public Health England\">PHE</abbr> is an operationally autonomous executive agency of the Department of Health. www.gov.uk/phe. Follow us on Twitter @PHE_uk</li></ol><div class=\"contact \" id=\"contact_3198\">  <div class=\"content\">    <h3><abbr title=\"Public Health England\">PHE</abbr> press office</h3>    <div class=\"vcard contact-inner\">        <div class=\"email-url-number\">            <p class=\"tel\">              <span class=\"type\">Main switchboard</span>              020 7654 8000            </p>            <p class=\"tel\">              <span class=\"type\">Out of hours</span>              020 8200 4400            </p>        </div>    </div>  </div></div></div>",
+    "first_public_at": "2016-12-28T00:00:19.000+00:00",
+    "government": {
+      "current": true,
+      "slug": "2015-conservative-government",
+      "title": "2015-conservative-government"
+    },
+    "emphasised_organisations": [
+      "4ae92ddf-5ba6-4ec4-a7d5-7648ea4c9ffd"
+    ],
+    "political": false,
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    }
+  }
+}

--- a/formats/news_article/frontend/examples/news_article_press_release.json
+++ b/formats/news_article/frontend/examples/news_article_press_release.json
@@ -33,7 +33,7 @@
     "government": {
       "current": true,
       "slug": "2015-conservative-government",
-      "title": "2015-conservative-government"
+      "title": "2015 Conservative government"
     },
     "emphasised_organisations": [
       "4ae92ddf-5ba6-4ec4-a7d5-7648ea4c9ffd"

--- a/formats/news_article/publisher/details.json
+++ b/formats/news_article/publisher/details.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+   "body",
+   "first_public_at",
+   "government",
+   "political"
+  ],
+  "properties": {
+    "body": {
+      "type": "string"
+    },
+    "image": {
+      "$ref": "#/definitions/image"
+    },
+    "first_public_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "change_history": {
+      "$ref": "#/definitions/change_history"
+    },
+    "tags": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "emphasised_organisations": {
+      "$ref": "#/definitions/emphasised_organisations"
+    },
+    "government": {
+      "$ref": "#/definitions/government"
+    },
+    "political": {
+      "$ref": "#/definitions/political"
+    }
+  }
+}

--- a/formats/news_article/publisher/links.json
+++ b/formats/news_article/publisher/links.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "policies": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "ministers": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "topical_events": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "world_locations": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}

--- a/formats/speech/publisher/details.json
+++ b/formats/speech/publisher/details.json
@@ -69,9 +69,6 @@
           }
         }
       }
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
     }
   }
 }

--- a/formats/world_location_news_article/publisher/details.json
+++ b/formats/world_location_news_article/publisher/details.json
@@ -51,9 +51,6 @@
     },
     "political": {
       "$ref": "#/definitions/political"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
     }
   }
 }


### PR DESCRIPTION
* Add schema for news article
* Add examples for news story, translated news story, press release, government response and history mode
* Remove withdrawal notice from speeches and world location news articles - new formats that haven't yet been republished, they shouldn't have withdrawal notice in details as it's provided by default

Part of:
https://trello.com/c/Jse0oAvr/575-news-article-migration-1-mvp-content-schema-examples-and-front-end-work

Goes with:
https://github.com/alphagov/government-frontend/pull/232