### PR TITLE
Add finder links to specialist documents

### DIFF
--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -188,6 +143,12 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -222,6 +177,12 @@
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -192,6 +147,12 @@
         "public_updated_at": {
           "$ref": "#/definitions/public_updated_at"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -205,6 +160,12 @@
             }
           }
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -266,6 +221,12 @@
         "tags": {
           "$ref": "#/definitions/tags"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -313,6 +313,12 @@
         }
       }
     },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    },
     "absolute_path": {
       "type": "string",
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -200,6 +155,12 @@
           "description": "Groups of corporate information to display on about pages",
           "$ref": "#/definitions/grouped_lists_of_links"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -231,6 +186,12 @@
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -237,6 +192,12 @@
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -228,6 +183,12 @@
         "govdelivery_title": {
           "type": "string"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -200,6 +155,12 @@
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -229,6 +184,12 @@
         "summary": {
           "$ref": "#/definitions/finder_summary"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -268,6 +223,12 @@
             }
           ]
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -179,6 +134,12 @@
   },
   "definitions": {
     "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    },
+    "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -185,6 +140,12 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -189,6 +144,12 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -188,6 +143,12 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -200,6 +155,12 @@
         "tags": {
           "$ref": "#/definitions/tags"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -204,6 +159,12 @@
         "child_section_groups": {
           "$ref": "#/definitions/hmrc_manual_child_section_groups"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -201,6 +156,12 @@
         "first_published_version": {
           "type": "boolean"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -220,6 +175,12 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -198,6 +153,12 @@
         "groups": {
           "$ref": "#/definitions/topic_groups"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -197,6 +152,12 @@
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -199,6 +154,12 @@
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -249,6 +204,12 @@
           "type": "integer",
           "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -212,6 +167,12 @@
         "political": {
           "$ref": "#/definitions/political"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -243,6 +198,12 @@
         "tags": {
           "$ref": "#/definitions/tags"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -254,6 +209,12 @@
             }
           }
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -216,6 +171,12 @@
         "national_applicability": {
           "$ref": "#/definitions/national_applicability"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -219,6 +174,12 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -180,6 +135,12 @@
   "definitions": {
     "details": {
       "type": "object",
+      "properties": {
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
       "properties": {
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -190,6 +145,12 @@
           "format": "uri",
           "description": "URL to the service standard poster (absolute)"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -231,6 +186,12 @@
             }
           }
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -192,6 +147,12 @@
         "withdrawn_notice": {
           "$ref": "#/definitions/withdrawn_notice"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -250,6 +205,12 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -169,6 +169,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "finder": {
+          "description": "The finder for this specialist document.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -208,6 +163,12 @@
           "type": "boolean",
           "description": "Indicates that the user should choose a new update type on the next save."
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -227,6 +182,12 @@
         "tags": {
           "$ref": "#/definitions/tags"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -209,6 +164,12 @@
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -218,6 +173,12 @@
             "official"
           ]
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -192,6 +147,12 @@
         "image": {
           "$ref": "#/definitions/image"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -189,6 +144,12 @@
           "type": "string",
           "description": "Usage notes for editors when tagging content to a taxon."
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -188,6 +143,12 @@
         "groups": {
           "$ref": "#/definitions/topic_groups"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -192,6 +147,12 @@
         "body": {
           "$ref": "#/definitions/body"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -246,6 +201,12 @@
         "publishing_request_id": {
           "$ref": "#/definitions/publishing_request_id"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -234,6 +189,12 @@
         "publishing_request_id": {
           "$ref": "#/definitions/publishing_request_id"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -205,6 +160,12 @@
         "public_updated_at": {
           "$ref": "#/definitions/public_updated_at"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -188,6 +143,12 @@
         "body": {
           "$ref": "#/definitions/body"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -120,52 +120,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string"
@@ -209,6 +164,12 @@
         "political": {
           "$ref": "#/definitions/political"
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
       }
     },
     "absolute_path": {

--- a/formats/base_edition_links.json
+++ b/formats/base_edition_links.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+  }
+}

--- a/formats/specialist_document/publisher/edition_links.json
+++ b/formats/specialist_document/publisher/edition_links.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "finder": {
+      "description": "The finder for this specialist document.",
+      "$ref": "#/definitions/guid_list",
+      "maxItems": 1
+    }
+  }
+}

--- a/formats/v2_metadata.json
+++ b/formats/v2_metadata.json
@@ -25,52 +25,7 @@
       ]
     },
     "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "description": "Links associated with a particular edition of a document.",
-      "not": {
-        "anyOf": [
-          {
-            "required": [
-              "available_translations"
-            ]
-          },
-          {
-            "required": [
-              "children"
-            ]
-          },
-          {
-            "required": [
-              "policies"
-            ]
-          },
-          {
-            "required": [
-              "document_collections"
-            ]
-          },
-          {
-            "required": [
-              "child_taxons"
-            ]
-          },
-          {
-            "required": [
-              "topic_content"
-            ]
-          },
-          {
-            "required": [
-              "mainstream_browse_content"
-            ]
-          }
-        ]
-      }
+      "$ref": "#/definitions/links"
     },
     "change_note": {
       "type": [

--- a/lib/govuk_content_schemas/schema_combiner.rb
+++ b/lib/govuk_content_schemas/schema_combiner.rb
@@ -53,14 +53,15 @@ private
   end
 
   def add_links(schema, target)
-    return unless schemas.key?(:base_links)
+    base_links = schemas[:base_links]
+    edition_links = schemas[:edition_links]
+    linkset_links = schemas[:links]
+
+    order = [edition_links, linkset_links, base_links].compact
+    return if order.empty?
 
     schema[target] = {} unless schema.key?(target)
-    if schemas.key?(:links)
-      schema[target]["links"] = merge_schemas(schemas[:links], schemas.fetch(:base_links))
-    else
-      schema[target]["links"] = embeddable_schema(schemas.fetch(:base_links))
-    end
+    schema[target]["links"] = merge_schemas(*order)
   end
 
   def merge_schemas(base_schema, *others)

--- a/lib/govuk_content_schemas/schema_combiner.rb
+++ b/lib/govuk_content_schemas/schema_combiner.rb
@@ -63,10 +63,14 @@ private
     end
   end
 
-  def merge_schemas(base_schema, other)
+  def merge_schemas(base_schema, *others)
     merged_schema = embeddable_schema(base_schema)
-    other = embeddable_schema(other)
-    merged_schema["properties"] = merged_schema["properties"].merge(other["properties"])
+
+    other_properties = others.map do |other|
+      embeddable_schema(other)["properties"]
+    end
+
+    merged_schema["properties"].merge!(other_properties.reduce({}, :merge))
     merged_schema
   end
 

--- a/lib/govuk_content_schemas/schema_combiner.rb
+++ b/lib/govuk_content_schemas/schema_combiner.rb
@@ -53,11 +53,18 @@ private
   end
 
   def add_links(schema, target)
-    base_links = schemas[:base_links]
-    edition_links = schemas[:edition_links]
+    base_linkset_links = schemas[:base_links]
     linkset_links = schemas[:links]
+    base_edition_links = schemas[:base_edition_links]
+    edition_links = schemas[:edition_links]
 
-    order = [edition_links, linkset_links, base_links].compact
+    order = [
+      edition_links,
+      linkset_links,
+      base_edition_links,
+      base_linkset_links
+    ].compact
+
     return if order.empty?
 
     schema[target] = {} unless schema.key?(target)

--- a/lib/tasks/combine_schemas.rake
+++ b/lib/tasks/combine_schemas.rake
@@ -28,11 +28,11 @@ def sources_for_v1_schema(filename)
   )
 end
 
-def sources_for_v2_details(filename)
+def sources_for_v2_schema(filename)
   Rake::FileList.new(
     "formats/definitions.json",
     metadata_sources(filename),
-    filename.pathmap("%{^dist/,}p").pathmap("%{_v2,}d/details.json")
+    filename.pathmap("%{^dist/,}p").pathmap("%{_v2,}d/{details,edition_links}.json")
   )
 end
 
@@ -96,7 +96,7 @@ combine_frontend_schemas = ->(task) do
 end
 
 rule %r{^dist/formats/.*/publisher/schema.json} => ->(f) { sources_for_v1_schema(f) }, &combine_publisher_schemas
-rule %r{^dist/formats/.*/publisher_v2/schema.json} => ->(f) { sources_for_v2_details(f) }, &combine_publisher_schemas
+rule %r{^dist/formats/.*/publisher_v2/schema.json} => ->(f) { sources_for_v2_schema(f) }, &combine_publisher_schemas
 rule %r{^dist/formats/.*/publisher_v2/links.json} => ->(f) { sources_for_v2_links(f) }, &combine_publisher_schemas
 
 rule %r{^dist/formats/.*/frontend/schema.json} => ->(f) { sources_for_frontend_schema(f) }, &combine_frontend_schemas
@@ -117,7 +117,7 @@ task combine_publisher_schemas: %i{
   combine_publisher_v2_links
 }
 
-task :announce_combining_schemas do 
+task :announce_combining_schemas do
   print "Combining (generating) schemas... "
 end
 

--- a/lib/tasks/combine_schemas.rake
+++ b/lib/tasks/combine_schemas.rake
@@ -30,7 +30,7 @@ end
 
 def sources_for_v2_schema(filename)
   Rake::FileList.new(
-    "formats/definitions.json",
+    "formats/{definitions,base_edition_links}.json",
     metadata_sources(filename),
     filename.pathmap("%{^dist/,}p").pathmap("%{_v2,}d/{details,edition_links}.json")
   )

--- a/spec/lib/schema_combiner_spec.rb
+++ b/spec/lib/schema_combiner_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
   let(:metadata_schema) { build_schema("metadata.json", properties: build_string_properties("body")) }
   let(:definitions) { build_schema("definitions.json", definitions: build_string_properties("def1")) }
   let(:base_links) { build_schema("base_links.json", properties: build_ref_properties(["mainstream_browse_pages"], "guid_list")) }
+  let(:edition_links) { build_schema("edition_links.json", properties: build_ref_properties(["finder"], "guid_list")) }
   let(:format_name) { "my_format" }
 
   let(:schemas) {
@@ -168,7 +169,7 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
     end
   end
 
-  context "combining metadata and details for a v2 schema" do
+  context "combining metadata, details and edition links for a v2 schema" do
     let(:metadata_schema) {
       build_schema("metadata.json",
                    properties: build_string_properties("body"),
@@ -183,8 +184,8 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
       build_schema("details.json", properties: build_string_properties("detail"))
     }
 
-    let(:links_schema) {
-      build_schema("links.json", properties: build_string_properties("organisations"))
+    let(:edition_links_schema) {
+      build_schema("edition_links.json", properties: build_string_properties("organisations"))
     }
 
     let(:definitions) {
@@ -196,7 +197,8 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
         definitions: definitions,
         metadata: metadata_schema,
         v2_metadata: v2_metadata,
-        details: details_schema
+        details: details_schema,
+        edition_links: edition_links_schema,
       }, format_name).combined
     end
 
@@ -208,8 +210,8 @@ RSpec.describe GovukContentSchemas::SchemaCombiner do
       expect(combined.schema["definitions"]).to include("def1", "def2")
     end
 
-    it "doesn't merge the links schema" do
-      expect(combined.schema).not_to have_key("links")
+    it "has the edition links" do
+      expect(combined.schema["definitions"]).to include("links")
     end
 
     it "merges in v2 required properties" do

--- a/spec/tasks/combine_schema_spec.rb
+++ b/spec/tasks/combine_schema_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe "combine_schemas" do
         definitions: reader.read(project_root.join("formats/definitions.json")),
         details: build_schema("details.json", properties: build_string_properties("detail")),
         links: build_schema("links.json", properties: build_string_properties("links")),
-        base_links: reader.read(project_root.join("formats/base_links.json"))
+        base_links: reader.read(project_root.join("formats/base_links.json")),
+        base_edition_links: reader.read(project_root.join("formats/base_edition_links.json")),
       }
     }
 
@@ -84,7 +85,7 @@ RSpec.describe "combine_schemas" do
 
         specify "the schema.json file contains the combined schemas" do
           expected = GovukContentSchemas::SchemaCombiner.new(
-            slice_hash(schemas, :definitions, :metadata, :v2_metadata, :details),
+            slice_hash(schemas, :definitions, :metadata, :v2_metadata, :details, :base_edition_links),
             format_name
           ).combined
 
@@ -127,7 +128,7 @@ RSpec.describe "combine_schemas" do
 
         specify "the schema.json file contains the combined schemas" do
           expected = GovukContentSchemas::SchemaCombiner.new(
-            slice_hash(schemas, :definitions, :metadata, :details),
+            slice_hash(schemas, :definitions, :metadata, :details, :base_edition_links),
             format_name
           ).combined
 


### PR DESCRIPTION
We're going to be adding links between specialist documents and finders to help template consolidation. The name `finder` is not set in stone and is up for discussion.

See [our Trello card](https://trello.com/c/2wzkWWAR/439-add-links-between-specialist-documents-and-the-finder-blocking-template-consolidation-from-07-03) for background.

This branch is based on changes I've made in the #543 PR, which should get reviewed and merged first.

/cc @tijmenb 