### PR TITLE
Add service manual to Jenkins dependent applications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,8 @@ def dependentApplications = [
   'finder-frontend',
   'policy-publisher',
   'publisher',
+  'service-manual-frontend',
+  'service-manual-publisher',
   'specialist-publisher',
   'whitehall',
 ]


### PR DESCRIPTION
We've updated the service manual to Jenkins 2, and set up content schema
tests per the ops manual. This adds `service-manual-publisher` and
`service-manual-frontend` to the list of dependent applications in the
Jenkins config, to ensure their tests are run when the schemas change.

Relevant PRs:
- alphagov/service-manual-frontend#100
- alphagov/service-manual-publisher#379
- alphagov/govuk-puppet#5392

See also https://github.gds/gds/opsmanual/blob/master/infrastructure/testing/application-testing.md#content-schema-tests