### PR TITLE
Add short-url-manager to `dependentApplications`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ def dependentApplications = [
   'policy-publisher',
   'publisher',
   'publishing-api',
+  'short-url-manager',
   'service-manual-frontend',
   'service-manual-publisher',
   'specialist-frontend',


### PR DESCRIPTION
Looks to me like the [short-url-manager JenkinsFile](https://github.com/alphagov/short-url-manager/blob/master/Jenkinsfile) is already setup to be run from here. I think this is all we do and we can remove the ci.dev schema_branches job for short-url-manager.