### PR TITLE
Add links for email to migrated formats

### DIFF
--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -93,6 +93,14 @@
         "topical_events": {
           "$ref": "#/definitions/frontend_links"
         },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -23,6 +23,14 @@
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
+        "roles": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
+        "people": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -87,6 +87,14 @@
         "ministers": {
           "$ref": "#/definitions/frontend_links"
         },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -18,6 +18,14 @@
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },
+        "roles": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
+        "people": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -96,6 +96,14 @@
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -26,6 +26,14 @@
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },
+        "roles": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
+        "people": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -95,6 +95,14 @@
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -25,6 +25,14 @@
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },
+        "roles": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
+        "people": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -101,6 +101,14 @@
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -31,6 +31,14 @@
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },
+        "roles": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
+        "people": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/formats/consultation/publisher/links.json
+++ b/formats/consultation/publisher/links.json
@@ -15,6 +15,14 @@
     },
     "topical_events": {
       "$ref": "#/definitions/guid_list"
+    },
+    "roles": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+    },
+    "people": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
     }
   }
 }

--- a/formats/fatality_notice/publisher/links.json
+++ b/formats/fatality_notice/publisher/links.json
@@ -10,6 +10,14 @@
     },
     "ministers": {
       "$ref": "#/definitions/guid_list"
+    },
+    "roles": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+    },
+    "people": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
     }
   }
 }

--- a/formats/news_article/publisher/links.json
+++ b/formats/news_article/publisher/links.json
@@ -18,6 +18,14 @@
     },
     "world_locations": {
       "$ref": "#/definitions/guid_list"
+    },
+    "roles": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+    },
+    "people": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
     }
   }
 }

--- a/formats/publication/publisher/links.json
+++ b/formats/publication/publisher/links.json
@@ -17,6 +17,14 @@
     },
     "world_locations": {
       "$ref": "#/definitions/guid_list"
+    },
+    "roles": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+    },
+    "people": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
     }
   }
 }

--- a/formats/speech/publisher/links.json
+++ b/formats/speech/publisher/links.json
@@ -23,6 +23,14 @@
     },
     "world_locations": {
       "$ref": "#/definitions/guid_list"
+    },
+    "roles": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+    },
+    "people": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
     }
   }
 }


### PR DESCRIPTION
Adds `people` and `roles` to `links.json` for the following formats:

* Consultation
* Fatality Notice
* News Article
* Publication
* Speech

In order to send emails, Email Alert Api relies on the presence of links in data that the Publishing Api sends to the rabbit queues. Whitehall in turn needs to present these links to the Publishing Api. Roles and People are currently required but missing. This will allow Email Alert Api to take over from Govuk Delivery and ultimately allow us to retire Govuk Delivery.

There will be a corresponding PR in Whitehall to present these links to the Publishing Api (currently a work in progress on this branch https://github.com/alphagov/whitehall/tree/add-links-for-email-to-migrated-formats).

[Trello](https://trello.com/c/WizHAZBT)