### PR TITLE
Consistently use policies links

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -83,6 +83,9 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -117,9 +120,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -185,6 +185,10 @@
       "additionalProperties": false,
       "properties": {
         "related_policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED use policies instead. @gpeng will remove"
+        },
+        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -11,6 +11,10 @@
       "additionalProperties": false,
       "properties": {
         "related_policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED use policies instead. @gpeng will remove"
+        },
+        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -86,6 +86,9 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "related_mainstream_content": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -117,9 +120,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -197,6 +197,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED use policies instead. @gpeng will remove"
+        },
+        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_mainstream_content": {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -14,6 +14,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED use policies instead. @gpeng will remove"
+        },
+        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_mainstream_content": {

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -86,6 +86,9 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
+        "policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "related_statistical_data_sets": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -123,9 +126,6 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -182,6 +182,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED use policies instead. @gpeng will remove"
+        },
+        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_statistical_data_sets": {

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -14,6 +14,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED use policies instead. @gpeng will remove"
+        },
+        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_statistical_data_sets": {

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -56,7 +56,7 @@
         "locale": "en"
       }
     ],
-    "related_policies": [
+    "policies": [
       {
         "content_id": "155c22d4-c1f9-40fc-bbe4-4a19df82b164",
         "title": "Helping people to find and stay in work",

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -40,7 +40,7 @@
         "analytics_identifier": "L2"
       }
     ],
-    "related_policies": [
+    "policies": [
 
     ],
     "world_locations": [

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "properties": {
     "related_policies": {
+      "$ref": "#/definitions/guid_list",
+      "description": "DEPRECATED use policies instead. @gpeng will remove"
+    },
+    "policies": {
       "$ref": "#/definitions/guid_list"
     },
     "world_locations": {

--- a/formats/case_study/publisher_v2/examples/case_study_links.json
+++ b/formats/case_study/publisher_v2/examples/case_study_links.json
@@ -3,7 +3,7 @@
     "organisations": [
       "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
     ],
-    "related_policies": [
+    "policies": [
 
     ],
     "world_locations": [

--- a/formats/detailed_guide/frontend/examples/england-2014-to-2020-european-structural-and-investment-funds.json
+++ b/formats/detailed_guide/frontend/examples/england-2014-to-2020-european-structural-and-investment-funds.json
@@ -163,7 +163,7 @@
         "api_path": "/api/content/government/topics/business-and-enterprise"
       }
     ],
-    "related_policies": [
+    "policies": [
       {
         "analytics_identifier": null,
         "content_id": "5d37d041-7631-11e4-a3cb-005056011aef",

--- a/formats/detailed_guide/publisher/links.json
+++ b/formats/detailed_guide/publisher/links.json
@@ -7,6 +7,10 @@
       "$ref": "#/definitions/guid_list"
     },
     "related_policies": {
+      "$ref": "#/definitions/guid_list",
+      "description": "DEPRECATED use policies instead. @gpeng will remove"
+    },
+    "policies": {
       "$ref": "#/definitions/guid_list"
     },
     "related_mainstream_content": {

--- a/formats/publication/frontend/examples/political_publication.json
+++ b/formats/publication/frontend/examples/political_publication.json
@@ -72,7 +72,7 @@
         "locale": "en"
       }
     ],
-    "related_policies": [
+    "policies": [
       {
         "content_id": "5d2b69f0-7631-11e4-a3cb-005056011aef",
         "title": "Climate change impact in developing countries",

--- a/formats/publication/publisher/links.json
+++ b/formats/publication/publisher/links.json
@@ -7,6 +7,10 @@
       "$ref": "#/definitions/guid_list"
     },
     "related_policies": {
+      "$ref": "#/definitions/guid_list",
+      "description": "DEPRECATED use policies instead. @gpeng will remove"
+    },
+    "policies": {
       "$ref": "#/definitions/guid_list"
     },
     "related_statistical_data_sets": {


### PR DESCRIPTION
We are using `related_policies` and `policies` to refer to the same thing. This PR deprecates `related_policies` in favour of `policies` for consistency and to remove the redundant `related` as these are links and are `related` implicitly.