### PR TITLE
[DO NOT MERGE] Updates schema to html publications

### DIFF
--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -268,6 +268,14 @@
         "first_published_version": {
           "type": "boolean"
         },
+        "isbn": {
+          "type": "string",
+          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
+        },
+        "print_meta_data_contact_address": {
+          "type": "string",
+          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -261,6 +261,14 @@
         "first_published_version": {
           "type": "boolean"
         },
+        "isbn": {
+          "type": "string",
+          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
+        },
+        "print_meta_data_contact_address": {
+          "type": "string",
+          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -156,6 +156,14 @@
         },
         "first_published_version": {
           "type": "boolean"
+        },
+        "isbn": {
+          "type": "string",
+          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
+        },
+        "print_meta_data_contact_address": {
+          "type": "string",
+          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication"
         }
       }
     },

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -155,6 +155,14 @@
         },
         "first_published_version": {
           "type": "boolean"
+        },
+        "isbn": {
+          "type": "string",
+          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
+        },
+        "print_meta_data_contact_address": {
+          "type": "string",
+          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication"
         }
       }
     },

--- a/formats/html_publication/frontend/examples/print_with_meta_data.json
+++ b/formats/html_publication/frontend/examples/print_with_meta_data.json
@@ -1,0 +1,55 @@
+{
+  "content_id": "db2df831-2a59-487c-bdf2-3ab7aec807bd",
+  "base_path": "/government/publications/working-with-the-overseas-territories/working-with-the-overseas-territories",
+  "details": {
+    "body": "<div class=\"govspeak\"><p>Like other government departments, the Department for Communities and Local Government fully supports the implementation of the <a href=\"https://www.gov.uk/government/policies/protecting-and-developing-the-overseas-territories\">2012 white paper on Overseas Territories.</a> To demonstrate this we work with the <a rel=\"external\" href=\"http://www.local.gov.uk\">Local Government Association</a> and others to provide access to advice and support on the policy issues where we have the lead.</p>\n\n<h2 id=\"department-for-communities-and-local-government\">\n<span class=\"number\">1. </span>Department for Communities and Local Government</h2>\n\n<p>The Department for Communities and Local Government sets policy on:</p>\n\n<ul>\n  <li>local government</li>\n  <li>communities and neighbourhoods</li>\n  <li>local growth</li>\n  <li>housing</li>\n  <li>planning, building and the environment</li>\n  <li>fire</li>\n</ul>\n\n<p>Local councils, planning and fire authorities, among others, are responsible for the delivery of services to citizens and the implementation of many of our policies. Those who are seeking advice or guidance from practitioners may be directed towards those outside the department.</p>\n\n<h2 id=\"working-with-the-territories\">\n<span class=\"number\">2. </span>Working with the Territories</h2>\n\n<p>The department has worked with several of the Territories in the past to provide advice and guidance on areas where we have expertise and to signpost relevant information or contacts. This includes expertise in planning, housing, governance issues, local finance and taxation and fire safety and services.</p>\n\n<p>Some examples of our support are described below.</p>\n\n<h3 id=\"flying-flags\">\n<span class=\"number\">2.1 </span>Flying flags</h3>\n\n<p>The department has demonstrated its support by proudly flying Territory flags outside Eland House, our London building, as part of a rolling programme that includes the Union and English county flags. The flags are flown at appropriate times to recognise national days of significance. The flags flown include the Gibralter Flag to mark the Territory’s National Day,  the British Virgin Islands flag to mark the St Ursula’s Day, and before that the flags of the Cayman and Falkland Islands.</p>\n\n<p>In addition, since last October, as part of the liberalisation of the regime for flying flags, we have made clear that the flag of any Overseas Territory may be flown in England without the consent of the local planning authority. Read a <a href=\"https://www.gov.uk/government/publications/flying-flags-a-plain-english-guide\">plain English guide to the new flag-flying regime.</a></p>\n\n<h3 id=\"planning-case-study\">\n<span class=\"number\">2.2 </span>Planning case study</h3>\n\n<p>St Helena has Department for International Development (DfID) support for building its first airport. The Territory lacked the systems and expertise in planning for such a major development. The department’s Chief Planner was able to provide support and assistance by working with the Territory to define what sort of expertise they needed to ensure good planning practice was followed. It was identified that a professional planner should be recruited. Our Chief Planner helped draw up a job description and acted as an external assessor on the interview panel for the appointment.</p>\n\n<p>Since then the department’s officials have met the Deputy Governor for St Helena to exchange ideas and information on housing, integration and governance issues.</p>\n\n<h3 id=\"fire-case-study\">\n<span class=\"number\">2.3 </span>Fire case study</h3>\n\n<p>Our fire inspectors have a long history of working with Overseas Territories and until 2002 carried out inspections regularly. Technical standards for equipment and regulations for managing fire and rescue services were also promulgated from the UK.</p>\n\n<p>Since 2002, the relationship has continued as the Territories have become more responsible for their own services. There are some ongoing relationships between particular territories and particular fire and rescue services. Sir Ken Knight, our former Chief Fire and Rescue Adviser led reviews of the fire services for the governments of Bermuda and Gibraltar.</p>\n\n<p>The <a rel=\"external\" href=\"http://www.fireservicecollege.ac.uk\">Fire Service College</a> formerly an executive agency of the Department for Communities and Local Government, also has an ongoing relationship with the Territories, with members of fire and rescue services attending both standard and tailored courses. The UK has also sent specialist teams and equipment across the globe to respond to significant emergencies.</p>\n\n<h3 id=\"sustainable-buildings-case-study\">\n<span class=\"number\">2.4 </span>Sustainable buildings case study</h3>\n\n<p>The Climate Change and Sustainable Buildings Division has provided assistance to Gibraltar, giving them access to a standard methodology and energy calculation software for 3 years, royalty free. This has given the Territory a proven way of assessing and demonstrating compliance with Building Regulations and generating Energy Performance Certificates when buildings are constructed, leased or sold. The department reserves the right to charge for a licence fee in future.</p>\n\n<h2 id=\"what-the-department-can-do-in-the-future\">\n<span class=\"number\">3. </span>What the department can do in the future</h2>\n\n<p>We will continue to provide support in the areas identified above. Our contact point for Overseas Territories work is <a href=\"mailto:sue.westcott@Communities.gsi.gov.uk\">Sue Westcott</a> 030 3444 2490</p>\n\n<p>The Local Government Association, as the sector lead body, now has the responsibility for improvement and sharing best practice in many areas and so will often be a useful source of information to those seeking to develop their services and policies in particular areas. Information on how the territories can work with the Local Government Association is given below.</p>\n\n<h2 id=\"local-government-association\">\n<span class=\"number\">4. </span>Local Government Association</h2>\n\n<p>In the white paper on Overseas Territories, the Foreign Secretary stated:</p>\n\n<blockquote>\n  <p class=\"last-child\">I particularly welcome the growing partnerships between the Territories and local authorities and with the non-governmental organisations community on environmental and other issues.</p>\n</blockquote>\n\n<p>The Local Government Association is the national voice of local government and its mission is to support, promote and improve councils.</p>\n\n<p>The Local Government Association provides a range of support services to its member councils, including:</p>\n\n<ul>\n  <li>peer review and support</li>\n  <li>e-learning</li>\n  <li>best practice exchange</li>\n  <li>leadership development</li>\n</ul>\n\n<p>As many of these services to local councils could be helpful to improve services and governance in Overseas Territories, the Local Government Association would be happy to discuss how its expertise could be used to support good governance and service improvement in the Overseas Territories.</p>\n\n<p>Contact the Local Government Association: info@local.gov.uk Telephone: 020 7664 3000</p>\n</div>",
+    "headings": "<ol><li><a href=\"#department-for-communities-and-local-government\">Department for Communities and Local Government</a></li><li><a href=\"#working-with-the-territories\">Working with the Territories</a></li><li><a href=\"#what-the-department-can-do-in-the-future\">What the department can do in the future</a></li><li><a href=\"#local-government-association\">Local Government Association</a></li></ol>",
+    "public_timestamp": "2016-01-17T14:19:42.460Z",
+    "first_published_version": true,
+    "isbn": "978-1-4098-4066-4",
+    "print_meta_data_contact_address": "Department for Communities and Local Government\r\n2nd floor NW, Fry Building \r\n2 Marsham Street \r\nLondon \r\nSW1P 4DF"
+  },
+  "format": "html_publication",
+  "schema_name": "html_publication",
+  "document_type": "html_publication",
+  "links": {
+    "parent": [
+      {
+        "content_id": "5ec69271-7631-11e4-a3cb-005056011aef",
+        "schema_name": "placeholder_publication",
+        "document_type": "policy_paper",
+        "title": "Working with the Overseas Territories",
+        "api_path": "/api/content/government/publications/working-with-the-overseas-territories",
+        "base_path": "/government/publications/working-with-the-overseas-territories",
+        "api_url": "https://www.gov.uk/api/content/government/publications/working-with-the-overseas-territories",
+        "web_url": "https://www.gov.uk/government/publications/working-with-the-overseas-territories",
+        "locale": "en"
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "title": "Department for Communities and Local Government",
+        "details": {
+          "logo": {
+            "formatted_title": "Department for \r\nCommunities and\r\nLocal Government",
+            "crest": "single-identity"
+          }
+        },
+        "api_path": "/api/content/government/organisations/department-for-communities-and-local-government",
+        "base_path": "/government/organisations/department-for-communities-and-local-government",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-communities-and-local-government",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-communities-and-local-government",
+        "locale": "en",
+        "analytics_identifier": "D4"
+      }
+    ]
+  },
+  "locale": "en",
+  "need_ids": [
+
+  ],
+  "public_updated_at": "2013-11-19T14:17:01.460Z",
+  "title": "Working with the Overseas Territories",
+  "updated_at": "2013-11-19T14:17:01Z"
+}

--- a/formats/html_publication/publisher/details.json
+++ b/formats/html_publication/publisher/details.json
@@ -21,6 +21,14 @@
     },
     "first_published_version": {
       "type": "boolean"
+    },
+    "isbn": {
+      "type": "string",
+      "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
+    },
+    "print_meta_data_contact_address": {
+      "type": "string",
+      "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication"
     }
   }
 }


### PR DESCRIPTION
For: https://trello.com/c/88zaXS8J/47-create-print-styles-for-official-documents

This will add two more fields to be sent along to Publishing API from Whitehall. These two fields will be included in the print version of HTML Publications which are edited on whitehall, but will be displayed by frontend.

You can still see a draft of the HTML Publication on Whitehall, but the frontend app actually needs to display this information.

These schemas will signal to frontend to use two extra fields (that will be displayed in the print version of the HTML Publication). 

They are: `isbn` and `print_meta_data_contact_address`. Both fields are optional.

`isbn` - Identifies the Web ISBN to be displayed when printing an HTML Publication
`print_meta_data_contact_address` - Identifies the address of the institution which has produced the HTML Publication

Is dependent on this PR: https://github.com/alphagov/govuk-content-schemas/pull/561/commits/312e10e87c5534a3151337a2b647310f55184eb1