### PR TITLE
Revert "Consistently use policies links"

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -83,9 +83,6 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -120,6 +117,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -185,10 +185,6 @@
       "additionalProperties": false,
       "properties": {
         "related_policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED use policies instead. @gpeng will remove"
-        },
-        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -11,10 +11,6 @@
       "additionalProperties": false,
       "properties": {
         "related_policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED use policies instead. @gpeng will remove"
-        },
-        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -80,6 +80,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/consultation/publisher/schema.json
+++ b/dist/formats/consultation/publisher/schema.json
@@ -228,8 +228,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "policies": {
+        "related_policies": {
           "$ref": "#/definitions/guid_list"
+        },
+        "policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
         },
         "ministers": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "policies": {
+        "related_policies": {
           "$ref": "#/definitions/guid_list"
+        },
+        "policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
         },
         "ministers": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -86,9 +86,6 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "related_mainstream_content": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -120,6 +117,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -197,10 +197,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED use policies instead. @gpeng will remove"
-        },
-        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_mainstream_content": {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -14,10 +14,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED use policies instead. @gpeng will remove"
-        },
-        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_mainstream_content": {

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -80,6 +80,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/news_article/publisher/schema.json
+++ b/dist/formats/news_article/publisher/schema.json
@@ -174,8 +174,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "policies": {
+        "related_policies": {
           "$ref": "#/definitions/guid_list"
+        },
+        "policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
         },
         "ministers": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -10,8 +10,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "policies": {
+        "related_policies": {
           "$ref": "#/definitions/guid_list"
+        },
+        "policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
         },
         "ministers": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -86,9 +86,6 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
         "related_statistical_data_sets": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -126,6 +123,9 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -182,10 +182,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED use policies instead. @gpeng will remove"
