### PR TITLE
Correct public_updated_at date in specialist document example

### DIFF
--- a/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
@@ -127,7 +127,7 @@
       }
     ]
   },
-  "public_updated_at": "2015-04-02T11:07:32+00:00",
+  "public_updated_at": "2016-03-29T08:43:53.000+00:00",
   "schema_name": "specialist_document",
   "document_type": "countryside_stewardship_grant",
   "links": {


### PR DESCRIPTION
The example had an impossible public updated at date – it was before more recent updates.
It should match the most recent change note in the change history, ie a list of public updates.

This was missed in #513