### PR TITLE
Add edition links for document collections

### DIFF
--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -305,6 +305,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -339,6 +339,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -309,6 +309,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -322,6 +322,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -383,6 +383,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -473,6 +473,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -317,6 +317,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -348,6 +348,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -354,6 +354,27 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "documents": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -363,16 +363,16 @@
         "parent": {
           "$ref": "#/definitions/guid_list"
         },
-        "policy_areas": {
+        "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
-        "related_policies": {
+        "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
         "topics": {
           "$ref": "#/definitions/guid_list"
         },
-        "topical_events": {
+        "policy_areas": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -345,6 +345,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -317,6 +317,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -346,6 +346,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -385,6 +385,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -299,6 +299,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -302,6 +302,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -306,6 +306,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -305,6 +305,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -317,6 +317,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -321,6 +321,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -326,6 +326,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -325,6 +325,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -337,6 +337,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -315,6 +315,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -314,6 +314,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -316,6 +316,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -366,6 +366,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -329,6 +329,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -314,6 +314,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -360,6 +360,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -371,6 +371,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -333,6 +333,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -336,6 +336,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -298,6 +298,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -307,6 +307,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -348,6 +348,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -309,6 +309,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -367,6 +367,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -329,6 +329,9 @@
           "description": "The finder for this specialist document.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -344,6 +344,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -326,6 +326,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -335,6 +335,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -309,6 +309,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -306,6 +306,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -305,6 +305,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -309,6 +309,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -350,6 +350,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -350,6 +350,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -322,6 +322,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -305,6 +305,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -326,6 +326,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
       }
     },
     "absolute_path": {

--- a/formats/base_edition_links.json
+++ b/formats/base_edition_links.json
@@ -3,5 +3,8 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "policy_areas": {
+      "$ref": "#/definitions/guid_list"
+    }
   }
 }

--- a/formats/document_collection/publisher/edition_links.json
+++ b/formats/document_collection/publisher/edition_links.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "documents": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "organisations": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "parent": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "policy_areas": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "related_policies": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "topics": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "topical_events": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}

--- a/formats/document_collection/publisher/edition_links.json
+++ b/formats/document_collection/publisher/edition_links.json
@@ -12,16 +12,13 @@
     "parent": {
       "$ref": "#/definitions/guid_list"
     },
-    "policy_areas": {
-      "$ref": "#/definitions/guid_list"
-    },
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },
-    "topics": {
+    "topical_events": {
       "$ref": "#/definitions/guid_list"
     },
-    "topical_events": {
+    "topics": {
       "$ref": "#/definitions/guid_list"
     }
   }


### PR DESCRIPTION
This PR adds edition links to the Whitehall `DocumentCollection` schema. 

It also extracts common links into `edition_base_links.json` based on the links that we considered common in `base_links`.

There is currently duplication between these two files which we hope to be able to remove as we update other formats.

[Trello](https://trello.com/c/s7LjBWav/634-use-draft-links-for-documentcollections)