### PR TITLE
Add supertypes to frontend & notification schemas

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -149,6 +149,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -146,6 +146,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -149,6 +149,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -146,6 +146,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -146,6 +146,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -146,6 +146,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -152,6 +152,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -149,6 +149,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -139,6 +139,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -101,6 +101,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -155,6 +155,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -155,6 +155,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -146,6 +146,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -149,6 +149,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -160,6 +160,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -122,6 +122,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -152,6 +152,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -143,6 +143,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -140,6 +140,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -149,6 +149,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -102,6 +102,14 @@
       "type": "string",
       "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
+    "navigation_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    },
+    "whitehall_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"
+    },
     "updated_at": {
       "type": "string",
       "format": "date-time"

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -103,6 +103,14 @@ private
         "type" => "string",
         "description" => "DEPRECATED: use `document_type` instead. This field will be removed."
       },
+      "navigation_document_supertype" => {
+        "type" => "string",
+        "description" => "Document type grouping powering the new taxonomy-based navigation pages",
+      },
+      "whitehall_document_supertype" => {
+        "type" => "string",
+        "description" => "Document type grouping intended to power the Whitehall finders and email subscriptions",
+      },
       "updated_at" => updated_at,
       "base_path" => { "$ref" => "#/definitions/absolute_path" }
     )


### PR DESCRIPTION
Document types can be grouped into "document supertypes". For example, the `whitehall_document_supertype` grouping splits document types into "Publications", "Announcements" and "Statistics".

This adds two of these types (it's possible that more will come).

These are only in the frontend schemas because publishing-api will add them automatically. See alphagov/publishing-api#805.

We don't have `whitehall_document_supertype` yet, but this should come quite soon.

https://trello.com/c/07lAcDtC