### PR TITLE
Rough and ready script to compare used fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gem 'rspec'
 gem 'govuk-dummy_content_store', '0.0.5'
 gem 'foreman', '0.78.0'
 
+# Used for statistic purposes - not main validator
+gem 'json_schema', require: false
+
 group :test do
   gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       rack-contrib
     json-schema (2.5.0)
       addressable (~> 2.3)
+    json_schema (0.16.1)
     method_source (0.8.2)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -48,6 +49,7 @@ DEPENDENCIES
   foreman (= 0.78.0)
   govuk-dummy_content_store (= 0.0.5)
   json-schema
+  json_schema
   pry-byebug
   rake
   rspec

--- a/bin/schema_differences
+++ b/bin/schema_differences
@@ -1,0 +1,37 @@
+#! /usr/bin/env ruby
+
+require 'json'
+require 'json_schema'
+
+def schema_for(schema_name)
+  path = File.expand_path("../dist/formats/#{schema_name}/frontend/schema.json", __dir__)
+  schema = JsonSchema.parse!(JSON.load(File.read(path)))
+  schema.expand_references!
+  schema
+rescue Errno::ENOENT
+  nil
+end
+
+def fields_from(schema)
+  schema.properties["details"].properties.keys
+end
+
+fields = {}
+schemas = Dir[File.expand_path("../dist/formats/*", __dir__)].map { |s| s.split('/').last }
+
+schemas.each do |schema_name|
+  schema = schema_for(schema_name)
+  next unless schema
+  fields_from(schema).each do |field|
+    fields[field] ||= []
+    fields[field] << schema_name
+  end
+end
+
+puts (['schema_name'] + fields.keys).join(',')
+
+schemas.each do |schema_name|
+  columns = [schema_name]
+  columns += fields.keys.map { |f| 'x' if fields[f].include? schema_name }
+  puts columns.join(',')
+end


### PR DESCRIPTION
Generates a CSV comparing the different fields used in details hash
across all schemas. Run using:

```
bin/schema_differences > schemas.csv
```

/cc @tomnatt 