### PR TITLE
Check in the up-to-date generated schemas

### DIFF
--- a/dist/formats/news_article/publisher/schema.json
+++ b/dist/formats/news_article/publisher/schema.json
@@ -70,15 +70,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -69,15 +69,16 @@
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "users"
-      ],
       "properties": {
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "fact_check_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for fact checking."
         }
       }
     },


### PR DESCRIPTION
The generated schemas were out-of-sync with the source files.

I've generated up-to-date schemas using `bundle exec rake clean build`.

I suspect this was just due to the order in which #483 and #488 were merged. @fofr and @danielroseman - could you check that this fix is correct?