### PR TITLE
Add Publisher to the dependent applications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ def dependentApplications = [
   'email-alert-service',
   'finder-frontend',
   'policy-publisher',
+  'publisher',
   'specialist-publisher',
   'whitehall',
 ]


### PR DESCRIPTION
Trello: https://trello.com/c/UCcCp13D/576-move-publisher-to-new-ci-infrastructure-1

In the context of moving Publisher to the new CI, we want to not rely anymore on Jenkins 1 also for schema tests.

The current PR adds Publisher to the dependentApplications list to kick off a build of it to test the schema.