### PR TITLE
Add edition links to html publications

### DIFF
--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -315,6 +315,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "$ref": "#/definitions/guid_list"
         }

--- a/formats/html_publication/publisher/edition_links.json
+++ b/formats/html_publication/publisher/edition_links.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "organisations": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "parent": {
+      "$ref": "#/definitions/guid_list"
+    }
+  }
+}


### PR DESCRIPTION
https://trello.com/c/RWL7ppZ6/637-use-draft-links-for-publications

Edition links for Html Publications are needed to complete the parent/children
link resolution which effectively ties a draft publication to an html attachment.

We need to present the parent of the html publication so that the links on the parent publication are resolved.