-        },
-        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_statistical_data_sets": {

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -14,10 +14,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "related_policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED use policies instead. @gpeng will remove"
-        },
-        "policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_statistical_data_sets": {

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -83,6 +83,9 @@
         "speaker": {
           "$ref": "#/definitions/frontend_links"
         },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "policies": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/speech/publisher/schema.json
+++ b/dist/formats/speech/publisher/schema.json
@@ -194,8 +194,12 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
+        "related_policies": {
           "$ref": "#/definitions/guid_list"
+        },
+        "policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED in favour of related_policies @gpeng will remove"
         },
         "ministers": {
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -15,8 +15,12 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
-        "policies": {
+        "related_policies": {
           "$ref": "#/definitions/guid_list"
+        },
+        "policies": {
+          "$ref": "#/definitions/guid_list",
+          "description": "DEPRECATED in favour of related_policies @gpeng will remove"
         },
         "ministers": {
           "$ref": "#/definitions/guid_list"

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -56,7 +56,7 @@
         "locale": "en"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "155c22d4-c1f9-40fc-bbe4-4a19df82b164",
         "title": "Helping people to find and stay in work",

--- a/formats/case_study/frontend/examples/case_study.json
+++ b/formats/case_study/frontend/examples/case_study.json
@@ -40,7 +40,7 @@
         "analytics_identifier": "L2"
       }
     ],
-    "policies": [
+    "related_policies": [
 
     ],
     "world_locations": [

--- a/formats/case_study/publisher/links.json
+++ b/formats/case_study/publisher/links.json
@@ -4,10 +4,6 @@
   "additionalProperties": false,
   "properties": {
     "related_policies": {
-      "$ref": "#/definitions/guid_list",
-      "description": "DEPRECATED use policies instead. @gpeng will remove"
-    },
-    "policies": {
       "$ref": "#/definitions/guid_list"
     },
     "world_locations": {

--- a/formats/case_study/publisher_v2/examples/case_study_links.json
+++ b/formats/case_study/publisher_v2/examples/case_study_links.json
@@ -3,7 +3,7 @@
     "organisations": [
       "8b19c238-54e3-4e27-b0d7-60f8e2a677c9"
     ],
-    "policies": [
+    "related_policies": [
 
     ],
     "world_locations": [

--- a/formats/consultation/frontend/examples/unopened_consultation.json
+++ b/formats/consultation/frontend/examples/unopened_consultation.json
@@ -47,7 +47,7 @@
         "analytics_identifier": "EA199"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d37acc4-7631-11e4-a3cb-005056011aef",
         "title": "Radioactive and nuclear substances and waste",

--- a/formats/consultation/publisher/links.json
+++ b/formats/consultation/publisher/links.json
@@ -3,8 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "policies": {
+    "related_policies": {
       "$ref": "#/definitions/guid_list"
+    },
+    "policies": {
+      "$ref": "#/definitions/guid_list",
+      "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
     },
     "ministers": {
       "$ref": "#/definitions/guid_list"

--- a/formats/detailed_guide/frontend/examples/england-2014-to-2020-european-structural-and-investment-funds.json
+++ b/formats/detailed_guide/frontend/examples/england-2014-to-2020-european-structural-and-investment-funds.json
@@ -163,7 +163,7 @@
         "api_path": "/api/content/government/topics/business-and-enterprise"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "analytics_identifier": null,
         "content_id": "5d37d041-7631-11e4-a3cb-005056011aef",

--- a/formats/detailed_guide/publisher/links.json
+++ b/formats/detailed_guide/publisher/links.json
@@ -7,10 +7,6 @@
       "$ref": "#/definitions/guid_list"
     },
     "related_policies": {
-      "$ref": "#/definitions/guid_list",
-      "description": "DEPRECATED use policies instead. @gpeng will remove"
-    },
-    "policies": {
       "$ref": "#/definitions/guid_list"
     },
     "related_mainstream_content": {

--- a/formats/news_article/frontend/examples/news_article_government_response.json
+++ b/formats/news_article/frontend/examples/news_article_government_response.json
@@ -21,7 +21,7 @@
         "analytics_identifier": "PB57"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d5e94fa-7631-11e4-a3cb-005056011aef",
         "title": "Marine environment",

--- a/formats/news_article/frontend/examples/news_article_history_mode.json
+++ b/formats/news_article/frontend/examples/news_article_history_mode.json
@@ -21,7 +21,7 @@
         "analytics_identifier": "D12"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d606d99-7631-11e4-a3cb-005056011aef",
         "title": "Health and social care integration",

--- a/formats/news_article/publisher/links.json
+++ b/formats/news_article/publisher/links.json
@@ -3,8 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "policies": {
+    "related_policies": {
       "$ref": "#/definitions/guid_list"
+    },
+    "policies": {
+      "$ref": "#/definitions/guid_list",
+      "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
     },
     "ministers": {
       "$ref": "#/definitions/guid_list"

--- a/formats/publication/frontend/examples/political_publication.json
+++ b/formats/publication/frontend/examples/political_publication.json
@@ -72,7 +72,7 @@
         "locale": "en"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d2b69f0-7631-11e4-a3cb-005056011aef",
         "title": "Climate change impact in developing countries",

--- a/formats/publication/publisher/links.json
+++ b/formats/publication/publisher/links.json
@@ -7,10 +7,6 @@
       "$ref": "#/definitions/guid_list"
     },
     "related_policies": {
-      "$ref": "#/definitions/guid_list",
-      "description": "DEPRECATED use policies instead. @gpeng will remove"
-    },
-    "policies": {
       "$ref": "#/definitions/guid_list"
     },
     "related_statistical_data_sets": {

--- a/formats/speech/frontend/examples/speech-authored-article.json
+++ b/formats/speech/frontend/examples/speech-authored-article.json
@@ -76,7 +76,7 @@
         "locale": "en"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d278051-7631-11e4-a3cb-005056011aef",
         "title": "European single market",

--- a/formats/speech/frontend/examples/speech-speaker-without-profile.json
+++ b/formats/speech/frontend/examples/speech-speaker-without-profile.json
@@ -74,7 +74,7 @@
         "locale": "en"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d278051-7631-11e4-a3cb-005056011aef",
         "title": "Government transparency and accountability",

--- a/formats/speech/frontend/examples/speech-speaking-notes.json
+++ b/formats/speech/frontend/examples/speech-speaking-notes.json
@@ -66,7 +66,7 @@
         "locale": "en"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d5e9fca-7631-11e4-a3cb-005056011aef",
         "title": "Policing",

--- a/formats/speech/frontend/examples/speech-transcript.json
+++ b/formats/speech/frontend/examples/speech-transcript.json
@@ -88,7 +88,7 @@
         "locale": "en"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d278051-7631-11e4-a3cb-005056011aef",
         "title": "Government transparency and accountability",

--- a/formats/speech/frontend/examples/speech-written-statement-parliament.json
+++ b/formats/speech/frontend/examples/speech-written-statement-parliament.json
@@ -76,7 +76,7 @@
         "locale": "en"
       }
     ],
-    "policies": [
+    "related_policies": [
       {
         "content_id": "5d278051-7631-11e4-a3cb-005056011aef",
         "title": "School and college funding",

--- a/formats/speech/publisher/links.json
+++ b/formats/speech/publisher/links.json
@@ -8,8 +8,12 @@
       "$ref": "#/definitions/guid_list",
       "maxItems": 1
     },
-    "policies": {
+    "related_policies": {
       "$ref": "#/definitions/guid_list"
+    },
+    "policies": {
+      "$ref": "#/definitions/guid_list",
+      "description": "DEPRECATED in favour of related_policies @gpeng will remove"
     },
     "ministers": {
       "$ref": "#/definitions/guid_list"


### PR DESCRIPTION
We have decided to use `related_policies` consistently to avoid clashing with the `working_groups` -> `policies` reverse links.

Reverts alphagov/govuk-content-schemas#532