### PR TITLE
Include featured policies in placeholder edition links

### DIFF
--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -349,6 +349,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "featured_policies": {
+          "description": "Featured policies primarily for use with Whitehall organisations",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "$ref": "#/definitions/guid_list"
         }

--- a/formats/placeholder/publisher/edition_links.json
+++ b/formats/placeholder/publisher/edition_links.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "featured_policies": {
+      "description": "Featured policies primarily for use with Whitehall organisations",
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}


### PR DESCRIPTION
Organisations are a placeholder format on Whitehall. To render an
Organisation on Whitehall there is currently use of the Publishing API
linkable endpoint, this has proven nicht gut causing some errors in
production.

This allows placeholder documents to have edition links to
featured_policies so we can start working around this problem.

It seemed a shame that all placeholder items may have to deal with this,
but this already seems to be the case with link set links, so doesn't
appear to be a new precedent.