### PR TITLE
Add schema for business support schemes

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -126,6 +126,7 @@
       "enum": [
         "aaib_report",
         "asylum_support_decision",
+        "business_finance_support_scheme",
         "cma_case",
         "countryside_stewardship_grant",
         "dfid_research_output",
@@ -1160,6 +1161,9 @@
           "$ref": "#/definitions/asylum_support_decision_metadata"
         },
         {
+          "$ref": "#/definitions/business_finance_support_scheme_metadata"
+        },
+        {
           "$ref": "#/definitions/cma_case_metadata"
         },
         {
@@ -1337,6 +1341,84 @@
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "business_finance_support_scheme_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "additional_information": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "continuation_link": {
+          "type": "string"
+        },
+        "eligibility": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "evaluation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_employees": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "organiser": {
+          "type": "string"
+        },
+        "will_continue_on": {
           "type": "string"
         }
       }

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -94,6 +94,7 @@
       "enum": [
         "aaib_report",
         "asylum_support_decision",
+        "business_finance_support_scheme",
         "cma_case",
         "countryside_stewardship_grant",
         "dfid_research_output",
@@ -1162,6 +1163,9 @@
           "$ref": "#/definitions/asylum_support_decision_metadata"
         },
         {
+          "$ref": "#/definitions/business_finance_support_scheme_metadata"
+        },
+        {
           "$ref": "#/definitions/cma_case_metadata"
         },
         {
@@ -1339,6 +1343,84 @@
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "business_finance_support_scheme_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "additional_information": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "continuation_link": {
+          "type": "string"
+        },
+        "eligibility": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "evaluation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_employees": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "organiser": {
+          "type": "string"
+        },
+        "will_continue_on": {
           "type": "string"
         }
       }

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -128,6 +128,7 @@
       "enum": [
         "aaib_report",
         "asylum_support_decision",
+        "business_finance_support_scheme",
         "cma_case",
         "countryside_stewardship_grant",
         "dfid_research_output",
@@ -1115,6 +1116,9 @@
           "$ref": "#/definitions/asylum_support_decision_metadata"
         },
         {
+          "$ref": "#/definitions/business_finance_support_scheme_metadata"
+        },
+        {
           "$ref": "#/definitions/cma_case_metadata"
         },
         {
@@ -1292,6 +1296,84 @@
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "business_finance_support_scheme_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "additional_information": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "continuation_link": {
+          "type": "string"
+        },
+        "eligibility": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "evaluation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_employees": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "organiser": {
+          "type": "string"
+        },
+        "will_continue_on": {
           "type": "string"
         }
       }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1091,6 +1091,9 @@
           "$ref": "#/definitions/asylum_support_decision_metadata"
         },
         {
+          "$ref": "#/definitions/business_finance_support_scheme_metadata"
+        },
+        {
           "$ref": "#/definitions/cma_case_metadata"
         },
         {
@@ -1268,6 +1271,84 @@
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "business_finance_support_scheme_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "additional_information": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "continuation_link": {
+          "type": "string"
+        },
+        "eligibility": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "evaluation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_employees": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "organiser": {
+          "type": "string"
+        },
+        "will_continue_on": {
           "type": "string"
         }
       }

--- a/formats/finder/frontend/examples/business-finance-support-schemes.json
+++ b/formats/finder/frontend/examples/business-finance-support-schemes.json
@@ -1,0 +1,39 @@
+{
+  "content_id": "9b3d352e-61ab-46b7-8613-7e9411f1c636",
+  "base_path": "/business-finance-support",
+  "title": "Finance and support for your business",
+  "description": "Find government-backed support and finance for business",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "updated_at": "2015-07-21T12:45:18.202Z",
+  "public_updated_at": "2015-04-29T09:22:41.000+00:00",
+  "details": {
+    "facets": [
+
+    ],
+    "document_noun": "scheme",
+    "filter": {
+      "document_type": "business_finance_support_scheme"
+    },
+    "format_name": "Business finance support scheme",
+    "show_summaries": true
+  },
+  "links": {
+    "available_translations": [
+      {
+        "content_id": "9b3d352e-61ab-46b7-8613-7e9411f1c636",
+        "title": "Finance and support for your business",
+        "api_path": "/api/content/business-finance-support",
+        "base_path": "/business-finance-support",
+        "description": "Find government-backed support and finance for business",
+        "api_url": "https://www.gov.uk/api/content/business-finance-support",
+        "web_url": "https://www.gov.uk/business-finance-support",
+        "locale": "en"
+      }
+    ]
+  },
+  "schema_name": "finder",
+  "document_type": "finder"
+}

--- a/formats/specialist_document/frontend/examples/business-finance-support-scheme.json
+++ b/formats/specialist_document/frontend/examples/business-finance-support-scheme.json
@@ -1,0 +1,37 @@
+{
+  "content_id": "63f10fb1-b355-46f9-b090-bdd6c1c71870",
+  "public_updated_at": "2016-11-08T12:55:20+00:00",
+  "locale": "en",
+  "details": {
+    "body": "",
+    "attachments": [
+
+    ],
+    "metadata": {
+      "additional_information": "<p>Big issue Invest can also work with partner social investors to provide finance of over £3 million.</p>",
+      "continuation_link": "http://www.bigissueinvest.com",
+      "eligibility": "<p>Established social enterprises operating at least 24 months.</p>",
+      "evaluation": "",
+      "max_employees": null,
+      "max_value": 3000000,
+      "min_value": 20000,
+      "organiser": "Big Issue Invest",
+      "will_continue_on": "the Big Issue Invest website"
+    },
+    "max_cache_time": 10,
+    "change_history": [
+      {
+        "note": "First published.",
+        "public_timestamp": "2015-07-09T08:17:10+00:00"
+      }
+    ]
+  },
+  "base_path": "/business-finance-support/big-issue-invest",
+  "description": "Big Issue Invest helps scale up social enterprises and charities throughout the UK by providing loans and investments",
+  "title": "Big Issue Invest",
+  "updated_at": "2016-11-08T12:55:20+00:00",
+  "schema_name": "specialist_document",
+  "document_type": "business_finance_support_scheme",
+  "links": {
+  }
+}

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -41,6 +41,9 @@
           "$ref": "#/definitions/asylum_support_decision_metadata"
         },
         {
+          "$ref": "#/definitions/business_finance_support_scheme_metadata"
+        },
+        {
           "$ref": "#/definitions/cma_case_metadata"
         },
         {
@@ -218,6 +221,84 @@
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "business_finance_support_scheme_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "additional_information": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "continuation_link": {
+          "type": "string"
+        },
+        "eligibility": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "evaluation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_employees": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min_value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "organiser": {
+          "type": "string"
+        },
+        "will_continue_on": {
           "type": "string"
         }
       }

--- a/formats/specialist_document/publisher/document_types.json
+++ b/formats/specialist_document/publisher/document_types.json
@@ -16,6 +16,7 @@
       "enum": [
         "aaib_report",
         "asylum_support_decision",
+        "business_finance_support_scheme",
         "cma_case",
         "countryside_stewardship_grant",
         "dfid_research_output",


### PR DESCRIPTION
This commit adds schemas and examples for the migrated business finance support schemes.

Trello: https://trello.com/c/UHsavPI5/485-create-a-new-specialist-document-type-for-business-support-scheme