### PR TITLE
Remove required body field

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -220,9 +220,6 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body"
-      ],
       "properties": {
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -222,9 +222,6 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body"
-      ],
       "properties": {
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"

--- a/dist/formats/answer/publisher/schema.json
+++ b/dist/formats/answer/publisher/schema.json
@@ -137,9 +137,6 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body"
-      ],
       "properties": {
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -171,9 +171,6 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body"
-      ],
       "properties": {
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -220,9 +220,6 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body"
-      ],
       "properties": {
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -222,9 +222,6 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body"
-      ],
       "properties": {
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"

--- a/dist/formats/help_page/publisher/schema.json
+++ b/dist/formats/help_page/publisher/schema.json
@@ -137,9 +137,6 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body"
-      ],
       "properties": {
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -171,9 +171,6 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body"
-      ],
       "properties": {
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"

--- a/formats/answer/publisher/details.json
+++ b/formats/answer/publisher/details.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "body"
-  ],
   "properties": {
     "body": {
       "$ref": "#/definitions/body_html_and_govspeak"

--- a/formats/help_page/publisher/details.json
+++ b/formats/help_page/publisher/details.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "body"
-  ],
   "properties": {
     "body": {
       "$ref": "#/definitions/body_html_and_govspeak"


### PR DESCRIPTION
Currently Publisher does not validate the presence of content within in the body field for the Help Page and Answer formats. This means that we get an error for nil fields.

This PR now allows nil values to be sent in the body field for both the above formats.