### PR TITLE
Remove reason for change from change history definition

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -578,10 +578,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -580,10 +580,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/answer/publisher/schema.json
+++ b/dist/formats/answer/publisher/schema.json
@@ -531,10 +531,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -526,10 +526,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -618,10 +618,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -611,10 +611,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -574,10 +574,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -402,10 +402,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -560,10 +560,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -582,10 +582,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -584,10 +584,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -535,10 +535,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -530,10 +530,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -659,10 +659,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -655,10 +655,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/consultation/publisher/schema.json
+++ b/dist/formats/consultation/publisher/schema.json
@@ -618,10 +618,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -402,10 +402,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -604,10 +604,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -775,10 +775,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -774,10 +774,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -728,10 +728,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -396,10 +396,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -659,10 +659,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -593,10 +593,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -592,10 +592,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/corporate_information_page/publisher/schema.json
+++ b/dist/formats/corporate_information_page/publisher/schema.json
@@ -546,10 +546,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -396,10 +396,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -538,10 +538,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -627,10 +627,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -620,10 +620,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -583,10 +583,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -402,10 +402,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -569,10 +569,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -630,10 +630,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -626,10 +626,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -587,10 +587,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -400,10 +400,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -575,10 +575,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -618,10 +618,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -620,10 +620,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -571,10 +571,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -566,10 +566,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -593,10 +593,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -589,10 +589,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -551,10 +551,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -401,10 +401,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -538,10 +538,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -625,10 +625,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -621,10 +621,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -581,10 +581,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -402,10 +402,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -567,10 +567,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -661,10 +661,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -660,10 +660,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -614,10 +614,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -396,10 +396,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -606,10 +606,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -572,10 +572,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -574,10 +574,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic/publisher/schema.json
+++ b/dist/formats/generic/publisher/schema.json
@@ -525,10 +525,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -520,10 +520,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -575,10 +575,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -577,10 +577,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic_with_external_related_links/publisher/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher/schema.json
@@ -528,10 +528,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -523,10 +523,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -579,10 +579,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -581,10 +581,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/guide/publisher/schema.json
+++ b/dist/formats/guide/publisher/schema.json
@@ -532,10 +532,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -527,10 +527,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -578,10 +578,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -580,10 +580,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/help_page/publisher/schema.json
+++ b/dist/formats/help_page/publisher/schema.json
@@ -531,10 +531,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -526,10 +526,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -590,10 +590,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -592,10 +592,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -543,10 +543,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -538,10 +538,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -594,10 +594,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -596,10 +596,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -547,10 +547,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -542,10 +542,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -591,10 +591,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -593,10 +593,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -544,10 +544,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -539,10 +539,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -610,10 +610,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -612,10 +612,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/local_transaction/publisher/schema.json
+++ b/dist/formats/local_transaction/publisher/schema.json
@@ -563,10 +563,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -558,10 +558,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -600,10 +600,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -590,10 +590,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -557,10 +557,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -409,10 +409,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -536,10 +536,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -590,10 +590,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -589,10 +589,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -546,10 +546,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -399,10 +399,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -535,10 +535,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -592,10 +592,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -591,10 +591,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -548,10 +548,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -399,10 +399,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -537,10 +537,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -639,10 +639,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -641,10 +641,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/need/publisher/schema.json
+++ b/dist/formats/need/publisher/schema.json
@@ -592,10 +592,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -587,10 +587,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -608,10 +608,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -601,10 +601,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/news_article/publisher/schema.json
+++ b/dist/formats/news_article/publisher/schema.json
@@ -567,10 +567,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -405,10 +405,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -550,10 +550,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -633,10 +633,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -635,10 +635,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -586,10 +586,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -581,10 +581,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -659,10 +659,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -646,10 +646,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -616,10 +616,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -412,10 +412,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -592,10 +592,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -618,10 +618,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -605,10 +605,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -574,10 +574,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -408,10 +408,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -554,10 +554,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -612,10 +612,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -608,10 +608,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -570,10 +570,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -401,10 +401,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -557,10 +557,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -571,10 +571,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -573,10 +573,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_homepage/publisher/schema.json
+++ b/dist/formats/service_manual_homepage/publisher/schema.json
@@ -524,10 +524,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -519,10 +519,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -578,10 +578,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -577,10 +577,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -532,10 +532,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -397,10 +397,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -523,10 +523,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -621,10 +621,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -623,10 +623,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_toolkit/publisher/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher/schema.json
@@ -574,10 +574,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -569,10 +569,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -591,10 +591,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -584,10 +584,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -547,10 +547,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -405,10 +405,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -530,10 +530,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -616,10 +616,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -618,10 +618,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -571,10 +571,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -546,10 +546,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -626,10 +626,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -616,10 +616,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/speech/publisher/schema.json
+++ b/dist/formats/speech/publisher/schema.json
@@ -587,10 +587,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -410,10 +410,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -565,10 +565,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -596,10 +596,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -598,10 +598,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistical_data_set/publisher/schema.json
+++ b/dist/formats/statistical_data_set/publisher/schema.json
@@ -552,10 +552,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -547,10 +547,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -608,10 +608,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -610,10 +610,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -561,10 +561,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -556,10 +556,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -582,10 +582,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -584,10 +584,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -535,10 +535,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -530,10 +530,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -582,10 +582,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -581,10 +581,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -536,10 +536,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -397,10 +397,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -527,10 +527,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -581,10 +581,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -580,10 +580,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -539,10 +539,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -401,10 +401,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -526,10 +526,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -582,10 +582,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -584,10 +584,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -535,10 +535,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -530,10 +530,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -639,10 +639,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -638,10 +638,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -592,10 +592,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -396,10 +396,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -584,10 +584,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -627,10 +627,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -626,10 +626,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -580,10 +580,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -396,10 +396,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -572,10 +572,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -595,10 +595,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -597,10 +597,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -548,10 +548,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -543,10 +543,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -578,10 +578,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -580,10 +580,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -531,10 +531,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -393,10 +393,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -526,10 +526,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -605,10 +605,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -598,10 +598,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/world_location_news_article/publisher/schema.json
+++ b/dist/formats/world_location_news_article/publisher/schema.json
@@ -561,10 +561,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -402,10 +402,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -547,10 +547,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -349,10 +349,6 @@
           "note": {
             "type": "string",
             "description": "A summary of the change"
-          },
-          "reason_for_change": {
-            "type": "string",
-            "description": "Why the change is being made. This is multiline text, and will be rendered inside <p> tags. Govspeak is not yet supported here."
           }
         },
         "required": [

--- a/formats/service_manual_guide/frontend/examples/point_page.json
+++ b/formats/service_manual_guide/frontend/examples/point_page.json
@@ -21,18 +21,15 @@
     "change_history": [
       {
         "public_timestamp": "2015-10-07T08:17:10+00:00",
-        "note": "This is our latest change",
-        "reason_for_change": "This is the reason for our latest change"
+        "note": "This is our latest change"
       },
       {
         "public_timestamp": "2015-09-09T08:17:10+00:00",
-        "note": "This is another change",
-        "reason_for_change": "This is why we made this change\nand it has a second line of text"
+        "note": "This is another change"
       },
       {
         "public_timestamp": "2015-09-01T08:17:10+00:00",
-        "note": "Guidance first published",
-        "reason_for_change": ""
+        "note": "Guidance first published"
       }
     ]
   },

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide.json
@@ -15,18 +15,15 @@
     "change_history": [
       {
         "public_timestamp": "2015-10-07T08:17:10+00:00",
-        "note": "This is our latest change",
-        "reason_for_change": "This is the reason for our latest change"
+        "note": "This is our latest change"
       },
       {
         "public_timestamp": "2015-09-09T08:17:10+00:00",
-        "note": "This is another change",
-        "reason_for_change": "This is why we made this change\nand it has a second line of text"
+        "note": "This is another change"
       },
       {
         "public_timestamp": "2015-09-01T08:17:10+00:00",
-        "note": "Guidance first published",
-        "reason_for_change": ""
+        "note": "Guidance first published"
       }
     ]
   },

