### PR TITLE
Add `user_journey_stage` document supertype

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -153,6 +153,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -153,6 +153,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -153,6 +153,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -150,6 +150,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -150,6 +150,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -150,6 +150,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -156,6 +156,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -156,6 +156,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -143,6 +143,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -105,6 +105,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -159,6 +159,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -159,6 +159,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -150,6 +150,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -153,6 +153,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -164,6 +164,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -126,6 +126,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -159,6 +159,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -147,6 +147,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -144,6 +144,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -153,6 +153,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -106,6 +106,10 @@
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"
     },
+    "user_journey_document_supertype": {
+      "type": "string",
+      "description": "Document type grouping powering analytics of user journeys"
+    },
     "whitehall_document_supertype": {
       "type": "string",
       "description": "Document type grouping intended to power the Whitehall finders and email subscriptions"

--- a/lib/govuk_content_schemas/frontend_schema_generator.rb
+++ b/lib/govuk_content_schemas/frontend_schema_generator.rb
@@ -107,6 +107,10 @@ private
         "type" => "string",
         "description" => "Document type grouping powering the new taxonomy-based navigation pages",
       },
+      "user_journey_document_supertype" => {
+        "type" => "string",
+        "description" => "Document type grouping powering analytics of user journeys",
+      },
       "whitehall_document_supertype" => {
         "type" => "string",
         "description" => "Document type grouping intended to power the Whitehall finders and email subscriptions",


### PR DESCRIPTION
Add document supertype which will classify pages by where they sit in a user journey: do they contain content, or do they help the user find content?

https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages