### PR TITLE
Add `homepage` and `search` document types 

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/answer/publisher/schema.json
+++ b/dist/formats/answer/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -162,6 +162,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -197,6 +198,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -256,6 +258,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -287,15 +290,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/case_study/publisher/schema.json
+++ b/dist/formats/case_study/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/coming_soon/publisher/schema.json
+++ b/dist/formats/coming_soon/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/completed_transaction/publisher/schema.json
+++ b/dist/formats/completed_transaction/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -162,6 +162,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -197,6 +198,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -256,6 +258,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -287,15 +290,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/consultation/publisher/schema.json
+++ b/dist/formats/consultation/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/contact/publisher/schema.json
+++ b/dist/formats/contact/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -119,6 +119,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -154,6 +155,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -213,6 +215,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -244,15 +247,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/corporate_information_page/publisher/schema.json
+++ b/dist/formats/corporate_information_page/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -162,6 +162,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -197,6 +198,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -256,6 +258,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -287,15 +290,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/detailed_guide/publisher/schema.json
+++ b/dist/formats/detailed_guide/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -162,6 +162,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -197,6 +198,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -256,6 +258,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -287,15 +290,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/document_collection/publisher/schema.json
+++ b/dist/formats/document_collection/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/email_alert_signup/publisher/schema.json
+++ b/dist/formats/email_alert_signup/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -159,6 +159,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -194,6 +195,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -253,6 +255,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -284,15 +287,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/fatality_notice/publisher/schema.json
+++ b/dist/formats/fatality_notice/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -159,6 +159,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -194,6 +195,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -253,6 +255,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -284,15 +287,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/finder/publisher/schema.json
+++ b/dist/formats/finder/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/finder_email_signup/publisher/schema.json
+++ b/dist/formats/finder_email_signup/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/generic/publisher/schema.json
+++ b/dist/formats/generic/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/generic_with_external_related_links/publisher/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/guide/publisher/schema.json
+++ b/dist/formats/guide/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/help_page/publisher/schema.json
+++ b/dist/formats/help_page/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/hmrc_manual/publisher/schema.json
+++ b/dist/formats/hmrc_manual/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/hmrc_manual_section/publisher/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/html_publication/publisher/schema.json
+++ b/dist/formats/html_publication/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/licence/publisher/schema.json
+++ b/dist/formats/licence/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/local_transaction/publisher/schema.json
+++ b/dist/formats/local_transaction/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -165,6 +165,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -200,6 +201,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -259,6 +261,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -290,15 +293,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/mainstream_browse_page/publisher/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/manual/publisher/schema.json
+++ b/dist/formats/manual/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/manual_section/publisher/schema.json
+++ b/dist/formats/manual_section/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/need/publisher/schema.json
+++ b/dist/formats/need/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -165,6 +165,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -200,6 +201,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -259,6 +261,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -290,15 +293,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/news_article/publisher/schema.json
+++ b/dist/formats/news_article/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/place/publisher/schema.json
+++ b/dist/formats/place/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/placeholder/publisher/schema.json
+++ b/dist/formats/placeholder/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -168,6 +168,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -203,6 +204,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -262,6 +264,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -293,15 +296,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/policy/publisher/schema.json
+++ b/dist/formats/policy/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -168,6 +168,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -203,6 +204,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -262,6 +264,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -293,15 +296,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/publication/publisher/schema.json
+++ b/dist/formats/publication/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -159,6 +159,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -194,6 +195,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -253,6 +255,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -284,15 +287,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_guide/publisher/schema.json
+++ b/dist/formats/service_manual_guide/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_homepage/publisher/schema.json
+++ b/dist/formats/service_manual_homepage/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_service_standard/publisher/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_service_toolkit/publisher/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -162,6 +162,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -197,6 +198,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -256,6 +258,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -287,15 +290,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_topic/publisher/schema.json
+++ b/dist/formats/service_manual_topic/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/simple_smart_answer/publisher/schema.json
+++ b/dist/formats/simple_smart_answer/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -168,6 +168,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -203,6 +204,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -262,6 +264,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -293,15 +296,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/speech/publisher/schema.json
+++ b/dist/formats/speech/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/statistical_data_set/publisher/schema.json
+++ b/dist/formats/statistical_data_set/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/statistics_announcement/publisher/schema.json
+++ b/dist/formats/statistics_announcement/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/take_part/publisher/schema.json
+++ b/dist/formats/take_part/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/taxon/publisher/schema.json
+++ b/dist/formats/taxon/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/topic/publisher/schema.json
+++ b/dist/formats/topic/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/topical_event_about_page/publisher/schema.json
+++ b/dist/formats/topical_event_about_page/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/travel_advice/publisher/schema.json
+++ b/dist/formats/travel_advice/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -156,6 +156,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -191,6 +192,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -250,6 +252,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -281,15 +284,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/travel_advice_index/publisher/schema.json
+++ b/dist/formats/travel_advice_index/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/unpublishing/publisher/schema.json
+++ b/dist/formats/unpublishing/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -153,6 +153,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -188,6 +189,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -247,6 +249,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -278,15 +281,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/working_group/publisher/schema.json
+++ b/dist/formats/working_group/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -162,6 +162,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -197,6 +198,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -256,6 +258,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -287,15 +290,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -112,6 +112,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -147,6 +148,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -206,6 +208,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -237,15 +240,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/world_location_news_article/publisher/schema.json
+++ b/dist/formats/world_location_news_article/publisher/schema.json
@@ -146,6 +146,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -181,6 +182,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -240,6 +242,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -271,15 +274,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -145,6 +145,7 @@
         "coming_soon",
         "complaints_procedure",
         "completed_transaction",