--- a/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
+++ b/formats/service_manual_guide/frontend/examples/service_manual_guide_community.json
@@ -14,18 +14,15 @@
     "change_history": [
       {
         "public_timestamp": "2015-10-07T08:17:10+00:00",
-        "note": "This is our latest change",
-        "reason_for_change": "This is the reason for our latest change"
+        "note": "This is our latest change"
       },
       {
         "public_timestamp": "2015-09-09T08:17:10+00:00",
-        "note": "This is another change",
-        "reason_for_change": "This is why we made this change\nand it has a second line of text"
+        "note": "This is another change"
       },
       {
         "public_timestamp": "2015-09-01T08:17:10+00:00",
-        "note": "Guidance first published",
-        "reason_for_change": ""
+        "note": "Guidance first published"
       }
     ]
   },

--- a/formats/service_manual_guide/publisher_v2/examples/point_page.json
+++ b/formats/service_manual_guide/publisher_v2/examples/point_page.json
@@ -14,18 +14,15 @@
     "change_history": [
       {
         "public_timestamp": "2015-10-07T08:17:10+00:00",
-        "note": "This is our latest change",
-        "reason_for_change": "This is the reason for our latest change"
+        "note": "This is our latest change"
       },
       {
         "public_timestamp": "2015-09-09T08:17:10+00:00",
-        "note": "This is another change",
-        "reason_for_change": "This is why we made this change\nand it has a second line of text"
+        "note": "This is another change"
       },
       {
         "public_timestamp": "2015-09-01T08:17:10+00:00",
-        "note": "Guidance first published",
-        "reason_for_change": ""
+        "note": "Guidance first published"
       }
     ]
   },

--- a/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
+++ b/formats/service_manual_guide/publisher_v2/examples/service_manual_guide.json
@@ -13,18 +13,15 @@
     "change_history": [
       {
         "public_timestamp": "2015-10-07T08:17:10+00:00",
-        "note": "This is our latest change",
-        "reason_for_change": "This is the reason for our latest change"
+        "note": "This is our latest change"
       },
       {
         "public_timestamp": "2015-09-09T08:17:10+00:00",
-        "note": "This is another change",
-        "reason_for_change": "This is why we made this change\nand it has a second line of text"
+        "note": "This is another change"
       },
       {
         "public_timestamp": "2015-09-01T08:17:10+00:00",
-        "note": "Guidance first published",
-        "reason_for_change": ""
+        "note": "Guidance first published"
       }
     ]
   },


### PR DESCRIPTION
The `reason_for_change` field inside a change history definition was
added in #280 to support `service-manual-publisher`, which wanted both a
reason for change and a change note.

We're now removing the reason for change field as it's no longer
considered useful. This removes it from the shared definition.

In the 10 months that have elapsed since it was added, it doesn't appear
to be used by any other applications. Searching GitHub for non-JSON
references to "reason_for_change" outside of the
service-manual-publisher repo [yields nothing](https://github.com/search?utf8=%E2%9C%93&q=org%3Aalphagov+reason_for_change+-repo%3Aalphagov%2Fservice-manual-publisher+-language%3Ajson&type=Code&ref=searchresults).