### PR TITLE
Add related policies to document collection links

### DIFF
--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -86,6 +86,9 @@
         "topical_events": {
           "$ref": "#/definitions/frontend_links"
         },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -206,6 +206,9 @@
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -17,6 +17,9 @@
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/formats/document_collection/publisher/links.json
+++ b/formats/document_collection/publisher/links.json
@@ -9,6 +9,9 @@
     },
     "topical_events": {
       "$ref": "#/definitions/guid_list"
+    },
+    "related_policies": {
+      "$ref": "#/definitions/guid_list"
     }
   }
 }


### PR DESCRIPTION
The Whitehall format Document Collection has `related_policies`. Update schema to reflect this.