### PR TITLE
Remove rummager from triggered CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ def dependentApplications = [
   'email-alert-service',
   'finder-frontend',
   'policy-publisher',
-  'rummager',
   'specialist-publisher',
   'whitehall',
 ]


### PR DESCRIPTION
As far as I can tell, Rummager doesn't actually depend directly on the content schemas, so it doesn't need to be built to test changes to this project.