### PR TITLE
Add edition links to publications

### DIFF
--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -335,6 +335,30 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "related_statistical_data_sets": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "$ref": "#/definitions/guid_list"
         }

--- a/formats/publication/publisher/edition_links.json
+++ b/formats/publication/publisher/edition_links.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ministers": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "organisations": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "parent": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "related_policies": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "related_statistical_data_sets": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "topical_events": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "topics": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "world_locations": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}


### PR DESCRIPTION
https://trello.com/c/RWL7ppZ6/637-use-draft-links-for-publications

Adds edition links for the publications format.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/567 specifically changes in `formats/base_edition_links.json`