### PR TITLE
Remove withdrawn notices from details

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -255,9 +255,6 @@
         "tags": {
           "$ref": "#/definitions/tags"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "archive_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -248,9 +248,6 @@
         "tags": {
           "$ref": "#/definitions/tags"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "archive_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -163,9 +163,6 @@
         "tags": {
           "$ref": "#/definitions/tags"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "archive_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -159,9 +159,6 @@
         "tags": {
           "$ref": "#/definitions/tags"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "archive_notice": {
           "type": "object",
           "additionalProperties": false,

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -310,9 +310,6 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -306,9 +306,6 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/consultation/publisher/schema.json
+++ b/dist/formats/consultation/publisher/schema.json
@@ -221,9 +221,6 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -217,9 +217,6 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -276,9 +276,6 @@
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -269,9 +269,6 @@
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -184,9 +184,6 @@
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -180,9 +180,6 @@
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -281,9 +281,6 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -277,9 +277,6 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -192,9 +192,6 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -188,9 +188,6 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -267,9 +267,6 @@
         "political": {
           "$ref": "#/definitions/political"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -254,9 +254,6 @@
         "political": {
           "$ref": "#/definitions/political"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -169,9 +169,6 @@
         "political": {
           "$ref": "#/definitions/political"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -165,9 +165,6 @@
         "political": {
           "$ref": "#/definitions/political"
         },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -247,9 +247,6 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -249,9 +249,6 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher/schema.json
+++ b/dist/formats/statistical_data_set/publisher/schema.json
@@ -164,9 +164,6 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -160,9 +160,6 @@
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
         }
       }
     },

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -42,11 +42,7 @@
     },
     "emphasised_organisations": [
       "dbeaa22b-fb0c-49b0-b44e-0ca6cb52b381"
-    ],
-    "withdrawn_notice": {
-      "explanation": "<div class=\"govspeak\"><p>We’ve withdrawn this case study and published newer <a href=\"https://www.gov.uk/government/collections/work-programme-real-life-stories\">Work Programme real life stories</a>.</p></div>",
-      "withdrawn_at": "2014-08-22T10:29:02+01:00"
-    }
+    ]
   },
   "links": {
     "organisations": [

--- a/formats/case_study/publisher/details.json
+++ b/formats/case_study/publisher/details.json
@@ -28,9 +28,6 @@
     "tags": {
       "$ref": "#/definitions/tags"
     },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
     "archive_notice": {
       "type": "object",
       "additionalProperties": false,

--- a/formats/consultation/publisher/details.json
+++ b/formats/consultation/publisher/details.json
@@ -86,9 +86,6 @@
     },
     "tags": {
       "$ref": "#/definitions/tags"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
     }
   }
 }

--- a/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
+++ b/formats/detailed_guide/frontend/examples/withdrawn_detailed_guide.json
@@ -45,11 +45,7 @@
     "political": false,
     "emphasised_organisations": [
       "de4e9dc6-cca4-43af-a594-682023b84d6c"
-    ],
-    "withdrawn_notice": {
-      "explanation": "<div class=\"govspeak\"><p>This information has been archived as it is now out of date. For current information please go to <a rel=\"external\" href=\"http://www.hse.gov.uk/reach/\">http://www.hse.gov.uk/reach/</a></p></div>",
-      "withdrawn_at": "2015-01-28T13:05:30Z"
-    }
+    ]
   },
   "links": {
     "organisations": [

--- a/formats/detailed_guide/publisher/details.json
+++ b/formats/detailed_guide/publisher/details.json
@@ -49,9 +49,6 @@
     "emphasised_organisations": {
       "$ref": "#/definitions/emphasised_organisations"
     },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
     "national_applicability": {
       "$ref": "#/definitions/national_applicability"
     }

--- a/formats/document_collection/publisher/details.json
+++ b/formats/document_collection/publisher/details.json
@@ -57,9 +57,6 @@
     },
     "emphasised_organisations": {
       "$ref": "#/definitions/emphasised_organisations"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
     }
   }
 }

--- a/formats/publication/frontend/examples/withdrawn_publication.json
+++ b/formats/publication/frontend/examples/withdrawn_publication.json
@@ -49,11 +49,7 @@
     "political": false,
     "emphasised_organisations": [
       "de4e9dc6-cca4-43af-a594-682023b84d6c"
-    ],
-    "withdrawn_notice": {
-      "explanation": "<div class=\"govspeak\"><p>This information is now out of date. For our current guidance please read <a href=\"https://www.gov.uk/government/collections/guidance-for-keepers-of-sheep-goats-and-pigs\">guidance for keepers of sheep, goats and pigs</a>.</p></div>",
-      "withdrawn_at": "2015-01-13T13:05:30Z"
-    }
+    ]
   },
   "links": {
     "organisations": [

--- a/formats/publication/publisher/details.json
+++ b/formats/publication/publisher/details.json
@@ -34,9 +34,6 @@
     "political": {
       "$ref": "#/definitions/political"
     },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
     "national_applicability": {
       "$ref": "#/definitions/national_applicability"
     }

--- a/formats/statistical_data_set/publisher/details.json
+++ b/formats/statistical_data_set/publisher/details.json
@@ -29,9 +29,6 @@
     },
     "emphasised_organisations": {
       "$ref": "#/definitions/emphasised_organisations"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
     }
   }
 }


### PR DESCRIPTION
Closes #487 

Part of https://trello.com/c/AlivhTv8/591-remove-withdrawn-notice-from-details-in-schemas

* Remove notice from schema and examples rendered by government-frontend
* withdrawn_notices in the details hash are ignored by the frontend: https://github.com/alphagov/government-frontend/blob/master/app/presenters/withdrawable.rb#L3

Need to republish before merge:
* There are 7,000 odd content items that have withdrawn notice in details and at top level
`{"case_study"=>46, "publication"=>7630, "detailed_guide"=>1}`

Whitehall references to withdrawn notices in details that need updating:
* https://github.com/alphagov/whitehall/blob/59a5420c8c55832a9ff83fcd864482653ffed75f/test/unit/presenters/publishing_api/publication_presenter_test.rb#L168
* https://github.com/alphagov/whitehall/blob/19cd7d72de32454d532c195f35b027fa1b3ba6ac/script/publishing-api-sync-checks/detailed_guide_sync_check.rb#L64

```
 1) Failure:
PublishingApi::PublicationPresenterTest#test_a_withdrawn_publication_includes_details_of_the_archive_notice
JSON not valid against publication schema: ["The property '#/details' contains additional properties [\"withdrawn_notice\"] outside of the schema when none are allowed in schema

  1) Failure:
PublishingApi::CaseStudyPresenterTest#test_a_withdrawn_case_study_includes_details_of_the_archive_notice
JSON not valid against case_study schema: ["The property '#/details' contains additional properties [\"withdrawn_notice\"] outside of the schema when none are allowed in schema
```