### PR TITLE
Lock down rendering_app & publishing_app

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -546,10 +546,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -539,10 +539,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -423,10 +423,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -586,10 +586,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -570,10 +570,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -184,10 +184,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -457,10 +457,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -550,10 +550,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -543,10 +543,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -427,10 +427,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -563,10 +563,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -556,10 +556,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -440,10 +440,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -630,10 +630,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -614,10 +614,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -188,10 +188,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -501,10 +501,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -743,10 +743,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -733,10 +733,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -178,10 +178,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -34,10 +34,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -614,10 +614,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -561,10 +561,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -551,10 +551,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -178,10 +178,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -435,10 +435,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -595,10 +595,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -579,10 +579,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -184,10 +184,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -466,10 +466,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -601,10 +601,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -585,10 +585,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -185,10 +185,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -490,10 +490,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -586,10 +586,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -579,10 +579,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -463,10 +463,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -561,10 +561,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -548,10 +548,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -183,10 +183,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -435,10 +435,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -593,10 +593,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -580,10 +580,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -184,10 +184,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -464,10 +464,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -629,10 +629,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -619,10 +619,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -178,10 +178,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -503,10 +503,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -540,10 +540,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -533,10 +533,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -417,10 +417,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -543,10 +543,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -536,10 +536,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -420,10 +420,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -547,10 +547,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -540,10 +540,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -424,10 +424,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -546,10 +546,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -539,10 +539,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -423,10 +423,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -558,10 +558,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -551,10 +551,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -435,10 +435,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -562,10 +562,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -555,10 +555,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -439,10 +439,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -567,10 +567,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -560,10 +560,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -444,10 +444,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -565,10 +565,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -558,10 +558,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -442,10 +442,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -578,10 +578,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -571,10 +571,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -455,10 +455,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -568,10 +568,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -549,10 +549,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -191,10 +191,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -433,10 +433,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -558,10 +558,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -548,10 +548,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -181,10 +181,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -432,10 +432,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -560,10 +560,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -550,10 +550,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -181,10 +181,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -434,10 +434,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -607,10 +607,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -600,10 +600,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -484,10 +484,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -579,10 +579,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -560,10 +560,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -191,10 +191,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -447,10 +447,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -555,10 +555,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -548,10 +548,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -432,10 +432,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -601,10 +601,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -594,10 +594,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -478,10 +478,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -627,10 +627,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -605,10 +605,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -194,10 +194,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -489,10 +489,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -586,10 +586,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -564,10 +564,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -190,10 +190,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -475,10 +475,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -580,10 +580,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -567,10 +567,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -183,10 +183,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -454,10 +454,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -539,10 +539,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -532,10 +532,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -416,10 +416,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -551,10 +551,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -541,10 +541,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -179,10 +179,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -425,10 +425,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -589,10 +589,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -582,10 +582,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -466,10 +466,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -559,10 +559,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -543,10 +543,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -187,10 +187,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -427,10 +427,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -608,10 +608,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -601,10 +601,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -485,10 +485,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -564,10 +564,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -557,10 +557,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -448,10 +448,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -597,10 +597,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -575,10 +575,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -196,10 +196,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -462,10 +462,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -564,10 +564,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -557,10 +557,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -444,10 +444,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -576,10 +576,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -569,10 +569,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -453,10 +453,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -550,10 +550,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -543,10 +543,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -427,10 +427,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -550,10 +550,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -540,10 +540,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -179,10 +179,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -424,10 +424,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -549,10 +549,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -539,10 +539,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -179,10 +179,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -423,10 +423,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -550,10 +550,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -543,10 +543,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -427,10 +427,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -571,10 +571,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -564,10 +564,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -448,10 +448,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -594,10 +594,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -584,10 +584,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -178,10 +178,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -468,10 +468,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -555,10 +555,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -545,10 +545,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -178,10 +178,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -429,10 +429,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -563,10 +563,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -556,10 +556,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -440,10 +440,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -546,10 +546,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -539,10 +539,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -175,10 +175,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -423,10 +423,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -36,10 +36,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -573,10 +573,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -557,10 +557,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -184,10 +184,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -37,10 +37,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -444,10 +444,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/formats/contact/publisher_v2/metadata.json
+++ b/formats/contact/publisher_v2/metadata.json
@@ -32,10 +32,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -127,10 +127,82 @@
         "$ref": "#/definitions/guid"
       }
     },
-    "application_name": {
-      "description": "Applications on GOV.UK only use lowercase letters and dashes",
+    "publishing_app_name": {
+      "description": "The application that published this item.",
       "type": "string",
-      "pattern": "[a-z-]"
+      "enum": [
+        "businesssupportfinder",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "govuk_content_api",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "businesssupportfinder",
+            "calculators",
+            "calendars",
+            "collections",
+            "contacts-frontend",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "specialist-frontend",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "type": "null",
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
+        }
+      ]
     },
     "image": {
       "type": "object",

--- a/formats/metadata.json
+++ b/formats/metadata.json
@@ -34,10 +34,10 @@
       "$ref": "#/definitions/first_published_at"
     },
     "publishing_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/publishing_app_name"
     },
     "rendering_app": {
-      "$ref": "#/definitions/application_name"
+      "$ref": "#/definitions/rendering_app_name"
     },
     "locale": {
       "$ref": "#/definitions/locale"

--- a/formats/travel_advice/frontend/examples/alt-country.json
+++ b/formats/travel_advice/frontend/examples/alt-country.json
@@ -12,7 +12,7 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:33:43.000+00:00",
   "publishing_app": "travel-advice-publisher",
-  "rendering_app": "multipage-frontend",
+  "rendering_app": "government-frontend",
   "schema_name": "travel_advice",
   "title": "Turkey travel advice",
   "updated_at": "2017-02-17T12:52:44.142Z",

--- a/formats/travel_advice/frontend/examples/full-country.json
+++ b/formats/travel_advice/frontend/examples/full-country.json
@@ -12,7 +12,7 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:42:21.000+00:00",
   "publishing_app": "travel-advice-publisher",
-  "rendering_app": "multipage-frontend",
+  "rendering_app": "government-frontend",
   "schema_name": "travel_advice",
   "title": "Albania travel advice",
   "updated_at": "2017-02-17T12:52:43.537Z",


### PR DESCRIPTION
We currently allow any well-formatted value in the `rendering_app` and `publishing_app`. This leave us open to typos. This restricts the fields to only allow apps that we know exist in the system.

The lists were generated by running the following on production content store:

```
ContentItem.distinct(:publishing_app)
ContentItem.distinct(:rendering_app)
```

It surfaces some odd stuff in the database (like `email-campaign-frontend`) but we don't want to make current items invalid, so we'll allow them too. Hopefully they'll get cleaned up at some point.

## Dependencies

- [x] https://github.com/alphagov/publishing-api/pull/843