+        "consultation",
         "consultation_outcome",
         "contact",
         "corporate_report",
@@ -180,6 +181,7 @@
         "help_page",
         "hmrc_manual",
         "hmrc_manual_section",
+        "homepage",
         "html_publication",
         "impact_assessment",
         "independent_report",
@@ -239,6 +241,7 @@
         "redirect",
         "regulation",
         "research",
+        "search",
         "service_manual_guide",
         "service_manual_homepage",
         "service_manual_service_standard",
@@ -270,15 +273,14 @@
         "travel_advice_index",
         "unpublishing",
         "utaac_decision",
+        "vehicle_recalls_and_faults_alert",
         "video",
         "welsh_language_scheme",
         "working_group",
         "world_location",
         "world_location_news_article",
         "worldwide_organisation",
-        "written_statement",
-        "consultation",
-        "vehicle_recalls_and_faults_alert"
+        "written_statement"
       ]
     },
     "schema_name": {

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -1,5 +1,3 @@
-# Produced by running `y ContentItem.distinct(:document_type)` in the content
-# store Rails console.
 - aaib_report
 - about
 - about_our_services
@@ -20,6 +18,7 @@
 - coming_soon
 - complaints_procedure
 - completed_transaction
+- consultation
 - consultation_outcome
 - contact
 - corporate_report
@@ -145,6 +144,7 @@
 - travel_advice_index
 - unpublishing
 - utaac_decision
+- vehicle_recalls_and_faults_alert
 - video
 - welsh_language_scheme
 - working_group
@@ -152,9 +152,3 @@
 - world_location_news_article
 - worldwide_organisation
 - written_statement
-
-# Not from content-store, but possible:
-- consultation
-
-# Not released yet.
-- vehicle_recalls_and_faults_alert

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -54,6 +54,7 @@
 - help_page
 - hmrc_manual
 - hmrc_manual_section
+- homepage
 - html_publication
 - impact_assessment
 - independent_report
@@ -113,6 +114,7 @@
 - redirect
 - regulation
 - research
+- search
 - service_manual_guide
 - service_manual_homepage
 - service_manual_service_standard


### PR DESCRIPTION
- Merge lists of allowed document types. Remove the comments about how the allowed document types were generated because govuk-content-schemas is now the source of truth about document types rather than the content store.
- Add new document types to represent the GOV.UK homepage and search page. These used to be `special_route`, but giving them a more specific type will allow us to specify their document supertype in govuk_document_types to improve analytics.
- Regenerate schemas

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing