### PR TITLE
Remove contacts-frontend from downstream builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ def dependentApplications = [
   'collections',
   'collections-publisher',
   'contacts',
-  'contacts-frontend',
   'content-tagger',
   'email-alert-frontend',
   'email-alert-service',


### PR DESCRIPTION
This app is no longer used.

cc @fofr 