### PR TITLE
Add custom logo image to organisation logos

### DIFF
--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -269,6 +269,10 @@
                 null
               ],
               "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+            },
+            "image": {
+              "description": "An image for organisations that use a custom logo",
+              "$ref": "#/definitions/image"
             }
           }
         },

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -271,6 +271,10 @@
                 null
               ],
               "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+            },
+            "image": {
+              "description": "An image for organisations that use a custom logo",
+              "$ref": "#/definitions/image"
             }
           }
         },

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -186,6 +186,10 @@
                 null
               ],
               "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+            },
+            "image": {
+              "description": "An image for organisations that use a custom logo",
+              "$ref": "#/definitions/image"
             }
           }
         },

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -220,6 +220,10 @@
                 null
               ],
               "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+            },
+            "image": {
+              "description": "An image for organisations that use a custom logo",
+              "$ref": "#/definitions/image"
             }
           }
         },

--- a/formats/corporate_information_page/frontend/examples/corporate_information_page_translated_custom_logo.json
+++ b/formats/corporate_information_page/frontend/examples/corporate_information_page_translated_custom_logo.json
@@ -39,7 +39,11 @@
           "brand": "department-for-business-innovation-skills",
           "logo": {
             "formatted_title": "Land Registry",
-            "crest": null
+            "crest": null,
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/69/LR_logo_265.png",
+              "alt_text": "Land Registry"
+            }
           }
         }
       }
@@ -88,7 +92,11 @@
                 "brand": "department-for-business-innovation-skills",
                 "logo": {
                   "formatted_title": "Land Registry",
-                  "crest": null
+                  "crest": null,
+                  "image": {
+                    "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/69/LR_logo_265.png",
+                    "alt_text": "Land Registry"
+                  }
                 }
               }
             }

--- a/formats/html_publication/frontend/examples/published.json
+++ b/formats/html_publication/frontend/examples/published.json
@@ -31,7 +31,11 @@
         "details": {
           "logo": {
             "formatted_title": "Environment Agency",
-            "crest": null
+            "crest": null,
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/199/EAlogo.png",
+              "alt_text": "Environment Agency"
+            }
           }
         },
         "api_path": "/api/content/government/organisations/environment-agency",

--- a/formats/html_publication/frontend/examples/updated.json
+++ b/formats/html_publication/frontend/examples/updated.json
@@ -31,7 +31,11 @@
         "details": {
           "logo": {
             "formatted_title": "Environment Agency",
-            "crest": "department-for-environment-food-rural-affairs"
+            "crest": null,
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/199/EAlogo.png",
+              "alt_text": "Environment Agency"
+            }
           }
         },
         "api_path": "/api/content/government/organisations/environment-agency",

--- a/formats/placeholder/frontend/examples/organisation-custom-logo.json
+++ b/formats/placeholder/frontend/examples/organisation-custom-logo.json
@@ -1,0 +1,52 @@
+{
+  "analytics_identifier": "D69",
+  "base_path": "/government/organisations/land-registry",
+  "content_id": "5c54ae52-341b-499e-a6dd-67f04633b8cf",
+  "document_type": "organisation",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "format": "placeholder",
+  "locale": "en",
+  "need_ids": [
+
+  ],
+  "phase": "live",
+  "public_updated_at": "2016-02-01T08:33:09.000+00:00",
+  "publishing_app": "whitehall",
+  "rendering_app": "whitehall-frontend",
+  "schema_name": "placeholder",
+  "title": "Land Registry",
+  "updated_at": "2016-12-12T10:35:49.323Z",
+  "withdrawn_notice": {
+  },
+  "links": {
+    "available_translations": [
+      {
+        "analytics_identifier": "D69",
+        "content_id": "5c54ae52-341b-499e-a6dd-67f04633b8cf",
+        "description": null,
+        "document_type": "organisation",
+        "public_updated_at": "2016-02-01T08:33:09Z",
+        "schema_name": "placeholder",
+        "title": "Land Registry",
+        "base_path": "/government/organisations/land-registry",
+        "locale": "en",
+        "api_path": "/api/content/government/organisations/land-registry",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/land-registry",
+        "web_url": "https://www.gov.uk/government/organisations/land-registry",
+        "links": {
+        }
+      }
+    ]
+  },
+  "details": {
+    "brand": "department-for-business-innovation-skills",
+    "logo": {
+      "formatted_title": "Land Registry",
+      "crest": null,
+      "image": {
+        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/69/LR_logo_265.png",
+        "alt_text": "Land Registry"
+      }
+    }
+  }
+}

--- a/formats/placeholder/publisher/details.json
+++ b/formats/placeholder/publisher/details.json
@@ -52,6 +52,10 @@
             null
           ],
           "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+        },
+        "image": {
+          "description": "An image for organisations that use a custom logo",
+          "$ref": "#/definitions/image"
         }
       }
     },


### PR DESCRIPTION
Goes with:
* https://github.com/alphagov/government-frontend/pull/246
* https://github.com/alphagov/static/pull/894

Part of https://trello.com/c/HtSGDoRb/594-add-organisation-logos-that-are-images-to-content-item-2

Organisations such as Land Registry, HM Prison Service, Environment Agency and Radioactive Waste Management have custom logo images.

* Use image definition to add images to organisation logos
* Include Land Registry example
* Update examples in other formats that use org logos