### PR TITLE
Remove `children` links from `topics` publisher schema

### DIFF
--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -80,9 +80,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "children": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "linked_items": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -111,6 +108,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -150,10 +150,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "children": {
-          "description": "Any child topics",
-          "$ref": "#/definitions/guid_list"
-        },
         "linked_items": {
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -10,10 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "children": {
-          "description": "Any child topics",
-          "$ref": "#/definitions/guid_list"
-        },
         "linked_items": {
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"

--- a/formats/topic/publisher/links.json
+++ b/formats/topic/publisher/links.json
@@ -3,10 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "children": {
-      "description": "Any child topics",
-      "$ref": "#/definitions/guid_list"
-    },
     "linked_items": {
       "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
       "$ref": "#/definitions/guid_list"

--- a/formats/topic/publisher_v2/examples/topic_links.json
+++ b/formats/topic/publisher_v2/examples/topic_links.json
@@ -1,9 +1,0 @@
-{
-  "links": {
-    "children": [
-      "f6eef5ca-be55-41b2-98be-f72b3e649b84",
-      "0a6116da-fbf6-4d5c-baa9-2a74ae8a8fb9"
-    ]
-  },
-  "previous_version": "10"
-}


### PR DESCRIPTION
These `children` links are reverse links which are added by the publishing API, so they should not be defined in the publisher schema. Publishing apps should rely on the publishing API to add topic `children` links for them.