### PR TITLE
Add/amend fields on business finance support scheme schema

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1410,21 +1410,34 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "additional_information": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "business_sizes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "between-10-and-249",
+              "between-250-and-500",
+              "over-500",
+              "under-10"
+            ]
+          }
+        },
+        "business_stages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "established",
+              "not-yet-trading",
+              "start-up"
+            ]
+          }
         },
         "continuation_link": {
           "type": "string"
         },
-        "eligibility": {
-          "anyOf": [
+        "how_much_you_can_get": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -1433,8 +1446,8 @@
             }
           ]
         },
-        "evaluation": {
-          "anyOf": [
+        "how_to_apply": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -1442,29 +1455,33 @@
               "type": "null"
             }
           ]
+        },
+        "industries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture-and-food",
+              "business-and-finance",
+              "construction",
+              "education",
+              "health",
+              "hospitality-and-catering",
+              "information-technology-digital-and-creative",
+              "manufacturing",
+              "mining",
+              "real-estate-and-property",
+              "science-and-technology",
+              "service-industries",
+              "transport-and-distribution",
+              "travel-and-leisure",
+              "utilities-providers",
+              "wholesale-and-retail"
+            ]
+          }
         },
         "max_employees": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "max_value": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "min_value": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "integer"
             },
@@ -1474,10 +1491,58 @@
           ]
         },
         "organiser": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "types_of_support": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "equity",
+              "expertise-and-advice",
+              "finance",
+              "grant",
+              "loan",
+              "recognition-award"
+            ]
+          }
+        },
+        "what_you_can_get": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "who_it_is_for": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "will_continue_on": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -1412,21 +1412,34 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "additional_information": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "business_sizes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "between-10-and-249",
+              "between-250-and-500",
+              "over-500",
+              "under-10"
+            ]
+          }
+        },
+        "business_stages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "established",
+              "not-yet-trading",
+              "start-up"
+            ]
+          }
         },
         "continuation_link": {
           "type": "string"
         },
-        "eligibility": {
-          "anyOf": [
+        "how_much_you_can_get": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -1435,8 +1448,8 @@
             }
           ]
         },
-        "evaluation": {
-          "anyOf": [
+        "how_to_apply": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -1444,29 +1457,33 @@
               "type": "null"
             }
           ]
+        },
+        "industries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture-and-food",
+              "business-and-finance",
+              "construction",
+              "education",
+              "health",
+              "hospitality-and-catering",
+              "information-technology-digital-and-creative",
+              "manufacturing",
+              "mining",
+              "real-estate-and-property",
+              "science-and-technology",
+              "service-industries",
+              "transport-and-distribution",
+              "travel-and-leisure",
+              "utilities-providers",
+              "wholesale-and-retail"
+            ]
+          }
         },
         "max_employees": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "max_value": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "min_value": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "integer"
             },
@@ -1476,10 +1493,58 @@
           ]
         },
         "organiser": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "types_of_support": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "equity",
+              "expertise-and-advice",
+              "finance",
+              "grant",
+              "loan",
+              "recognition-award"
+            ]
+          }
+        },
+        "what_you_can_get": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "who_it_is_for": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "will_continue_on": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -1365,21 +1365,34 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "additional_information": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "business_sizes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "between-10-and-249",
+              "between-250-and-500",
+              "over-500",
+              "under-10"
+            ]
+          }
+        },
+        "business_stages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "established",
+              "not-yet-trading",
+              "start-up"
+            ]
+          }
         },
         "continuation_link": {
           "type": "string"
         },
-        "eligibility": {
-          "anyOf": [
+        "how_much_you_can_get": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -1388,8 +1401,8 @@
             }
           ]
         },
-        "evaluation": {
-          "anyOf": [
+        "how_to_apply": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -1397,29 +1410,33 @@
               "type": "null"
             }
           ]
+        },
+        "industries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture-and-food",
+              "business-and-finance",
+              "construction",
+              "education",
+              "health",
+              "hospitality-and-catering",
+              "information-technology-digital-and-creative",
+              "manufacturing",
+              "mining",
+              "real-estate-and-property",
+              "science-and-technology",
+              "service-industries",
+              "transport-and-distribution",
+              "travel-and-leisure",
+              "utilities-providers",
+              "wholesale-and-retail"
+            ]
+          }
         },
         "max_employees": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "max_value": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "min_value": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "integer"
             },
@@ -1429,10 +1446,58 @@
           ]
         },
         "organiser": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "types_of_support": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "equity",
+              "expertise-and-advice",
+              "finance",
+              "grant",
+              "loan",
+              "recognition-award"
+            ]
+          }
+        },
+        "what_you_can_get": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "who_it_is_for": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "will_continue_on": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1340,21 +1340,34 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "additional_information": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "business_sizes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "between-10-and-249",
+              "between-250-and-500",
+              "over-500",
+              "under-10"
+            ]
+          }
+        },
+        "business_stages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "established",
+              "not-yet-trading",
+              "start-up"
+            ]
+          }
         },
         "continuation_link": {
           "type": "string"
         },
