### PR TITLE
Remove deprecated countries hash from travel index.

### DIFF
--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -414,45 +414,6 @@
         "email_signup_link": {
           "$ref": "#/definitions/email_signup_link"
         },
-        "countries": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "name",
-              "base_path",
-              "updated_at",
-              "public_updated_at",
-              "change_description",
-              "synonyms"
-            ],
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "base_path": {
-                "$ref": "#/definitions/absolute_path"
-              },
-              "updated_at": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "public_updated_at": {
-                "$ref": "#/definitions/public_updated_at"
-              },
-              "change_description": {
-                "type": "string"
-              },
-              "synonyms": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
         "max_cache_time": {
           "$ref": "#/definitions/max_cache_time"
         },

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -404,45 +404,6 @@
         "email_signup_link": {
           "$ref": "#/definitions/email_signup_link"
         },
-        "countries": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "name",
-              "base_path",
-              "updated_at",
-              "public_updated_at",
-              "change_description",
-              "synonyms"
-            ],
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "base_path": {
-                "$ref": "#/definitions/absolute_path"
-              },
-              "updated_at": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "public_updated_at": {
-                "$ref": "#/definitions/public_updated_at"
-              },
-              "change_description": {
-                "type": "string"
-              },
-              "synonyms": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
         "max_cache_time": {
           "$ref": "#/definitions/max_cache_time"
         },

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -300,45 +300,6 @@
         "email_signup_link": {
           "$ref": "#/definitions/email_signup_link"
         },
-        "countries": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "name",
-              "base_path",
-              "updated_at",
-              "public_updated_at",
-              "change_description",
-              "synonyms"
-            ],
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "base_path": {
-                "$ref": "#/definitions/absolute_path"
-              },
-              "updated_at": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "public_updated_at": {
-                "$ref": "#/definitions/public_updated_at"
-              },
-              "change_description": {
-                "type": "string"
-              },
-              "synonyms": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
         "max_cache_time": {
           "$ref": "#/definitions/max_cache_time"
         },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -299,45 +299,6 @@
         "email_signup_link": {
           "$ref": "#/definitions/email_signup_link"
         },
-        "countries": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "name",
-              "base_path",
-              "updated_at",
-              "public_updated_at",
-              "change_description",
-              "synonyms"
-            ],
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "base_path": {
-                "$ref": "#/definitions/absolute_path"
-              },
-              "updated_at": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "public_updated_at": {
-                "$ref": "#/definitions/public_updated_at"
-              },
-              "change_description": {
-                "type": "string"
-              },
-              "synonyms": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
         "max_cache_time": {
           "$ref": "#/definitions/max_cache_time"
         },

--- a/formats/travel_advice_index/publisher/details.json
+++ b/formats/travel_advice_index/publisher/details.json
@@ -9,45 +9,6 @@
     "email_signup_link": {
       "$ref": "#/definitions/email_signup_link"
     },
-    "countries": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "base_path",
-          "updated_at",
-          "public_updated_at",
-          "change_description",
-          "synonyms"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "public_updated_at": {
-            "$ref": "#/definitions/public_updated_at"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "synonyms": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
     "max_cache_time": {
       "$ref": "#/definitions/max_cache_time"
     },


### PR DESCRIPTION
This is no longer being sent by travel-advice-publisher or expected by frontend.