### PR TITLE
Configure dependent CI builds for email applications in Jenkins 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ def dependentApplications = [
   'collections',
   'collections-publisher',
   'content-tagger',
+  'email-alert-frontend',
+  'email-alert-service',
   'finder-frontend',
   'policy-publisher',
   'rummager',


### PR DESCRIPTION
Trigger builds of email-alert-service and email-alert-frontend, to test the production version of those against the latest changes to the content schema.