### PR TITLE
Add `topic_content` and `mainstream_browse_content` reverse link types

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -127,6 +127,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -124,6 +124,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -127,6 +127,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -124,6 +124,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -124,6 +124,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -124,6 +124,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -130,6 +130,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -127,6 +127,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -133,6 +133,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -133,6 +133,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -124,6 +124,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -127,6 +127,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -130,6 +130,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -121,6 +121,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -118,6 +118,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -127,6 +127,12 @@
         },
         "child_taxons": {
           "$ref": "#/definitions/frontend_links"
+        },
+        "topic_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_content": {
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -153,6 +153,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/formats/v2_metadata.json
+++ b/formats/v2_metadata.json
@@ -58,6 +58,16 @@
             "required": [
               "child_taxons"
             ]
+          },
+          {
+            "required": [
+              "topic_content"
+            ]
+          },
+          {
+            "required": [
+              "mainstream_browse_content"
+            ]
           }
         ]
       }

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -40,6 +40,14 @@ class GovukContentSchemas::FrontendSchemaGenerator
     # Content items that are linked to with a `parent_taxon` link type will automatically
     # have a `child_taxon` link type with those items.
     "child_taxons",
+
+    # Content items that are linked to as a `topic` will automatically have a
+    # `topic_content` link type with those items.
+    "topic_content",
+
+    # Content items that are linked to as a `mainstream_browse_page` will automatically
+    # have a `mainstream_browse_content` link type with those items.
+    "mainstream_browse_content",
   ].freeze
 
   CHANGE_HISTORY_REQUIRED = ['specialist_document'].freeze


### PR DESCRIPTION
 - Add the new link types to all the frontend schemas, since reverse links are added by the publishing API.
 - Exclude the link types from edition links. Only the publishing API may add these links, so no other apps should be allowed to add them.

https://trello.com/c/D8Heon8X/410-use-the-content-store-to-serve-pages-in-collections-frontend