### PR TITLE
Remove format fields

### DIFF
--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -13,12 +13,6 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [
-        "gone"
-      ]
-    },
     "document_type": {
       "enum": [
         "gone"

--- a/dist/formats/gone/publisher/schema.json
+++ b/dist/formats/gone/publisher/schema.json
@@ -15,12 +15,6 @@
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
     },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [
-        "gone"
-      ]
-    },
     "document_type": {
       "enum": [
         "gone"

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -13,12 +13,6 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [
-        "gone"
-      ]
-    },
     "document_type": {
       "enum": [
         "gone"

--- a/dist/formats/redirect/publisher/schema.json
+++ b/dist/formats/redirect/publisher/schema.json
@@ -15,12 +15,6 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
-    "format": {
-      "description": "DEPRECATED: This field will be removed by Tijmen.",
-      "enum": [
-        "redirect"
-      ]
-    },
     "document_type": {
       "enum": [
         "redirect"

--- a/formats/gone/frontend/schema.json
+++ b/formats/gone/frontend/schema.json
@@ -13,12 +13,6 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [
-        "gone"
-      ]
-    },
     "document_type": {
       "enum": [
         "gone"

--- a/formats/gone/publisher/schema.json
+++ b/formats/gone/publisher/schema.json
@@ -15,12 +15,6 @@
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
     },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [
-        "gone"
-      ]
-    },
     "document_type": {
       "enum": [
         "gone"

--- a/formats/gone/publisher_v2/schema.json
+++ b/formats/gone/publisher_v2/schema.json
@@ -13,12 +13,6 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
-    "format": {
-      "description": "DEPRECATED. This field will be removed by Tijmen.",
-      "enum": [
-        "gone"
-      ]
-    },
     "document_type": {
       "enum": [
         "gone"

--- a/formats/redirect/publisher/schema.json
+++ b/formats/redirect/publisher/schema.json
@@ -15,12 +15,6 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
-    "format": {
-      "description": "DEPRECATED: This field will be removed by Tijmen.",
-      "enum": [
-        "redirect"
-      ]
-    },
     "document_type": {
       "enum": [
         "redirect"


### PR DESCRIPTION
`format` has been deprecated and is replaced by `document_type` and `schema_name`.
