### PR TITLE
Add auth_bypass_id attribute to metadata

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -458,9 +458,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -435,9 +435,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -319,9 +319,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -498,9 +498,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -466,9 +466,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -80,9 +80,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -353,9 +353,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -462,9 +462,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -439,9 +439,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -323,9 +323,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -475,9 +475,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -452,9 +452,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -336,9 +336,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -542,9 +542,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -510,9 +510,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -84,9 +84,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -397,9 +397,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -655,9 +655,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -629,9 +629,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -74,9 +74,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -510,9 +510,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -473,9 +473,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -447,9 +447,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -74,9 +74,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -331,9 +331,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -507,9 +507,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -475,9 +475,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -80,9 +80,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -362,9 +362,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -509,9 +509,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -481,9 +481,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -81,9 +81,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -386,9 +386,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -498,9 +498,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -475,9 +475,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -359,9 +359,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -474,9 +474,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -444,9 +444,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -79,9 +79,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -331,9 +331,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -505,9 +505,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -476,9 +476,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -80,9 +80,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -360,9 +360,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -541,9 +541,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -515,9 +515,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -74,9 +74,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -399,9 +399,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -452,9 +452,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -429,9 +429,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -313,9 +313,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -455,9 +455,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -432,9 +432,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -316,9 +316,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -459,9 +459,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -436,9 +436,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -320,9 +320,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -458,9 +458,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -435,9 +435,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -319,9 +319,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -470,9 +470,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -447,9 +447,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -331,9 +331,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -474,9 +474,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -451,9 +451,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -335,9 +335,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -476,9 +476,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -456,9 +456,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -346,9 +346,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -477,9 +477,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -454,9 +454,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -338,9 +338,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -490,9 +490,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -467,9 +467,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -351,9 +351,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -484,9 +484,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -445,9 +445,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -87,9 +87,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -329,9 +329,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -470,9 +470,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -444,9 +444,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -77,9 +77,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -328,9 +328,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -472,9 +472,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -446,9 +446,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -77,9 +77,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -330,9 +330,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -519,9 +519,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -496,9 +496,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -380,9 +380,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -491,9 +491,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -456,9 +456,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -87,9 +87,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -343,9 +343,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -467,9 +467,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -444,9 +444,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -328,9 +328,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -517,9 +517,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -490,9 +490,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -378,9 +378,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -540,9 +540,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -501,9 +501,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -90,9 +90,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -385,9 +385,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -494,9 +494,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -460,9 +460,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -86,9 +86,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -371,9 +371,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -494,9 +494,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -463,9 +463,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -79,9 +79,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -350,9 +350,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -451,9 +451,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -428,9 +428,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -312,9 +312,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -464,9 +464,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -437,9 +437,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -75,9 +75,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -321,9 +321,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -501,9 +501,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -478,9 +478,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -362,9 +362,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -474,9 +474,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -439,9 +439,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -83,9 +83,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -323,9 +323,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -520,9 +520,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -497,9 +497,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -381,9 +381,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -481,9 +481,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -453,9 +453,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -348,9 +348,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -511,9 +511,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -471,9 +471,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -92,9 +92,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -358,9 +358,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -476,9 +476,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -453,9 +453,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -340,9 +340,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -488,9 +488,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -465,9 +465,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -349,9 +349,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -462,9 +462,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -439,9 +439,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -323,9 +323,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -463,9 +463,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -436,9 +436,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -75,9 +75,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -324,9 +324,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -462,9 +462,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -435,9 +435,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -75,9 +75,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -319,9 +319,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -462,9 +462,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -439,9 +439,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -323,9 +323,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -483,9 +483,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -460,9 +460,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -344,9 +344,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -506,9 +506,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -480,9 +480,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -74,9 +74,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -364,9 +364,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -467,9 +467,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -441,9 +441,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -74,9 +74,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -325,9 +325,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -475,9 +475,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -452,9 +452,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -336,9 +336,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -458,9 +458,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -435,9 +435,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -71,9 +71,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -319,9 +319,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -485,9 +485,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -453,9 +453,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -80,9 +80,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -340,9 +340,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -23,9 +23,13 @@
             "type": "string"
           }
         },
+        "auth_bypass_ids": {
+          "$ref": "#/definitions/guid_list",
+          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        },
         "fact_check_ids": {
           "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for fact checking."
+          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },


### PR DESCRIPTION
We want to be able to give people access to the draft stack for other states than just fact check (i.e. draft or ready) so we rename the field to be less specific. The [docs of authenticating proxy](https://github.com/alphagov/authenticating-proxy#technical-documentation) refer to this feature as "The application also supports bypassing authentication via a valid JWT token" so the new name `auth_bypass_id` feels more appropriate here...

We want to be able to maintain the old fact_check_id working for a short time in conjunction with the new auth_bypass_id attribute.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id