### PR TITLE
Add corporate information groups to corporate information pages

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -259,22 +259,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -696,6 +729,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -261,22 +261,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -698,6 +731,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/answer/publisher/schema.json
+++ b/dist/formats/answer/publisher/schema.json
@@ -212,22 +212,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -649,6 +682,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -207,22 +207,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -644,6 +677,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -296,22 +296,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -733,6 +766,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -289,22 +289,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -726,6 +759,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -252,22 +252,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -689,6 +722,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -80,22 +80,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -517,6 +550,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -238,22 +238,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -675,6 +708,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -260,22 +260,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -697,6 +730,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -262,22 +262,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -699,6 +732,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -213,22 +213,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -650,6 +683,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -208,22 +208,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -645,6 +678,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -337,22 +337,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -774,6 +807,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -333,22 +333,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -770,6 +803,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/consultation/publisher/schema.json
+++ b/dist/formats/consultation/publisher/schema.json
@@ -296,22 +296,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -733,6 +766,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -80,22 +80,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -517,6 +550,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -282,22 +282,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -719,6 +752,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -453,22 +453,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -890,6 +923,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -452,22 +452,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -889,6 +922,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -406,22 +406,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -843,6 +876,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -74,22 +74,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -511,6 +544,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -337,22 +337,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -774,6 +807,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -80,6 +80,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "corporate_information_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -235,6 +238,10 @@
         "tags": {
           "$ref": "#/definitions/tags"
         },
+        "corporate_information_groups": {
+          "description": "Groups of corporate information to display on about pages",
+          "$ref": "#/definitions/grouped_lists_of_links"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }
@@ -264,22 +271,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -701,6 +741,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -237,6 +237,10 @@
         "tags": {
           "$ref": "#/definitions/tags"
         },
+        "corporate_information_groups": {
+          "description": "Groups of corporate information to display on about pages",
+          "$ref": "#/definitions/grouped_lists_of_links"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }
@@ -266,22 +270,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -703,6 +740,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/corporate_information_page/publisher/schema.json
+++ b/dist/formats/corporate_information_page/publisher/schema.json
@@ -151,6 +151,10 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
+        },
+        "corporate_information_groups": {
+          "description": "Groups of corporate information to display on about pages",
+          "$ref": "#/definitions/grouped_lists_of_links"
         }
       }
     },
@@ -158,6 +162,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "corporate_information_pages": {
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -217,22 +224,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -654,6 +694,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -10,6 +10,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "corporate_information_pages": {
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
@@ -71,22 +74,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +544,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -185,6 +185,10 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
+        },
+        "corporate_information_groups": {
+          "description": "Groups of corporate information to display on about pages",
+          "$ref": "#/definitions/grouped_lists_of_links"
         }
       }
     },
@@ -212,22 +216,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -649,6 +686,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -305,22 +305,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -742,6 +775,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -298,22 +298,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -735,6 +768,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -261,22 +261,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -698,6 +731,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -80,22 +80,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -517,6 +550,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -247,22 +247,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -684,6 +717,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -308,22 +308,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -745,6 +778,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -304,22 +304,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -741,6 +774,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -265,22 +265,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -702,6 +735,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -78,22 +78,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -515,6 +548,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -253,22 +253,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -690,6 +723,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -296,22 +296,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -733,6 +766,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -298,22 +298,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -735,6 +768,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -249,22 +249,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -686,6 +719,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -244,22 +244,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -681,6 +714,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -271,22 +271,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -708,6 +741,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -267,22 +267,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -704,6 +737,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -229,22 +229,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -666,6 +699,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -79,22 +79,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -516,6 +549,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -216,22 +216,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -653,6 +686,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -303,22 +303,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -740,6 +773,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -299,22 +299,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -736,6 +769,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -259,22 +259,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -696,6 +729,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -80,22 +80,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -517,6 +550,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -245,22 +245,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -682,6 +715,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -339,22 +339,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -776,6 +809,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -338,22 +338,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -775,6 +808,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -292,22 +292,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -729,6 +762,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -74,22 +74,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -511,6 +544,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -284,22 +284,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -721,6 +754,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -250,22 +250,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -687,6 +720,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -252,22 +252,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -689,6 +722,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic/publisher/schema.json
+++ b/dist/formats/generic/publisher/schema.json
@@ -203,22 +203,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -640,6 +673,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -198,22 +198,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -635,6 +668,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -253,22 +253,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -690,6 +723,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -255,22 +255,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -692,6 +725,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic_with_external_related_links/publisher/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher/schema.json
@@ -206,22 +206,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -643,6 +676,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -201,22 +201,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -638,6 +671,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -259,22 +259,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -696,6 +729,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -261,22 +261,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -698,6 +731,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/help_page/publisher/schema.json
+++ b/dist/formats/help_page/publisher/schema.json
@@ -212,22 +212,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -649,6 +682,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -207,22 +207,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -644,6 +677,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -268,22 +268,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -705,6 +738,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -270,22 +270,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -707,6 +740,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -221,22 +221,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -658,6 +691,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -216,22 +216,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -653,6 +686,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -272,22 +272,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -709,6 +742,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -274,22 +274,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -711,6 +744,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -225,22 +225,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -662,6 +695,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -220,22 +220,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -657,6 +690,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -269,22 +269,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -706,6 +739,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -271,22 +271,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -708,6 +741,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -222,22 +222,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -659,6 +692,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -217,22 +217,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -654,6 +687,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -288,22 +288,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -725,6 +758,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -290,22 +290,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -727,6 +760,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/local_transaction/publisher/schema.json
+++ b/dist/formats/local_transaction/publisher/schema.json
@@ -241,22 +241,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -678,6 +711,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -236,22 +236,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -673,6 +706,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -278,22 +278,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -715,6 +748,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -268,22 +268,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -705,6 +738,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -235,22 +235,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -672,6 +705,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -87,22 +87,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -524,6 +557,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -214,22 +214,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -651,6 +684,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -268,22 +268,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -705,6 +738,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -267,22 +267,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -704,6 +737,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -224,22 +224,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -661,6 +694,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -77,22 +77,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -514,6 +547,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -213,22 +213,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -650,6 +683,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -270,22 +270,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -707,6 +740,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -269,22 +269,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -706,6 +739,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -226,22 +226,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -663,6 +696,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -77,22 +77,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -514,6 +547,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -215,22 +215,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -652,6 +685,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -317,22 +317,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -754,6 +787,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -319,22 +319,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -756,6 +789,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/need/publisher/schema.json
+++ b/dist/formats/need/publisher/schema.json
@@ -270,22 +270,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -707,6 +740,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -265,22 +265,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -702,6 +735,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -286,22 +286,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -723,6 +756,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -279,22 +279,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -716,6 +749,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/news_article/publisher/schema.json
+++ b/dist/formats/news_article/publisher/schema.json
@@ -245,22 +245,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -682,6 +715,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -83,22 +83,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -520,6 +553,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -228,22 +228,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -665,6 +698,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -311,22 +311,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -748,6 +781,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -313,22 +313,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -750,6 +783,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -264,22 +264,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -701,6 +734,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -259,22 +259,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -696,6 +729,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -337,22 +337,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -774,6 +807,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -324,22 +324,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -761,6 +794,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -294,22 +294,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -731,6 +764,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -90,22 +90,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -527,6 +560,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -270,22 +270,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -707,6 +740,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -296,22 +296,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -733,6 +766,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -283,22 +283,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -720,6 +753,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -252,22 +252,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -689,6 +722,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -86,22 +86,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -523,6 +556,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -232,22 +232,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -669,6 +702,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -290,22 +290,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -727,6 +760,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -286,22 +286,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -723,6 +756,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -248,22 +248,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -685,6 +718,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -79,22 +79,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -516,6 +549,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -235,22 +235,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -672,6 +705,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -249,22 +249,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -686,6 +719,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -251,22 +251,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -688,6 +721,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_homepage/publisher/schema.json
+++ b/dist/formats/service_manual_homepage/publisher/schema.json
@@ -202,22 +202,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -639,6 +672,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -197,22 +197,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -634,6 +667,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -256,22 +256,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -693,6 +726,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -255,22 +255,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -692,6 +725,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -210,22 +210,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -647,6 +680,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -75,22 +75,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -512,6 +545,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -201,22 +201,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -638,6 +671,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -299,22 +299,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -736,6 +769,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -301,22 +301,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -738,6 +771,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_toolkit/publisher/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher/schema.json
@@ -252,22 +252,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -689,6 +722,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -247,22 +247,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -684,6 +717,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -269,22 +269,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -706,6 +739,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -262,22 +262,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -699,6 +732,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -225,22 +225,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -662,6 +695,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -83,22 +83,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -520,6 +553,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -208,22 +208,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -645,6 +678,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -294,22 +294,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -731,6 +764,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -296,22 +296,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -733,6 +766,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/specialist_document/publisher/schema.json
+++ b/dist/formats/specialist_document/publisher/schema.json
@@ -249,22 +249,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -686,6 +719,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -224,22 +224,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -661,6 +694,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -304,22 +304,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -741,6 +774,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -294,22 +294,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -731,6 +764,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/speech/publisher/schema.json
+++ b/dist/formats/speech/publisher/schema.json
@@ -265,22 +265,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -702,6 +735,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -88,22 +88,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -525,6 +558,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -243,22 +243,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -680,6 +713,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -274,22 +274,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -711,6 +744,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -276,22 +276,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -713,6 +746,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistical_data_set/publisher/schema.json
+++ b/dist/formats/statistical_data_set/publisher/schema.json
@@ -230,22 +230,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -667,6 +700,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -225,22 +225,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -662,6 +695,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -286,22 +286,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -723,6 +756,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -288,22 +288,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -725,6 +758,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -239,22 +239,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -676,6 +709,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -234,22 +234,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -671,6 +704,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -260,22 +260,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -697,6 +730,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -262,22 +262,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -699,6 +732,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -213,22 +213,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -650,6 +683,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -208,22 +208,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -645,6 +678,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -260,22 +260,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -697,6 +730,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -259,22 +259,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -696,6 +729,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -214,22 +214,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -651,6 +684,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -75,22 +75,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -512,6 +545,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -205,22 +205,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -642,6 +675,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -259,22 +259,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -696,6 +729,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -258,22 +258,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -695,6 +728,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -217,22 +217,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -654,6 +687,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -79,22 +79,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -516,6 +549,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -204,22 +204,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -641,6 +674,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -260,22 +260,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -697,6 +730,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -262,22 +262,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -699,6 +732,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -213,22 +213,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -650,6 +683,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -208,22 +208,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -645,6 +678,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -337,22 +337,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -774,6 +807,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -336,22 +336,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -773,6 +806,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -290,22 +290,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -727,6 +760,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -74,22 +74,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -511,6 +544,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -282,22 +282,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -719,6 +752,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -305,22 +305,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -742,6 +775,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -304,22 +304,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -741,6 +774,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -258,22 +258,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -695,6 +728,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -74,22 +74,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -511,6 +544,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -250,22 +250,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -687,6 +720,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -273,22 +273,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -710,6 +743,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -275,22 +275,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -712,6 +745,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -226,22 +226,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -663,6 +696,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -221,22 +221,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -658,6 +691,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -256,22 +256,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -693,6 +726,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -258,22 +258,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -695,6 +728,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -209,22 +209,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -646,6 +679,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -508,6 +541,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -204,22 +204,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -641,6 +674,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -283,22 +283,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -720,6 +753,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -276,22 +276,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -713,6 +746,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/world_location_news_article/publisher/schema.json
+++ b/dist/formats/world_location_news_article/publisher/schema.json
@@ -239,22 +239,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -676,6 +709,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -80,22 +80,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -517,6 +550,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -225,22 +225,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -662,6 +695,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/formats/corporate_information_page/frontend/examples/corporate_information_page.json
+++ b/formats/corporate_information_page/frontend/examples/corporate_information_page.json
@@ -12,6 +12,37 @@
   "details": {
     "body": "<div class=\"govspeak\"><h2 id=\"our-responsibilities\">Our responsibilities</h2><ul>  <li>    <p>we lead across health and care by creating national policies and legislation, providing the long-term vision and ambition to meet current and future challenges, putting health and care at the heart of government and being a global leader in health and care policy</p>  </li>  <li>    <p>we support the integrity of the system by providing funding, assuring the delivery and continuity of services and accounting to Parliament in a way that represents the best interests of the patient, public and taxpayer.</p>  </li>  <li>    <p>we champion innovation and improvement by supporting research and technology, promoting honesty, openness and transparency, and instilling a culture that values compassion, dignity and the highest quality of care above everything</p>  </li>  <li>    <p>above all, <abbr title=\"The Department of Health\">DH</abbr> encourages staff in every health and care organisation, including our own, to understand and learn from people’s experience of health and care and to apply this to everything we do</p>  </li></ul><h2 id=\"our-priorities\">Our priorities</h2><p>From 2016 to 2017, our priorities will be:</p><ul>  <li>improving out-of-hospital care</li>  <li>creating the safest, highest quality healthcare services</li>  <li>maintaining and improving performance against core standards while achieving financial balance</li>  <li>improving efficiency and productivity of the health and care system</li>  <li>preventing ill health and supporting people to live healthier lives</li>  <li>supporting research, innovation and growth</li>  <li>enabling people and communities to make decisions about their own health and care</li>  <li>building and developing the workforce</li>  <li>improving services through the use of digital technology, information and transparency</li></ul><p>Read our <a href=\"https://www.gov.uk/government/publications/department-of-health-shared-delivery-plan-2015-to-2020\">Shared Delivery Plan</a> to find out more about how we are performing against our objectives.</p><h2 id=\"who-we-are\">Who we are</h2><p><abbr title=\"The Department of Health\">DH</abbr> is a ministerial department, supported by 15 arm’s length bodies and a number of other agencies and public bodies. The department employs 2,160 staff who work in locations across the country.</p><h2 id=\"partner-organisations-and-agencies-including-contact-information\">Partner organisations and agencies including contact information</h2><p><a href=\"https://www.gov.uk/government/publications/how-to-contact-department-of-health-arms-length-bodies\">Find out more about the department’s partner organisations and agencies, also known as arm’s length bodies.</a></p><p>This page includes contact information and a list of members of the executive boards.</p></div>",
     "organisation": "7cd6bf12-bbe9-4118-8523-f927b0442156",
+    "corporate_information_groups": [
+      {
+        "name": "Access our information",
+        "contents": [
+          "5f54ec49-7631-11e4-a3cb-005056011aef",
+          "5f55b4d0-7631-11e4-a3cb-005056011aef",
+          "5f553aa0-7631-11e4-a3cb-005056011aef",
+          "5f5543ee-7631-11e4-a3cb-005056011aef",
+          "5f554069-7631-11e4-a3cb-005056011aef",
+          {
+            "title": "Transparency data",
+            "path": "/government/publications?departments%5B%5D=department-of-health&publication_type=transparency-data"
+          },
+          {
+            "title": "Corporate reports",
+            "path": "/government/publications?departments%5B%5D=department-of-health&publication_type=corporate-reports"
+          }
+        ]
+      },
+      {
+        "name": "Jobs and contracts",
+        "contents": [
+          "5f54e968-7631-11e4-a3cb-005056011aef",
+          "5f54eea2-7631-11e4-a3cb-005056011aef",
+          {
+            "title": "Jobs",
+            "url": "https://www.civilservicejobs.service.gov.uk/csr"
+          }
+        ]
+      }
+    ],
     "tags": {
       "browse_pages": [
 
@@ -25,6 +56,80 @@
     }
   },
   "links": {
+    "corporate_information_pages": [
+      {
+        "content_id": "5f54ec49-7631-11e4-a3cb-005056011aef",
+        "title": "Complaints procedure",
+        "api_path": "/api/content/government/organisations/department-of-health/about/complaints-procedure",
+        "base_path": "/government/organisations/department-of-health/about/complaints-procedure",
+        "locale": "en",
+        "document_type": "complaints_procedure"
+      },
+      {
+        "content_id": "5f55b4d0-7631-11e4-a3cb-005056011aef",
+        "title": "Media enquiries",
+        "api_path": "/api/content/government/organisations/department-of-health/about/media-enquiries",
+        "base_path": "/government/organisations/department-of-health/about/media-enquiries",
+        "locale": "en",
+        "document_type": "media_enquiries"
+      },
+      {
+        "content_id": "5f553aa0-7631-11e4-a3cb-005056011aef",
+        "title": "Statistics at DH",
+        "api_path": "/api/content/government/organisations/department-of-health/about/statistics",
+        "base_path": "/government/organisations/department-of-health/about/statistics",
+        "locale": "en",
+        "document_type": "statistics"
+      },
+      {
+        "content_id": "5f5543ee-7631-11e4-a3cb-005056011aef",
+        "title": "Our governance",
+        "api_path": "/api/content/government/organisations/department-of-health/about/our-governance",
+        "base_path": "/government/organisations/department-of-health/about/our-governance",
+        "locale": "en",
+        "document_type": "our_governance"
+      },
+      {
+        "content_id": "5f554069-7631-11e4-a3cb-005056011aef",
+        "title": "Equality and diversity",
+        "api_path": "/api/content/government/organisations/department-of-health/about/equality-and-diversity",
+        "base_path": "/government/organisations/department-of-health/about/equality-and-diversity",
+        "locale": "en",
+        "document_type": "equality_and_diversity"
+      },
+      {
+        "content_id": "5f54e968-7631-11e4-a3cb-005056011aef",
+        "title": "Working for DH",
+        "api_path": "/api/content/government/organisations/department-of-health/about/recruitment",
+        "base_path": "/government/organisations/department-of-health/about/recruitment",
+        "locale": "en",
+        "document_type": "recruitment"
+      },
+      {
+        "content_id": "5f54eea2-7631-11e4-a3cb-005056011aef",
+        "title": "Procurement at DH",
+        "api_path": "/api/content/government/organisations/department-of-health/about/procurement",
+        "base_path": "/government/organisations/department-of-health/about/procurement",
+        "locale": "en",
+        "document_type": "procurement"
+      },
+      {
+        "content_id": "5f55435a-7631-11e4-a3cb-005056011aef",
+        "title": "Publication scheme",
+        "api_path": "/api/content/government/organisations/department-of-health/about/publication-scheme",
+        "base_path": "/government/organisations/department-of-health/about/publication-scheme",
+        "locale": "en",
+        "document_type": "publication_scheme"
+      },
+      {
+        "content_id": "5f54ed74-7631-11e4-a3cb-005056011aef",
+        "title": "Personal information charter",
+        "api_path": "/api/content/government/organisations/department-of-health/about/personal-information-charter",
+        "base_path": "/government/organisations/department-of-health/about/personal-information-charter",
+        "locale": "en",
+        "document_type": "personal_information_charter"
+      }
+    ],
     "organisations": [
       {
         "content_id": "7cd6bf12-bbe9-4118-8523-f927b0442156",

--- a/formats/corporate_information_page/publisher/details.json
+++ b/formats/corporate_information_page/publisher/details.json
@@ -16,6 +16,10 @@
     },
     "tags": {
       "$ref": "#/definitions/tags"
+    },
+    "corporate_information_groups": {
+      "description": "Groups of corporate information to display on about pages",
+      "$ref": "#/definitions/grouped_lists_of_links"
     }
   }
 }

--- a/formats/corporate_information_page/publisher/links.json
+++ b/formats/corporate_information_page/publisher/links.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "corporate_information_pages": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -27,22 +27,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -464,6 +497,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",


### PR DESCRIPTION
Part of:
https://trello.com/c/8syU3iNh/593-add-corporate-information-block-to-about-pages-corporate-information-pages-2

* Create new definitions for internal links without GUIDs and external links
* Create definition so that list of links can contain GUIDs, internal path without guid and external link
* Create new grouped_lists_of_links definition, a flexible object type that can be later re-used by formats with custom groups
* Modelled loosely on topic_groups
* Include example on about page (groups are only used on this document type)