### PR TITLE
Add publishing-api to downstream builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ def dependentApplications = [
   'manuals-publisher',
   'policy-publisher',
   'publisher',
+  'publishing-api',
   'service-manual-frontend',
   'service-manual-publisher',
   'specialist-frontend',


### PR DESCRIPTION
Test the publishing API against any changes to the content schemas.