### PR TITLE
Stop the Jenkins build immediately if schemas are out of date

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,11 +56,10 @@ node {
       schemasAreUpToDate = sh(script: "git diff --exit-code", returnStatus: true) == 0
 
       if (!schemasAreUpToDate) {
-        echo "Changes to checked-in files detected after running 'rake clean' " +
-          "and 'rake build'. If these are generated files, you might need to " +
-          "'rake clean build' to ensure they are regenerated and push the " +
-          "changes."
-        currentBuild.result = "FAILURE"
+        error("Changes to checked-in files detected after running 'rake clean' "
+          + "and 'rake build'. If these are generated files, you might need to "
+          + "'rake clean build' to ensure they are regenerated and push the "
+          + "changes.")
       }
     }
 


### PR DESCRIPTION
Prevent the expensive cross-project schema tests from running if the schemas are out of date. The build was already being (correctly) marked as a failure, but it should also stop immediately.

This should hopefully ease some of the queues on the CI server, because builds will fail fast before they kick off all the long-running downstream builds.