### PR TITLE
Deprecate `format` field

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -146,7 +146,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -143,7 +143,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -146,7 +146,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -143,7 +143,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -143,7 +143,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -143,7 +143,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -149,7 +149,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -146,7 +146,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -136,7 +136,8 @@
       "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -98,7 +98,8 @@
       "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -152,7 +152,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -152,7 +152,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -143,7 +143,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -146,7 +146,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -157,7 +157,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -119,7 +119,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -149,7 +149,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -140,7 +140,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -137,7 +137,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -146,7 +146,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -99,7 +99,8 @@
       ]
     },
     "format": {
-      "type": "string"
+      "type": "string",
+      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
     },
     "updated_at": {
       "type": "string",

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -99,7 +99,10 @@ private
 
     properties = properties.merge(
       "links" => frontend_links,
-      "format" => { "type" => "string" },
+      "format" => {
+        "type" => "string",
+        "description" => "DEPRECATED: use `document_type` instead. This field will be removed."
+      },
       "updated_at" => updated_at,
       "base_path" => { "$ref" => "#/definitions/absolute_path" }
     )


### PR DESCRIPTION
This should make clear that this field is deprecated in favour of `document_type`.