### PR TITLE
Add `poster_url` to service standard format

### DIFF
--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -227,6 +227,11 @@
         "body": {
           "$ref": "#/definitions/body"
         },
+        "poster_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the service standard poster (absolute)"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -226,6 +226,11 @@
         "body": {
           "$ref": "#/definitions/body"
         },
+        "poster_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the service standard poster (absolute)"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -140,6 +140,11 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "poster_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the service standard poster (absolute)"
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -174,6 +174,11 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "poster_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the service standard poster (absolute)"
         }
       }
     },

--- a/formats/service_manual_service_standard/frontend/examples/service_manual_service_standard.json
+++ b/formats/service_manual_service_standard/frontend/examples/service_manual_service_standard.json
@@ -95,6 +95,7 @@
   },
   "description": "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
   "details": {
-    "body": "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use."
+    "body": "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
+    "poster_url": "http://example.com/service-standard-poster.pdf"
   }
 }

--- a/formats/service_manual_service_standard/publisher/details.json
+++ b/formats/service_manual_service_standard/publisher/details.json
@@ -5,6 +5,11 @@
   "properties": {
     "body": {
       "$ref": "#/definitions/body"
+    },
+    "poster_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to the service standard poster (absolute)"
     }
   }
 }

--- a/formats/service_manual_service_standard/publisher_v2/examples/service_manual_service_standard.json
+++ b/formats/service_manual_service_standard/publisher_v2/examples/service_manual_service_standard.json
@@ -17,6 +17,7 @@
   "document_type": "service_manual_service_standard",
   "schema_name": "service_manual_service_standard",
   "details": {
-    "body": "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use."
+    "body": "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
+    "poster_url": "http://example.com/service-standard-poster.pdf"
   }
 }


### PR DESCRIPTION
We're adding a link to a poster of the service standard to the service
standard page in the service manual. This adds a `poster_url` field to
the `service_manual_service_standard` format to allow us to manage this
via service-manual-publisher.