### PR TITLE
Add links to v2 metadata

### DIFF
--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -119,6 +119,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "document_type": {
       "type": "string"
     },

--- a/formats/v2_metadata.json
+++ b/formats/v2_metadata.json
@@ -24,6 +24,44 @@
         "republish"
       ]
     },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      },
+      "description": "Links associated with a particular edition of a document.",
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "available_translations"
+            ]
+          },
+          {
+            "required": [
+              "children"
+            ]
+          },
+          {
+            "required": [
+              "policies"
+            ]
+          },
+          {
+            "required": [
+              "document_collections"
+            ]
+          },
+          {
+            "required": [
+              "child_taxons"
+            ]
+          }
+        ]
+      }
+    },
     "change_note": {
       "type": [
         "null",


### PR DESCRIPTION
We are [adding edition-level links][1] to the `publishing-api` to support the [the 'draft link' workflow][0]. The schema needs to be updated to allow publishing apps to send their links to the `publishing-api` using the [put content][2] endpoint.

[0]: https://trello.com/c/Yd7RZaaT/870-edition-link-workflow-3
[1]: https://github.com/alphagov/publishing-api/pull/749
[2]: https://github.com/alphagov/publishing-api/blob/master/doc/api.md#put-v2contentcontent_id