-        "eligibility": {
-          "anyOf": [
+        "how_much_you_can_get": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -1363,8 +1376,8 @@
             }
           ]
         },
-        "evaluation": {
-          "anyOf": [
+        "how_to_apply": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -1372,29 +1385,33 @@
               "type": "null"
             }
           ]
+        },
+        "industries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture-and-food",
+              "business-and-finance",
+              "construction",
+              "education",
+              "health",
+              "hospitality-and-catering",
+              "information-technology-digital-and-creative",
+              "manufacturing",
+              "mining",
+              "real-estate-and-property",
+              "science-and-technology",
+              "service-industries",
+              "transport-and-distribution",
+              "travel-and-leisure",
+              "utilities-providers",
+              "wholesale-and-retail"
+            ]
+          }
         },
         "max_employees": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "max_value": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "min_value": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "integer"
             },
@@ -1404,10 +1421,58 @@
           ]
         },
         "organiser": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "types_of_support": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "equity",
+              "expertise-and-advice",
+              "finance",
+              "grant",
+              "loan",
+              "recognition-award"
+            ]
+          }
+        },
+        "what_you_can_get": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "who_it_is_for": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "will_continue_on": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },

--- a/formats/specialist_document/frontend/examples/business-finance-support-scheme.json
+++ b/formats/specialist_document/frontend/examples/business-finance-support-scheme.json
@@ -8,14 +8,35 @@
 
     ],
     "metadata": {
-      "additional_information": "<p>Big issue Invest can also work with partner social investors to provide finance of over £3 million.</p>",
+      "business_sizes": [
+        "between-10-and-249",
+        "between-250-and-500",
+        "over-500",
+        "under-10"
+      ],
+      "business_stages": [
+        "established"
+      ],
       "continuation_link": "http://www.bigissueinvest.com",
-      "eligibility": "<p>Established social enterprises operating at least 24 months.</p>",
-      "evaluation": "",
+      "how_much_you_can_get": "£20,000 - £3,000,000",
+      "how_to_apply": null,
+      "industries": [
+        "business-and-finance",
+        "education",
+        "health",
+        "transport-and-distribution",
+        "travel-and-leisure",
+        "wholesale-and-retail"
+      ],
       "max_employees": null,
-      "max_value": 3000000,
-      "min_value": 20000,
       "organiser": "Big Issue Invest",
+      "types_of_support": [
+        "equity",
+        "finance",
+        "loan"
+      ],
+      "what_you_can_get": "<p>Big Issue Invest can also work with partner social investors to provide finance of over £3 million.</p>",
+      "who_it_is_for": "<p>Established social enterprises operating at least 24 months.</p>",
       "will_continue_on": "the Big Issue Invest website"
     },
     "max_cache_time": 10,

--- a/formats/specialist_document/publisher/details.json
+++ b/formats/specialist_document/publisher/details.json
@@ -232,21 +232,34 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "additional_information": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "business_sizes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "between-10-and-249",
+              "between-250-and-500",
+              "over-500",
+              "under-10"
+            ]
+          }
+        },
+        "business_stages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "established",
+              "not-yet-trading",
+              "start-up"
+            ]
+          }
         },
         "continuation_link": {
           "type": "string"
         },
-        "eligibility": {
-          "anyOf": [
+        "how_much_you_can_get": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -255,8 +268,8 @@
             }
           ]
         },
-        "evaluation": {
-          "anyOf": [
+        "how_to_apply": {
+          "oneOf": [
             {
               "type": "string"
             },
@@ -264,29 +277,33 @@
               "type": "null"
             }
           ]
+        },
+        "industries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture-and-food",
+              "business-and-finance",
+              "construction",
+              "education",
+              "health",
+              "hospitality-and-catering",
+              "information-technology-digital-and-creative",
+              "manufacturing",
+              "mining",
+              "real-estate-and-property",
+              "science-and-technology",
+              "service-industries",
+              "transport-and-distribution",
+              "travel-and-leisure",
+              "utilities-providers",
+              "wholesale-and-retail"
+            ]
+          }
         },
         "max_employees": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "max_value": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "min_value": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "integer"
             },
@@ -296,10 +313,58 @@
           ]
         },
         "organiser": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "types_of_support": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "equity",
+              "expertise-and-advice",
+              "finance",
+              "grant",
+              "loan",
+              "recognition-award"
+            ]
+          }
+        },
+        "what_you_can_get": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "who_it_is_for": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "will_continue_on": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
This commit adds/amends metadata fields on the business finance support scheme schema.

Since no content items are using this schema yet, the fields can be changed without backwards-compatibility concerns.

Trello: https://trello.com/c/UHsavPI5/485-create-a-new-specialist-document-type-for-business-support-scheme