### PR TITLE
Regenerate Guide schemas

### DIFF
--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -257,22 +257,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -718,6 +751,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -259,22 +259,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -720,6 +753,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/guide/publisher/schema.json
+++ b/dist/formats/guide/publisher/schema.json
@@ -210,22 +210,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -671,6 +704,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -71,22 +71,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -532,6 +565,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -205,22 +205,55 @@
     "external_related_links": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri"
-          }
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "url"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "path"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "government": {
       "type": "object",
@@ -666,6 +699,31 @@
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",
       "type": "integer"
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contents"
+        ],
+        "properties": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          },
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          }
+        }
+      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",


### PR DESCRIPTION
This was necessary as new definitions were added in [cc2986](https://github.com/alphagov/govuk-content-schemas/commit/cc2986a12b8eac18d3218d9d9a62ae8b7d85046c)