### PR TITLE
Edition links in frontend/notification schemas

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -90,51 +90,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -84,6 +84,7 @@
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "ministers": {
@@ -93,48 +94,63 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -84,51 +84,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -84,51 +84,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -90,51 +90,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -90,18 +90,23 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
@@ -117,24 +122,31 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -81,57 +81,74 @@
       "additionalProperties": false,
       "properties": {
         "field_of_operation": {
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "ministers": {
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -87,51 +87,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -84,51 +84,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -81,21 +81,27 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
@@ -108,24 +114,31 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -81,63 +81,83 @@
       "additionalProperties": false,
       "properties": {
         "top_level_browse_pages": {
+          "description": "All top-level browse pages",
           "$ref": "#/definitions/frontend_links"
         },
         "active_top_level_browse_page": {
+          "description": "The top-level browse page which is active",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page",
           "$ref": "#/definitions/frontend_links"
         },
         "related_topics": {
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -81,54 +81,70 @@
       "additionalProperties": false,
       "properties": {
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "sections": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -81,54 +81,70 @@
       "additionalProperties": false,
       "properties": {
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "manual": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -84,6 +84,7 @@
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "ministers": {
@@ -96,48 +97,63 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -81,51 +81,71 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
+        "featured_policies": {
+          "description": "Featured policies primarily for use with Whitehall organisations",
+          "$ref": "#/definitions/frontend_links"
+        },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -87,6 +87,7 @@
           "$ref": "#/definitions/frontend_links"
         },
         "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/frontend_links"
         },
         "related": {
@@ -96,51 +97,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -96,18 +96,23 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
@@ -123,24 +128,31 @@
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -81,57 +81,75 @@
       "additionalProperties": false,
       "properties": {
         "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/frontend_links"
         },
         "service_manual_topics": {
+          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -81,54 +81,71 @@
       "additionalProperties": false,
       "properties": {
         "email_alert_signup": {
+          "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -81,60 +81,79 @@
       "additionalProperties": false,
       "properties": {
         "linked_items": {
+          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/frontend_links"
         },
         "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/frontend_links"
         },
         "email_alert_signup": {
+          "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -81,51 +81,72 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
+        "finder": {
+          "description": "The finder for this specialist document.",
+          "maxItems": 1,
+          "$ref": "#/definitions/frontend_links"
+        },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -317,12 +317,16 @@
         "finder": {
           "description": "The finder for this specialist document.",
           "$ref": "#/definitions/guid_list",
+          "minItems": 1,
           "maxItems": 1
         },
         "policy_areas": {
           "$ref": "#/definitions/guid_list"
         }
-      }
+      },
+      "required": [
+        "finder"
+      ]
     },
     "absolute_path": {
       "type": "string",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -81,12 +81,15 @@
       "additionalProperties": false,
       "properties": {
         "speaker": {
+          "description": "A speaker that has a GOV.UK profile",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "ministers": {
@@ -99,48 +102,63 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -81,54 +81,71 @@
       "additionalProperties": false,
       "properties": {
         "parent_taxons": {
+          "description": "The list of taxon parents.",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -81,54 +81,71 @@
       "additionalProperties": false,
       "properties": {
         "linked_items": {
+          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -84,51 +84,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -84,51 +84,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -81,51 +81,67 @@
       "additionalProperties": false,
       "properties": {
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -90,51 +90,67 @@
           "$ref": "#/definitions/frontend_links"
         },
         "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links"
         },
         "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links"
         },
         "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links"
         },
         "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
         "policy_areas": {
           "$ref": "#/definitions/frontend_links"
         },
         "available_translations": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "policies": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "document_collections": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "topic_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
         "mainstream_browse_content": {
+          "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         }
       }

--- a/formats/specialist_document/frontend/examples/aaib-reports.json
+++ b/formats/specialist_document/frontend/examples/aaib-reports.json
@@ -85,6 +85,138 @@
         "api_path": "/api/content/government/organisations/air-accidents-investigation-branch"
       }
     ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/aaib-reports",
+        "base_path": "/aaib-reports",
+        "content_id": "b7574bba-969f-4c49-855a-ae1586258ff6",
+        "description": "Find reports of AAIB investigations into air accidents and incidents",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Air Accidents Investigation Branch reports",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "report",
+          "filter": {
+            "document_type": "aaib_report"
+          },
+          "format_name": "Air Accidents Investigation Branch report",
+          "show_summaries": true,
+          "facets": [
+            {
+              "key": "aircraft_category",
+              "name": "Aircraft category",
+              "type": "text",
+              "preposition": "in aircraft category",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Commercial - fixed wing",
+                  "value": "commercial-fixed-wing"
+                },
+                {
+                  "label": "Commercial - rotorcraft",
+                  "value": "commercial-rotorcraft"
+                },
+                {
+                  "label": "General aviation - fixed wing",
+                  "value": "general-aviation-fixed-wing"
+                },
+                {
+                  "label": "General aviation - rotorcraft",
+                  "value": "general-aviation-rotorcraft"
+                },
+                {
+                  "label": "Sport aviation and balloons",
+                  "value": "sport-aviation-and-balloons"
+                }
+              ]
+            },
+            {
+              "key": "report_type",
+              "name": "Report type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Annual safety report",
+                  "value": "annual-safety-report"
+                },
+                {
+                  "label": "Bulletin - Correspondence investigation",
+                  "value": "correspondence-investigation"
+                },
+                {
+                  "label": "Bulletin - Field investigation",
+                  "value": "field-investigation"
+                },
+                {
+                  "label": "Bulletin - Pre-1997 uncategorised monthly report",
+                  "value": "pre-1997-monthly-report"
+                },
+                {
+                  "label": "Foreign report",
+                  "value": "foreign-report"
+                },
+                {
+                  "label": "Formal report",
+                  "value": "formal-report"
+                },
+                {
+                  "label": "Special bulletin",
+                  "value": "special-bulletin"
+                },
+                {
+                  "label": "Safety study",
+                  "value": "safety-study"
+                }
+              ]
+            },
+            {
+              "key": "date_of_occurrence",
+              "name": "Date of occurrence",
+              "short_name": "Occurred",
+              "type": "date",
+              "preposition": "occurred",
+              "display_as_result_metadata": true,
+              "filterable": true
+            },
+            {
+              "key": "aircraft_type",
+              "name": "Aircraft type",
+              "type": "text",
+              "display_as_result_metadata": false,
+              "filterable": false
+            },
+            {
+              "key": "location",
+              "name": "Location",
+              "type": "text",
+              "display_as_result_metadata": false,
+              "filterable": false
+            },
+            {
+              "key": "registration",
+              "name": "Registration",
+              "type": "text",
+              "display_as_result_metadata": false,
+              "filterable": false
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/aaib-reports",
+        "web_url": "https://www.gov.uk/aaib-reports"
+      }
+    ],
     "available_translations": [
       {
         "analytics_identifier": null,

--- a/formats/specialist_document/frontend/examples/asylum-support-decision.json
+++ b/formats/specialist_document/frontend/examples/asylum-support-decision.json
@@ -59,6 +59,312 @@
     ]
   },
   "links": {
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/asylum-support-tribunal-decisions",
+        "base_path": "/asylum-support-tribunal-decisions",
+        "content_id": "581b4bba-e58f-4d07-8e0a-03c8c00165cc",
+        "description": "Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Asylum support tribunal decisions",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "decision",
+          "filter": {
+            "document_type": "asylum_support_decision"
+          },
+          "format_name": "Asylum support tribunal decision",
+          "show_summaries": true,
+          "summary": "<p>Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).</p>",
+          "facets": [
+            {
+              "key": "tribunal_decision_categories",
+              "name": "Category",
+              "type": "text",
+              "preposition": "categorised as",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Section 4(1) (support for persons who are neither an asylum seeker nor a failed asylum seeker)",
+                  "value": "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker"
+                },
+                {
+                  "label": "Section 4(2) (support for failed asylum seekers)",
+                  "value": "section-4-2-support-for-failed-asylum-seekers"
+                },
+                {
+                  "label": "Section 95 (support for asylum seekers)",
+                  "value": "section-95-support-for-asylum-seekers"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_category_name",
+              "name": "Category name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_sub_categories",
+              "name": "Sub-category",
+              "type": "text",
+              "preposition": "sub-categorised as",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Section 4(1) - bail",
+                  "value": "section-4-1-bail"
+                },
+                {
+                  "label": "Section 4(1) - other",
+                  "value": "section-4-1-other"
+                },
+                {
+                  "label": "Section 4(1) - temporary admission / release",
+                  "value": "section-4-1-temporary-admission-release"
+                },
+                {
+                  "label": "Section 4(2) - breach",
+                  "value": "section-4-2-breach"
+                },
+                {
+                  "label": "Section 4(2) - dependants",
+                  "value": "section-4-2-dependants"
+                },
+                {
+                  "label": "Section 4(2) - destitution",
+                  "value": "section-4-2-destitution"
+                },
+                {
+                  "label": "Section 4(2) - jurisdiction",
+                  "value": "section-4-2-jurisdiction"
+                },
+                {
+                  "label": "Section 4(2) - other",
+                  "value": "section-4-2-other"
+                },
+                {
+                  "label": "Section 4(2) - regulation 3(2)(a) - steps to leave",
+                  "value": "section-4-2-regulation-3-2-a-steps-to-leave"
+                },
+                {
+                  "label": "Section 4(2) - regulation 3(2)(b) - medical",
+                  "value": "section-4-2-regulation-3-2-b-medical"
+                },
+                {
+                  "label": "Section 4(2) - regulation 3(2)(c) - no route of return",
+                  "value": "section-4-2-regulation-3-2-c-no-route-of-return"
+                },
+                {
+                  "label": "Section 4(2) - regulation 3(2)(d) - judicial review",
+                  "value": "section-4-2-regulation-3-2-d-judicial-review"
+                },
+                {
+                  "label": "Section 4(2) - regulation 3(2)(e) - human rights / fresh reps",
+                  "value": "section-4-2-regulation-3-2-e-human-rights-fresh-reps"
+                },
+                {
+                  "label": "Section 95 - breach",
+                  "value": "section-95-breach"
+                },
+                {
+                  "label": "Section 95 - children",
+                  "value": "section-95-children"
+                },
+                {
+                  "label": "Section 95 - dependants",
+                  "value": "section-95-dependants"
+                },
+                {
+                  "label": "Section 95 - destitution",
+                  "value": "section-95-destitution"
+                },
+                {
+                  "label": "Section 95 - jurisdiction",
+                  "value": "section-95-jurisdiction"
+                },
+                {
+                  "label": "Section 95 - other",
+                  "value": "section-95-other"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_sub_category_name",
+              "name": "Sub-category name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_judges",
+              "name": "Judges",
+              "type": "text",
+              "preposition": "by judge",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Bashir, S",
+                  "value": "bashir-s"
+                },
+                {
+                  "label": "Bayati, C",
+                  "value": "bayati-c"
+                },
+                {
+                  "label": "Briden, R",
+                  "value": "briden-r"
+                },
+                {
+                  "label": "Carter, G",
+                  "value": "carter-g"
+                },
+                {
+                  "label": "Cornes, J",
+                  "value": "cornes-j"
+                },
+                {
+                  "label": "Gandhi, P",
+                  "value": "gandhi-p"
+                },
+                {
+                  "label": "Grewal, S",
+                  "value": "grewal-s"
+                },
+                {
+                  "label": "Hussain, R",
+                  "value": "hussain-r"
+                },
+                {
+                  "label": "Khan, NU",
+                  "value": "khan-nu"
+                },
+                {
+                  "label": "Lal, S",
+                  "value": "lal-s"
+                },
+                {
+                  "label": "Lewis, I",
+                  "value": "lewis-i"
+                },
+                {
+                  "label": "Lock, A",
+                  "value": "lock-a"
+                },
+                {
+                  "label": "Owens, R",
+                  "value": "owens-r"
+                },
+                {
+                  "label": "Penrose, M",
+                  "value": "penrose-m"
+                },
+                {
+                  "label": "Phelan, M",
+                  "value": "phelan-m"
+                },
+                {
+                  "label": "Rayner, C",
+                  "value": "rayner-c"
+                },
+                {
+                  "label": "Ripley, F",
+                  "value": "ripley-f"
+                },
+                {
+                  "label": "Rizvi, F",
+                  "value": "rizvi-f"
+                },
+                {
+                  "label": "Saunders, D",
+                  "value": "saunders-d"
+                },
+                {
+                  "label": "Smith, SV",
+                  "value": "smith-sv"
+                },
+                {
+                  "label": "Storey, S",
+                  "value": "storey-s"
+                },
+                {
+                  "label": "Swaney, J",
+                  "value": "swaney-j"
+                },
+                {
+                  "label": "Tootell, A",
+                  "value": "tootell-a"
+                },
+                {
+                  "label": "Wyman, J",
+                  "value": "wyman-j"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_judges_name",
+              "name": "Judges name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_landmark",
+              "name": "Landmark",
+              "type": "text",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Landmark",
+                  "value": "landmark"
+                },
+                {
+                  "label": "Not landmark",
+                  "value": "not-landmark"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_landmark_name",
+              "name": "Landmark name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_reference_number",
+              "name": "Reference number",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_decision_date",
+              "name": "Decision date",
+              "short_name": "Decided",
+              "type": "date",
+              "preposition": "decided",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/asylum-support-tribunal-decisions",
+        "web_url": "https://www.gov.uk/asylum-support-tribunal-decisions"
+      }
+    ],
     "available_translations": [
       {
         "content_id": "3917cb0e-0928-45b7-bf63-20f9bc113a7a",

--- a/formats/specialist_document/frontend/examples/cma-cases.json
+++ b/formats/specialist_document/frontend/examples/cma-cases.json
@@ -103,6 +103,365 @@
         "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority"
       }
     ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/cma-cases",
+        "base_path": "/cma-cases",
+        "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+        "description": "Find reports and updates on current and historical CMA investigations",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Competition and Markets Authority cases",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "case",
+          "filter": {
+            "document_type": "cma_case"
+          },
+          "format_name": "Competition and Markets Authority case",
+          "show_summaries": false,
+          "facets": [
+            {
+              "key": "case_type",
+              "name": "Case type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "CA98 and civil cartels",
+                  "value": "ca98-and-civil-cartels"
+                },
+                {
+                  "label": "Competition disqualification",
+                  "value": "competition-disqualification"
+                },
+                {
+                  "label": "Criminal cartels",
+                  "value": "criminal-cartels"
+                },
+                {
+                  "label": "Markets",
+                  "value": "markets"
+                },
+                {
+                  "label": "Mergers",
+                  "value": "mergers"
+                },
+                {
+                  "label": "Consumer enforcement",
+                  "value": "consumer-enforcement"
+                },
+                {
+                  "label": "Regulatory references and appeals",
+                  "value": "regulatory-references-and-appeals"
+                },
+                {
+                  "label": "Reviews of orders and undertakings",
+                  "value": "review-of-orders-and-undertakings"
+                }
+              ]
+            },
+            {
+              "key": "case_state",
+              "name": "Case state",
+              "type": "text",
+              "preposition": "which are",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Open",
+                  "value": "open"
+                },
+                {
+                  "label": "Closed",
+                  "value": "closed"
+                }
+              ]
+            },
+            {
+              "key": "market_sector",
+              "name": "Market sector",
+              "type": "text",
+              "preposition": "about",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Aerospace",
+                  "value": "aerospace"
+                },
+                {
+                  "label": "Agriculture, environment and natural resources",
+                  "value": "agriculture-environment-and-natural-resources"
+                },
+                {
+                  "label": "Building and construction",
+                  "value": "building-and-construction"
+                },
+                {
+                  "label": "Chemicals",
+                  "value": "chemicals"
+                },
+                {
+                  "label": "Clothing, footwear and fashion",
+                  "value": "clothing-footwear-and-fashion"
+                },
+                {
+                  "label": "Communications",
+                  "value": "communications"
+                },
+                {
+                  "label": "Defence",
+                  "value": "defence"
+                },
+                {
+                  "label": "Distribution and service industries",
+                  "value": "distribution-and-service-industries"
+                },
+                {
+                  "label": "Electronics",
+                  "value": "electronics-industry"
+                },
+                {
+                  "label": "Energy",
+                  "value": "energy"
+                },
+                {
+                  "label": "Engineering",
+                  "value": "engineering"
+                },
+                {
+                  "label": "Financial services",
+                  "value": "financial-services"
+                },
+                {
+                  "label": "Fire, police and security",
+                  "value": "fire-police-and-security"
+                },
+                {
+                  "label": "Food manufacturing",
+                  "value": "food-manufacturing"
+                },
+                {
+                  "label": "Giftware, jewellery and tableware",
+                  "value": "giftware-jewellery-and-tableware"
+                },
+                {
+                  "label": "Healthcare and medical equipment",
+                  "value": "healthcare-and-medical-equipment"
+                },
+                {
+                  "label": "Household goods, furniture and furnishings",
+                  "value": "household-goods-furniture-and-furnishings"
+                },
+                {
+                  "label": "Mineral extraction, mining and quarrying",
+                  "value": "mineral-extraction-mining-and-quarrying"
+                },
+                {
+                  "label": "Motor industry",
+                  "value": "motor-industry"
+                },
+                {
+                  "label": "Oil and gas refining and petrochemicals",
+                  "value": "oil-and-gas-refining-and-petrochemicals"
+                },
+                {
+                  "label": "Paper printing and packaging",
+                  "value": "paper-printing-and-packaging"
+                },
+                {
+                  "label": "Pharmaceuticals",
+                  "value": "pharmaceuticals"
+                },
+                {
+                  "label": "Public markets",
+                  "value": "public-markets"
+                },
+                {
+                  "label": "Recreation and leisure",
+                  "value": "recreation-and-leisure"
+                },
+                {
+                  "label": "Retail and wholesale",
+                  "value": "retail-and-wholesale"
+                },
+                {
+                  "label": "Telecommunications",
+                  "value": "telecommunications"
+                },
+                {
+                  "label": "Textiles",
+                  "value": "textiles"
+                },
+                {
+                  "label": "Transport",
+                  "value": "transport"
+                },
+                {
+                  "label": "Utilities",
+                  "value": "utilities"
+                }
+              ]
+            },
+            {
+              "key": "outcome_type",
+              "name": "Outcome",
+              "type": "text",
+              "preposition": "with outcome",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "CA98 - no grounds for action",
+                  "value": "ca98-no-grounds-for-action-non-infringement"
+                },
+                {
+                  "label": "CA98 - infringement Chapter I",
+                  "value": "ca98-infringement-chapter-i"
+                },
+                {
+                  "label": "CA98 - infringement Chapter II",
+                  "value": "ca98-infringement-chapter-ii"
+                },
+                {
+                  "label": "CA98 - administrative priorities",
+                  "value": "ca98-administrative-priorities"
+                },
+                {
+                  "label": "CA98 - commitments",
+                  "value": "ca98-commitment"
+                },
+                {
+                  "label": "Competition disqualification - order granted",
+                  "value": "competition-disqualification-order-granted"
+                },
+                {
+                  "label": "Competition disqualification - undertaking given",
+                  "value": "competition-disqualification-undertaking-given"
+                },
+                {
+                  "label": "Competition disqualification - no order granted or undertaking given",
+                  "value": "competition-disqualification-no-order-granted-or-undertaking-given"
+                },
+                {
+                  "label": "Criminal cartels - verdict",
+                  "value": "criminal-cartels-verdict"
+                },
+                {
+                  "label": "Markets - phase 1 no enforcement action",
+                  "value": "markets-phase-1-no-enforcement-action"
+                },
+                {
+                  "label": "Markets - phase 1 undertakings in lieu of reference",
+                  "value": "markets-phase-1-undertakings-in-lieu-of-reference"
+                },
+                {
+                  "label": "Markets - phase 1 referral",
+                  "value": "markets-phase-1-referral"
+                },
+                {
+                  "label": "Mergers - phase 1 clearance",
+                  "value": "mergers-phase-1-clearance"
+                },
+                {
+                  "label": "Mergers - phase 1 clearance with undertakings in lieu",
+                  "value": "mergers-phase-1-clearance-with-undertakings-in-lieu"
+                },
+                {
+                  "label": "Mergers - phase 1 referral",
+                  "value": "mergers-phase-1-referral"
+                },
+                {
+                  "label": "Mergers - phase 1 found not to qualify",
+                  "value": "mergers-phase-1-found-not-to-qualify"
+                },
+                {
+                  "label": "Mergers - phase 1 public interest intervention",
+                  "value": "mergers-phase-1-public-interest-interventions"
+                },
+                {
+                  "label": "Markets - phase 2 clearance - no adverse effect on competition",
+                  "value": "markets-phase-2-clearance-no-adverse-effect-on-competition"
+                },
+                {
+                  "label": "Markets - phase 2 adverse effect on competition leading to remedies",
+                  "value": "markets-phase-2-adverse-effect-on-competition-leading-to-remedies"
+                },
+                {
+                  "label": "Markets - phase 2 decision to dispense with procedural obligations",
+                  "value": "markets-phase-2-decision-to-dispense-with-procedural-obligations"
+                },
+                {
+                  "label": "Mergers - phase 2 clearance",
+                  "value": "mergers-phase-2-clearance"
+                },
+                {
+                  "label": "Mergers - phase 2 clearance with remedies",
+                  "value": "mergers-phase-2-clearance-with-remedies"
+                },
+                {
+                  "label": "Mergers - phase 2 prohibition",
+                  "value": "mergers-phase-2-prohibition"
+                },
+                {
+                  "label": "Mergers - phase 2 cancellation",
+                  "value": "mergers-phase-2-cancellation"
+                },
+                {
+                  "label": "Consumer enforcement - no formal action",
+                  "value": "consumer-enforcement-no-action"
+                },
+                {
+                  "label": "Consumer enforcement - court order",
+                  "value": "consumer-enforcement-court-order"
+                },
+                {
+                  "label": "Consumer enforcement - undertakings",
+                  "value": "consumer-enforcement-undertakings"
+                },
+                {
+                  "label": "Consumer enforcement - changes to business practices agreed",
+                  "value": "consumer-enforcement-changes-to-business-practices-agreed"
+                },
+                {
+                  "label": "Regulatory references and appeals - final determination",
+                  "value": "regulatory-references-and-appeals-final-determination"
+                }
+              ]
+            },
+            {
+              "key": "opened_date",
+              "name": "Opened",
+              "short_name": "Opened",
+              "type": "date",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "closed_date",
+              "name": "Closed",
+              "short_name": "Closed",
+              "type": "date",
+              "preposition": "closed",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/cma-cases",
+        "web_url": "https://www.gov.uk/cma-cases"
+      }
+    ],
     "available_translations": [
       {
         "analytics_identifier": null,

--- a/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
+++ b/formats/specialist_document/frontend/examples/countryside-stewardship-grants.json
@@ -131,5 +131,196 @@
   "schema_name": "specialist_document",
   "document_type": "countryside_stewardship_grant",
   "links": {
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/countryside-stewardship-grants",
+        "base_path": "/countryside-stewardship-grants",
+        "content_id": "0eb7b150-879a-4c44-becc-718e23a77e2c",
+        "description": "Find information about Countryside Stewardship options, capital items and supplements",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Countryside Stewardship grants",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "grant",
+          "filter": {
+            "document_type": "countryside_stewardship_grant"
+          },
+          "format_name": "Countryside Stewardship grant",
+          "show_summaries": false,
+          "summary": "<p>Find options, supplements and capital items to include in your application for Countryside Stewardship. See <a href=\"government/collections/countryside-stewardship-information-for-agreement-holders\">information for agreement holders</a> for earlier versions.</p>",
+          "facets": [
+            {
+              "key": "grant_type",
+              "name": "Grant type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Option",
+                  "value": "option"
+                },
+                {
+                  "label": "Capital item",
+                  "value": "capital-item"
+                },
+                {
+                  "label": "Supplement",
+                  "value": "supplement"
+                }
+              ]
+            },
+            {
+              "key": "land_use",
+              "name": "Land use",
+              "type": "text",
+              "preposition": "for",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Arable land",
+                  "value": "arable-land"
+                },
+                {
+                  "label": "Boundaries",
+                  "value": "boundaries"
+                },
+                {
+                  "label": "Coast",
+                  "value": "coast"
+                },
+                {
+                  "label": "Educational access",
+                  "value": "educational-access"
+                },
+                {
+                  "label": "Flood risk",
+                  "value": "flood-risk"
+                },
+                {
+                  "label": "Grassland",
+                  "value": "grassland"
+                },
+                {
+                  "label": "Historic environment",
+                  "value": "historic-environment"
+                },
+                {
+                  "label": "Livestock management",
+                  "value": "livestock-management"
+                },
+                {
+                  "label": "Organic land",
+                  "value": "organic-land"
+                },
+                {
+                  "label": "Priority habitats",
+                  "value": "priority-habitats"
+                },
+                {
+                  "label": "Trees (non-woodland)",
+                  "value": "trees-non-woodland"
+                },
+                {
+                  "label": "Uplands",
+                  "value": "uplands"
+                },
+                {
+                  "label": "Vegetation control",
+                  "value": "vegetation-control"
+                },
+                {
+                  "label": "Water quality",
+                  "value": "water-quality"
+                },
+                {
+                  "label": "Wildlife package",
+                  "value": "wildlife-package"
+                },
+                {
+                  "label": "Woodland",
+                  "value": "woodland"
+                }
+              ]
+            },
+            {
+              "key": "tiers_or_standalone_items",
+              "name": "Tiers or standalone items",
+              "type": "text",
+              "preposition": "for",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Higher Tier",
+                  "value": "higher-tier"
+                },
+                {
+                  "label": "Mid Tier",
+                  "value": "mid-tier"
+                },
+                {
+                  "label": "Standalone capital items",
+                  "value": "standalone-capital-items"
+                }
+              ]
+            },
+            {
+              "key": "funding_amount",
+              "name": "Funding (per unit per year)",
+              "type": "text",
+              "preposition": "of",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Up to £100",
+                  "value": "up-to-100"
+                },
+                {
+                  "label": "£101 to £200",
+                  "value": "101-to-200"
+                },
+                {
+                  "label": "£201 to £300",
+                  "value": "201-to-300"
+                },
+                {
+                  "label": "£301 to £400",
+                  "value": "301-to-400"
+                },
+                {
+                  "label": "£401 to £500",
+                  "value": "401-to-500"
+                },
+                {
+                  "label": "More than £500",
+                  "value": "more-than-500"
+                },
+                {
+                  "label": "Up to 50% actual costs",
+                  "value": "up-to-50-actual-costs"
+                },
+                {
+                  "label": "More than 50% actual costs",
+                  "value": "more-than-50-actual-costs"
+                }
+              ]
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/countryside-stewardship-grants",
+        "web_url": "https://www.gov.uk/countryside-stewardship-grants"
+      }
+    ]
   }
 }

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -162,6 +162,169 @@
         "web_url": "https://www.gov.uk/government/organisations/medicines-and-healthcare-products-regulatory-agency"
       }
     ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/drug-device-alerts",
+        "base_path": "/drug-device-alerts",
+        "content_id": "1e9c0ada-5f7e-43cc-a55f-cc32757edaa3",
+        "description": "Find alerts and recalls issued by MHRA",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Alerts and recalls for drugs and medical devices",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "alert",
+          "filter": {
+            "document_type": "medical_safety_alert"
+          },
+          "format_name": "Medical safety alert",
+          "show_summaries": true,
+          "facets": [
+            {
+              "key": "alert_type",
+              "name": "Alert type",
+              "type": "text",
+              "preposition": "for",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Drug alert",
+                  "value": "drugs"
+                },
+                {
+                  "label": "Medical device alert",
+                  "value": "devices"
+                },
+                {
+                  "label": "Field safety notice",
+                  "value": "field-safety-notices"
+                },
+                {
+                  "label": "Drug alert: company-led",
+                  "value": "company-led-drugs"
+                }
+              ]
+            },
+            {
+              "key": "medical_specialism",
+              "name": "Medical specialism",
+              "type": "text",
+              "preposition": "about",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Anaesthetics",
+                  "value": "anaesthetics"
+                },
+                {
+                  "label": "Cardiology",
+                  "value": "cardiology"
+                },
+                {
+                  "label": "Care home staff",
+                  "value": "care-home-staff"
+                },
+                {
+                  "label": "Cosmetic surgery",
+                  "value": "cosmetic-surgery"
+                },
+                {
+                  "label": "Critical care",
+                  "value": "critical-care"
+                },
+                {
+                  "label": "Dentistry",
+                  "value": "dentistry"
+                },
+                {
+                  "label": "General practice",
+                  "value": "general-practice"
+                },
+                {
+                  "label": "General surgery",
+                  "value": "general-surgery"
+                },
+                {
+                  "label": "Haematology and oncology",
+                  "value": "haematology-oncology"
+                },
+                {
+                  "label": "Infection prevention",
+                  "value": "infection-prevention"
+                },
+                {
+                  "label": "Obstetrics and gynaecology",
+                  "value": "obstetrics-gynaecology"
+                },
+                {
+                  "label": "Ophthalmology",
+                  "value": "ophthalmology"
+                },
+                {
+                  "label": "Orthopaedics",
+                  "value": "orthopaedics"
+                },
+                {
+                  "label": "Paediatrics",
+                  "value": "paediatrics"
+                },
+                {
+                  "label": "Pathology",
+                  "value": "pathology"
+                },
+                {
+                  "label": "Pharmacy",
+                  "value": "pharmacy"
+                },
+                {
+                  "label": "Physiotherapy and occupational therapy",
+                  "value": "physiotherapy-occupational-therapy"
+                },
+                {
+                  "label": "Radiology",
+                  "value": "radiology"
+                },
+                {
+                  "label": "Renal medicine",
+                  "value": "renal-medicine"
+                },
+                {
+                  "label": "Theatre practitioners",
+                  "value": "theatre-practitioners"
+                },
+                {
+                  "label": "Urology",
+                  "value": "urology"
+                },
+                {
+                  "label": "Vascular and cardiac surgery",
+                  "value": "vascular-cardiac-surgery"
+                }
+              ]
+            },
+            {
+              "key": "issued_date",
+              "name": "Issued",
+              "short_name": "Issued",
+              "type": "date",
+              "preposition": "issued",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/drug-device-alerts",
+        "web_url": "https://www.gov.uk/drug-device-alerts"
+      }
+    ],
     "available_translations": [
       {
         "analytics_identifier": null,

--- a/formats/specialist_document/frontend/examples/drug-safety-update.json
+++ b/formats/specialist_document/frontend/examples/drug-safety-update.json
@@ -87,6 +87,147 @@
         "web_url": "https://www.gov.uk/government/organisations/medicines-and-healthcare-products-regulatory-agency"
       }
     ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/drug-safety-update",
+        "base_path": "/drug-safety-update",
+        "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
+        "description": "Find drug safety updates issued by MHRA",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Drug Safety Update",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "update",
+          "filter": {
+            "document_type": "drug_safety_update"
+          },
+          "format_name": "Drug Safety Update",
+          "show_summaries": true,
+          "facets": [
+            {
+              "key": "therapeutic_area",
+              "name": "Therapeutic area",
+              "type": "text",
+              "preposition": "about",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Anaesthesia and intensive care",
+                  "value": "anaesthesia-intensive-care"
+                },
+                {
+                  "label": "Cancer",
+                  "value": "cancer"
+                },
+                {
+                  "label": "Cardiovascular disease and lipidology",
+                  "value": "cardiovascular-disease-lipidology"
+                },
+                {
+                  "label": "Dentistry",
+                  "value": "dentistry"
+                },
+                {
+                  "label": "Dermatology",
+                  "value": "dermatology"
+                },
+                {
+                  "label": "Ear, nose and throat",
+                  "value": "ear-nose-throat"
+                },
+                {
+                  "label": "Endocrinology, diabetology and metabolism",
+                  "value": "endocrinology-diabetology-metabolism"
+                },
+                {
+                  "label": "GI, hepatology and pancreatic disorders",
+                  "value": "gi-hepatology-pancreatic-disorders"
+                },
+                {
+                  "label": "Haematology",
+                  "value": "haematology"
+                },
+                {
+                  "label": "Immunology and vaccination",
+                  "value": "immunology-vaccination"
+                },
+                {
+                  "label": "Immunosuppression and transplantation",
+                  "value": "immunosuppression-transplantation"
+                },
+                {
+                  "label": "Infectious disease",
+                  "value": "infectious-disease"
+                },
+                {
+                  "label": "Neurology",
+                  "value": "neurology"
+                },
+                {
+                  "label": "Nutrition and dietetics",
+                  "value": "nutrition-dietetics"
+                },
+                {
+                  "label": "Obstetrics, gynaecology and fertility",
+                  "value": "obstetrics-gynaecology-fertility"
+                },
+                {
+                  "label": "Ophthalmology",
+                  "value": "ophthalmology"
+                },
+                {
+                  "label": "Paediatrics and neonatology",
+                  "value": "paediatrics-neonatology"
+                },
+                {
+                  "label": "Pain management and palliation",
+                  "value": "pain-management-palliation"
+                },
+                {
+                  "label": "Psychiatry",
+                  "value": "psychiatry"
+                },
+                {
+                  "label": "Radiology and imaging",
+                  "value": "radiology-imaging"
+                },
+                {
+                  "label": "Respiratory disease and allergy",
+                  "value": "respiratory-disease-allergy"
+                },
+                {
+                  "label": "Rheumatology",
+                  "value": "rheumatology"
+                },
+                {
+                  "label": "Urology and nephrology",
+                  "value": "urology-nephrology"
+                }
+              ]
+            },
+            {
+              "key": "first_published_at",
+              "name": "Published",
+              "short_name": "Published",
+              "type": "date",
+              "preposition": "published",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/drug-safety-update",
+        "web_url": "https://www.gov.uk/drug-safety-update"
+      }
+    ],
     "available_translations": [
       {
         "analytics_identifier": null,

--- a/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-appeal-tribunal-decision.json
@@ -50,6 +50,1051 @@
     ]
   },
   "links": {
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/employment-appeal-tribunal-decisions",
+        "base_path": "/employment-appeal-tribunal-decisions",
+        "content_id": "975cf540-6e64-40e3-b62a-df655a8c99ef",
+        "description": "Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Employment appeal tribunal decisions",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "decision",
+          "filter": {
+            "document_type": "employment_appeal_tribunal_decision"
+          },
+          "format_name": "Employment appeal tribunal decision",
+          "show_summaries": true,
+          "summary": "<p>Find decisions on appeals against employment tribunals heard by the Employment Appeal Tribunal.</p><p>Includes decisions after December 2015. Find details of <a rel=\"external\" href=\"http://www.employmentappeals.gov.uk/Public/Search.aspx\">older cases.</a></p>",
+          "facets": [
+            {
+              "key": "tribunal_decision_categories",
+              "name": "Category",
+              "type": "text",
+              "preposition": "categorised as",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Age Discrimination",
+                  "value": "age-discrimination"
+                },
+                {
+                  "label": "Agency Workers",
+                  "value": "agency-workers"
+                },
+                {
+                  "label": "Blacklisting Regulations",
+                  "value": "blacklisting-regulations"
+                },
+                {
+                  "label": "Central Arbitration Committee (CAC)",
+                  "value": "central-arbitration-committee-cac"
+                },
+                {
+                  "label": "Certification Officer",
+                  "value": "certification-officer"
+                },
+                {
+                  "label": "Contract of Employment",
+                  "value": "contract-of-employment"
+                },
+                {
+                  "label": "Disability Discrimination",
+                  "value": "disability-discrimination"
+                },
+                {
+                  "label": "Employment Agencies Act 1973",
+                  "value": "employment-agencies-act-1973"
+                },
+                {
+                  "label": "Equal Pay Act",
+                  "value": "equal-pay-act"
+                },
+                {
+                  "label": "European Material",
+                  "value": "european-material"
+                },
+                {
+                  "label": "Fixed Term Regulations",
+                  "value": "fixed-term-regulations"
+                },
+                {
+                  "label": "Flexible Working",
+                  "value": "flexible-working"
+                },
+                {
+                  "label": "Harassment",
+                  "value": "harassment"
+                },
+                {
+                  "label": "Health & Safety",
+                  "value": "health-safety"
+                },
+                {
+                  "label": "Human Rights",
+                  "value": "human-rights"
+                },
+                {
+                  "label": "Jurisdictional Points",
+                  "value": "jurisdictional-points"
+                },
+                {
+                  "label": "Maternity Rights and Parental Leave",
+                  "value": "maternity-rights-and-parental-leave"
+                },
+                {
+                  "label": "National Minimum Wage",
+                  "value": "national-minimum-wage"
+                },
+                {
+                  "label": "National Security",
+                  "value": "national-security"
+                },
+                {
+                  "label": "Part Time Workers",
+                  "value": "part-time-workers"
+                },
+                {
+                  "label": "Practice and Procedure",
+                  "value": "practice-and-procedure"
+                },
+                {
+                  "label": "Procedural Issues",
+                  "value": "procedural-issues"
+                },
+                {
+                  "label": "Public Interest Disclosure",
+                  "value": "public-interest-disclosure"
+                },
+                {
+                  "label": "Race Discrimination",
+                  "value": "race-discrimination"
+                },
+                {
+                  "label": "Redundancy",
+                  "value": "redundancy"
+                },
+                {
+                  "label": "Religion or Belief Discrimination",
+                  "value": "religion-or-belief-discrimination"
+                },
+                {
+                  "label": "Reserved Forces Act",
+                  "value": "reserved-forces-act"
+                },
+                {
+                  "label": "Right To Be Accompanied",
+                  "value": "right-to-be-accompanied"
+                },
+                {
+                  "label": "Rights on Insolvency",
+                  "value": "rights-on-insolvency"
+                },
+                {
+                  "label": "Sex Discrimination",
+                  "value": "sex-discrimination"
+                },
+                {
+                  "label": "Sexual Orientation Discrimination/Transexualism",
+                  "value": "sexual-orientation-discrimination-transexualism"
+                },
+                {
+                  "label": "Statutory Discipline and Grievance Procedures",
+                  "value": "statutory-discipline-and-grievance-procedures"
+                },
+                {
+                  "label": "Time Limits",
+                  "value": "time-limits"
+                },
+                {
+                  "label": "Time Off",
+                  "value": "time-off"
+                },
+                {
+                  "label": "Trade Union Membership",
+                  "value": "trade-union-membership"
+                },
+                {
+                  "label": "Trade Union Rights",
+                  "value": "trade-union-rights"
+                },
+                {
+                  "label": "Transfer of Undertakings",
+                  "value": "transfer-of-undertakings"
+                },
+                {
+                  "label": "Unfair Dismissal",
+                  "value": "unfair-dismissal"
+                },
+                {
+                  "label": "Unlawful Deduction from Wages",
+                  "value": "unlawful-deduction-from-wages"
+                },
+                {
+                  "label": "Victimisation Discrimination",
+                  "value": "victimisation-discrimination"
+                },
+                {
+                  "label": "Working Time Regulations",
+                  "value": "working-time-regulations"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_categories_name",
+              "name": "Category name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_sub_categories",
+              "name": "Sub-category",
+              "type": "text",
+              "preposition": "sub-categorised as",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Contract of Employment - Apprenticeship",
+                  "value": "contract-of-employment-apprenticeship"
+                },
+                {
+                  "label": "Contract of Employment - Breach of Contract",
+                  "value": "contract-of-employment-breach-of-contract"
+                },
+                {
+                  "label": "Contract of Employment - Damages for breach of contract",
+                  "value": "contract-of-employment-damages-for-breach-of-contract"
+                },
+                {
+                  "label": "Contract of Employment - Definition of employee",
+                  "value": "contract-of-employment-definition-of-employee"
+                },
+                {
+                  "label": "Contract of Employment - Disciplinary and grievance procedure",
+                  "value": "contract-of-employment-disciplinary-and-grievance-procedure"
+                },
+                {
+                  "label": "Contract of Employment - Frustration",
+                  "value": "contract-of-employment-frustration"
+                },
+                {
+                  "label": "Contract of Employment - Implied Term/Variation/Construction of Term",
+                  "value": "contract-of-employment-implied-term-variation-construction-of-term"
+                },
+                {
+                  "label": "Contract of Employment - Incorporation into Contract",
+                  "value": "contract-of-employment-incorporation-into-contract"
+                },
+                {
+                  "label": "Contract of Employment - Itemised pay statement",
+                  "value": "contract-of-employment-itemised-pay-statement"
+                },
+                {
+                  "label": "Contract of Employment - Mitigation",
+                  "value": "contract-of-employment-mitigation"
+                },
+                {
+                  "label": "Contract of Employment - Mutual trust and confidence",
+                  "value": "contract-of-employment-mutual-trust-and-confidence"
+                },
+                {
+                  "label": "Contract of Employment - Notice and pay in lieu",
+                  "value": "contract-of-employment-notice-and-pay-in-lieu"
+                },
+                {
+                  "label": "Contract of Employment - Sick pay and holiday pay",
+                  "value": "contract-of-employment-sick-pay-and-holiday-pay"
+                },
+                {
+                  "label": "Contract of Employment - Whether established",
+                  "value": "contract-of-employment-whether-established"
+                },
+                {
+                  "label": "Contract of Employment - Written particulars",
+                  "value": "contract-of-employment-written-particulars"
+                },
+                {
+                  "label": "Contract of Employment - Wrongful dismissal",
+                  "value": "contract-of-employment-wrongful-dismissal"
+                },
+                {
+                  "label": "Equal Pay Act - Article 141/European law",
+                  "value": "equal-pay-act-article-141-european-law"
+                },
+                {
+                  "label": "Equal Pay Act - Case management",
+                  "value": "equal-pay-act-case-management"
+                },
+                {
+                  "label": "Equal Pay Act - Damages/Compensation",
+                  "value": "equal-pay-act-damages-compensation"
+                },
+                {
+                  "label": "Equal Pay Act - Equal value",
+                  "value": "equal-pay-act-equal-value"
+                },
+                {
+                  "label": "Equal Pay Act - European law",
+                  "value": "equal-pay-act-european-law"
+                },
+                {
+                  "label": "Equal Pay Act - Indirect discrimination",
+                  "value": "equal-pay-act-indirect-discrimination"
+                },
+                {
+                  "label": "Equal Pay Act - Like work",
+                  "value": "equal-pay-act-like-work"
+                },
+                {
+                  "label": "Equal Pay Act - Material factor defence and justification",
+                  "value": "equal-pay-act-material-factor-defence-and-justification"
+                },
+                {
+                  "label": "Equal Pay Act - Other establishments",
+                  "value": "equal-pay-act-other-establishments"
+                },
+                {
+                  "label": "Equal Pay Act - Out of time",
+                  "value": "equal-pay-act-out-of-time"
+                },
+                {
+                  "label": "Equal Pay Act - Part-time Pensions",
+                  "value": "equal-pay-act-part-time-pensions"
+                },
+                {
+                  "label": "Equal Pay Act - Work rated equivalent",
+                  "value": "equal-pay-act-work-rated-equivalent"
+                },
+                {
+                  "label": "Harassment - Compensation",
+                  "value": "harassment-compensation"
+                },
+                {
+                  "label": "Harassment - Conduct",
+                  "value": "harassment-conduct"
+                },
+                {
+                  "label": "Harassment - Purpose",
+                  "value": "harassment-purpose"
+                },
+                {
+                  "label": "Health & Safety - Detriment",
+                  "value": "health-safety-detriment"
+                },
+                {
+                  "label": "Jurisdictional Points - 2002 Act and pre-action requirements",
+                  "value": "jurisdictional-points-2002-act-and-pre-action-requirements"
+                },
+                {
+                  "label": "Jurisdictional Points - Agency relationships",
+                  "value": "jurisdictional-points-agency-relationships"
+                },
+                {
+                  "label": "Jurisdictional Points - Claim in time and effective date of termination",
+                  "value": "jurisdictional-points-claim-in-time-and-effective-date-of-termination"
+                },
+                {
+                  "label": "Jurisdictional Points - Continuity of employment",
+                  "value": "jurisdictional-points-continuity-of-employment"
+                },
+                {
+                  "label": "Jurisdictional Points - Excluded employments",
+                  "value": "jurisdictional-points-excluded-employments"
+                },
+                {
+                  "label": "Jurisdictional Points - Extension of time: just and equitable",
+                  "value": "jurisdictional-points-extension-of-time-just-and-equitable"
+                },
+                {
+                  "label": "Jurisdictional Points - Extension of time: reasonably practicable",
+                  "value": "jurisdictional-points-extension-of-time-reasonably-practicable"
+                },
+                {
+                  "label": "Jurisdictional Points - Fraud and illegality",
+                  "value": "jurisdictional-points-fraud-and-illegality"
+                },
+                {
+                  "label": "Jurisdictional Points - State immunity",
+                  "value": "jurisdictional-points-state-immunity"
+                },
+                {
+                  "label": "Jurisdictional Points - Worker employee or neither",
+                  "value": "jurisdictional-points-worker-employee-or-neither"
+                },
+                {
+                  "label": "Jurisdictional Points - Working outside the jurisdiction",
+                  "value": "jurisdictional-points-working-outside-the-jurisdiction"
+                },
+                {
+                  "label": "Maternity Rights and Parental Leave - Detriment",
+                  "value": "maternity-rights-and-parental-leave-detriment"
+                },
+                {
+                  "label": "Maternity Rights and Parental Leave - Pregnancy",
+                  "value": "maternity-rights-and-parental-leave-pregnancy"
+                },
+                {
+                  "label": "Maternity Rights and Parental Leave - Return to work",
+                  "value": "maternity-rights-and-parental-leave-return-to-work"
+                },
+                {
+                  "label": "Maternity Rights and Parental Leave - Sex discrimination",
+                  "value": "maternity-rights-and-parental-leave-sex-discrimination"
+                },
+                {
+                  "label": "Maternity Rights and Parental Leave - Unfair dismissal",
+                  "value": "maternity-rights-and-parental-leave-unfair-dismissal"
+                },
+                {
+                  "label": "Practice and Procedure - 2002 Act and pre-action requirements",
+                  "value": "practice-and-procedure-2002-act-and-pre-action-requirements"
+                },
+                {
+                  "label": "Practice and Procedure - Absence of Party",
+                  "value": "practice-and-procedure-absence-of-party"
+                },
+                {
+                  "label": "Practice and Procedure - Admissibility of evidence",
+                  "value": "practice-and-procedure-admissibility-of-evidence"
+                },
+                {
+                  "label": "Practice and Procedure - Amendment",
+                  "value": "practice-and-procedure-amendment"
+                },
+                {
+                  "label": "Practice and Procedure - Appearance/Response",
+                  "value": "practice-and-procedure-appearance-response"
+                },
+                {
+                  "label": "Practice and Procedure - Appellate jurisdiction/Reasons/Burns-Barke",
+                  "value": "practice-and-procedure-appellate-jurisdiction-reasons-burns-barke"
+                },
+                {
+                  "label": "Practice and Procedure - Application/Claim",
+                  "value": "practice-and-procedure-application-claim"
+                },
+                {
+                  "label": "Practice and Procedure - Absence of Party",
+                  "value": "practice-and-procedure-absence-of-party"
+                },
+                {
+                  "label": "Practice and Procedure - Admissibility of evidence",
+                  "value": "practice-and-procedure-admissibility-of-evidence"
+                },
+                {
+                  "label": "Practice and Procedure - Amendment",
+                  "value": "practice-and-procedure-amendment"
+                },
+                {
+                  "label": "Practice and Procedure - Appearance/Response",
+                  "value": "practice-and-procedure-appearance-response"
+                },
+                {
+                  "label": "Practice and Procedure - Appellate jurisdiction/Reasons/Burns-Barke",
+                  "value": "practice-and-procedure-appellate-jurisdiction-reasons-burns-barke"
+                },
+                {
+                  "label": "Practice and Procedure - Bias misconduct and procedural irregularity",
+                  "value": "practice-and-procedure-bias-misconduct-and-procedural-irregularity"
+                },
+                {
+                  "label": "Practice and Procedure - Case Management",
+                  "value": "practice-and-procedure-case-management"
+                },
+                {
+                  "label": "Practice and Procedure - Chairman alone",
+                  "value": "practice-and-procedure-chairman-alone"
+                },
+                {
+                  "label": "Practice and Procedure - Chairmans notes of evidence",
+                  "value": "practice-and-procedure-chairmans-notes-of-evidence"
+                },
+                {
+                  "label": "Practice and Procedure - Compromise",
+                  "value": "practice-and-procedure-compromise"
+                },
+                {
+                  "label": "Practice and Procedure - Contribution",
+                  "value": "practice-and-procedure-contribution"
+                },
+                {
+                  "label": "Practice and Procedure - Costs",
+                  "value": "practice-and-procedure-costs"
+                },
+                {
+                  "label": "Practice and Procedure - Delay in ET judgment",
+                  "value": "practice-and-procedure-delay-in-et-judgment"
+                },
+                {
+                  "label": "Practice and Procedure - Disclosure",
+                  "value": "practice-and-procedure-disclosure"
+                },
+                {
+                  "label": "Practice and Procedure - Disposal of appeal including remission",
+                  "value": "practice-and-procedure-disposal-of-appeal-including-remission"
+                },
+                {
+                  "label": "Practice and Procedure - Estoppel or Abuse of Process",
+                  "value": "practice-and-procedure-estoppel-or-abuse-of-process"
+                },
+                {
+                  "label": "Practice and Procedure - Imposition of Deposit",
+                  "value": "practice-and-procedure-imposition-of-deposit"
+                },
+                {
+                  "label": "Practice and Procedure - Insolvency",
+                  "value": "practice-and-procedure-insolvency"
+                },
+                {
+                  "label": "Practice and Procedure - New evidence on appeal",
+                  "value": "practice-and-procedure-new-evidence-on-appeal"
+                },
+                {
+                  "label": "Practice and Procedure - No case to answer",
+                  "value": "practice-and-procedure-no-case-to-answer"
+                },
+                {
+                  "label": "Practice and Procedure - Parties",
+                  "value": "practice-and-procedure-parties"
+                },
+                {
+                  "label": "Practice and Procedure - Permission to appeal further",
+                  "value": "practice-and-procedure-permission-to-appeal-further"
+                },
+                {
+                  "label": "Practice and Procedure - Perversity",
+                  "value": "practice-and-procedure-perversity"
+                },
+                {
+                  "label": "Practice and Procedure - Postponement or stay",
+                  "value": "practice-and-procedure-postponement-or-stay"
+                },
+                {
+                  "label": "Practice and Procedure - Preliminary issues",
+                  "value": "practice-and-procedure-preliminary-issues"
+                },
+                {
+                  "label": "Practice and Procedure - Questionnaires",
+                  "value": "practice-and-procedure-questionnaires"
+                },
+                {
+                  "label": "Practice and Procedure - Restricted Reporting Order",
+                  "value": "practice-and-procedure-restricted-reporting-order"
+                },
+                {
+                  "label": "Practice and Procedure - Restriction of proceedings order",
+                  "value": "practice-and-procedure-restriction-of-proceedings-order"
+                },
+                {
+                  "label": "Practice and Procedure - Review",
+                  "value": "practice-and-procedure-review"
+                },
+                {
+                  "label": "Practice and Procedure - Right to be heard",
+                  "value": "practice-and-procedure-right-to-be-heard"
+                },
+                {
+                  "label": "Practice and Procedure - Service",
+                  "value": "practice-and-procedure-service"
+                },
+                {
+                  "label": "Practice and Procedure - Split hearings",
+                  "value": "practice-and-procedure-split-hearings"
+                },
+                {
+                  "label": "Practice and Procedure - Striking-out/dismissal",
+                  "value": "practice-and-procedure-striking-out-dismissal"
+                },
+                {
+                  "label": "Practice and Procedure - Time for appealing",
+                  "value": "practice-and-procedure-time-for-appealing"
+                },
+                {
+                  "label": "Practice and Procedure - Transfer/Hearing together",
+                  "value": "practice-and-procedure-transfer-hearing-together"
+                },
+                {
+                  "label": "Practice and Procedure - Withdrawal",
+                  "value": "practice-and-procedure-withdrawal"
+                },
+                {
+                  "label": "Race Discrimination - Aiding and abetting",
+                  "value": "race-discrimination-aiding-and-abetting"
+                },
+                {
+                  "label": "Race Discrimination - Burden of proof",
+                  "value": "race-discrimination-burden-of-proof"
+                },
+                {
+                  "label": "Race Discrimination - Comparison",
+                  "value": "race-discrimination-comparison"
+                },
+                {
+                  "label": "Race Discrimination - Continuing act",
+                  "value": "race-discrimination-continuing-act"
+                },
+                {
+                  "label": "Race Discrimination - Contract workers",
+                  "value": "race-discrimination-contract-workers"
+                },
+                {
+                  "label": "Race Discrimination - Detriment",
+                  "value": "race-discrimination-detriment"
+                },
+                {
+                  "label": "Race Discrimination - Direct",
+                  "value": "race-discrimination-direct"
+                },
+                {
+                  "label": "Race Discrimination - Discrimination by other bodies",
+                  "value": "race-discrimination-discrimination-by-other-bodies"
+                },
+                {
+                  "label": "Race Discrimination - Illegality/Fraud",
+                  "value": "race-discrimination-illegality-fraud"
+                },
+                {
+                  "label": "Race Discrimination - Indirect",
+                  "value": "race-discrimination-indirect"
+                },
+                {
+                  "label": "Race Discrimination - Inferring discrimination",
+                  "value": "race-discrimination-inferring-discrimination"
+                },
+                {
+                  "label": "Race Discrimination - Injury to feelings",
+                  "value": "race-discrimination-injury-to-feelings"
+                },
+                {
+                  "label": "Race Discrimination - Jurisdiction",
+                  "value": "race-discrimination-jurisdiction"
+                },
+                {
+                  "label": "Race Discrimination - Other losses",
+                  "value": "race-discrimination-other-losses"
+                },
+                {
+                  "label": "Race Discrimination - Out of Time",
+                  "value": "race-discrimination-out-of-time"
+                },
+                {
+                  "label": "Race Discrimination - Post Employment",
+                  "value": "race-discrimination-post-employment"
+                },
+                {
+                  "label": "Race Discrimination - Prospective employees",
+                  "value": "race-discrimination-prospective-employees"
+                },
+                {
+                  "label": "Race Discrimination - Protected by s41",
+                  "value": "race-discrimination-protected-by-s41"
+                },
+                {
+                  "label": "Race Discrimination - Recommendations",
+                  "value": "race-discrimination-recommendations"
+                },
+                {
+                  "label": "Race Discrimination - Vicarious liability",
+                  "value": "race-discrimination-vicarious-liability"
+                },
+                {
+                  "label": "Race Discrimination - Victimisation",
+                  "value": "race-discrimination-victimisation"
+                },
+                {
+                  "label": "Redundancy - Collective consultation and information",
+                  "value": "redundancy-collective-consultation-and-information"
+                },
+                {
+                  "label": "Redundancy - Contractual scheme",
+                  "value": "redundancy-contractual-scheme"
+                },
+                {
+                  "label": "Redundancy - Definition",
+                  "value": "redundancy-definition"
+                },
+                {
+                  "label": "Redundancy - Exclusion",
+                  "value": "redundancy-exclusion"
+                },
+                {
+                  "label": "Redundancy - Fairness",
+                  "value": "redundancy-fairness"
+                },
+                {
+                  "label": "Redundancy - Protective award",
+                  "value": "redundancy-protective-award"
+                },
+                {
+                  "label": "Redundancy - Suitable alternative employment",
+                  "value": "redundancy-suitable-alternative-employment"
+                },
+                {
+                  "label": "Redundancy - Trial period",
+                  "value": "redundancy-trial-period"
+                },
+                {
+                  "label": "Sex Discrimination - Aiding and abetting",
+                  "value": "sex-discrimination-aiding-and-abetting"
+                },
+                {
+                  "label": "Sex Discrimination - Burden of proof",
+                  "value": "sex-discrimination-burden-of-proof"
+                },
+                {
+                  "label": "Sex Discrimination - Comparison",
+                  "value": "sex-discrimination-comparison"
+                },
+                {
+                  "label": "Sex Discrimination - Continuing act",
+                  "value": "sex-discrimination-continuing-act"
+                },
+                {
+                  "label": "Sex Discrimination - Contract workers",
+                  "value": "sex-discrimination-contract-workers"
+                },
+                {
+                  "label": "Sex Discrimination - Detriment",
+                  "value": "sex-discrimination-detriment"
+                },
+                {
+                  "label": "Sex Discrimination - Direct",
+                  "value": "sex-discrimination-direct"
+                },
+                {
+                  "label": "Sex Discrimination - Discrimination by other bodies",
+                  "value": "sex-discrimination-discrimination-by-other-bodies"
+                },
+                {
+                  "label": "Sex Discrimination - Equal treatment directive",
+                  "value": "sex-discrimination-equal-treatment-directive"
+                },
+                {
+                  "label": "Sex Discrimination - Illegality/Fraud",
+                  "value": "sex-discrimination-illegality-fraud"
+                },
+                {
+                  "label": "Sex Discrimination - Indirect",
+                  "value": "sex-discrimination-indirect"
+                },
+                {
+                  "label": "Sex Discrimination - Inferring discrimination",
+                  "value": "sex-discrimination-inferring-discrimination"
+                },
+                {
+                  "label": "Sex Discrimination - Injury to feelings",
+                  "value": "sex-discrimination-injury-to-feelings"
+                },
+                {
+                  "label": "Sex Discrimination - Jurisdiction",
+                  "value": "sex-discrimination-jurisdiction"
+                },
+                {
+                  "label": "Sex Discrimination - Justification",
+                  "value": "sex-discrimination-justification"
+                },
+                {
+                  "label": "Sex Discrimination - Marital status",
+                  "value": "sex-discrimination-marital-status"
+                },
+                {
+                  "label": "Sex Discrimination - Other losses",
+                  "value": "sex-discrimination-other-losses"
+                },
+                {
+                  "label": "Sex Discrimination - Post Employment",
+                  "value": "sex-discrimination-post-employment"
+                },
+                {
+                  "label": "Sex Discrimination - Pregnancy and discrimination",
+                  "value": "sex-discrimination-pregnancy-and-discrimination"
+                },
+                {
+                  "label": "Sex Discrimination - S4(2) Defence",
+                  "value": "sex-discrimination-s4-2-defence"
+                },
+                {
+                  "label": "Sex Discrimination - Sexual harassment",
+                  "value": "sex-discrimination-sexual-harassment"
+                },
+                {
+                  "label": "Sex Discrimination - Sexual orientation",
+                  "value": "sex-discrimination-sexual-orientation"
+                },
+                {
+                  "label": "Sex Discrimination - Transsexualism",
+                  "value": "sex-discrimination-transsexualism"
+                },
+                {
+                  "label": "Sex Discrimination - Vicarious liability",
+                  "value": "sex-discrimination-vicarious-liability"
+                },
+                {
+                  "label": "Sex Discrimination - Victimisation",
+                  "value": "sex-discrimination-victimisation"
+                },
+                {
+                  "label": "Statutory Discipline and Grievance Procedures - Impact on compensation",
+                  "value": "statutory-discipline-and-grievance-procedures-impact-on-compensation"
+                },
+                {
+                  "label": "Statutory Discipline and Grievance Procedures - Whether applicable",
+                  "value": "statutory-discipline-and-grievance-procedures-whether-applicable"
+                },
+                {
+                  "label": "Statutory Discipline and Grievance Procedures - Whether infringed",
+                  "value": "statutory-discipline-and-grievance-procedures-whether-infringed"
+                },
+                {
+                  "label": "Time Off - Parental leave",
+                  "value": "time-off-parental-leave"
+                },
+                {
+                  "label": "Time Off - Public duties",
+                  "value": "time-off-public-duties"
+                },
+                {
+                  "label": "Time Off - Trade union activities",
+                  "value": "time-off-trade-union-activities"
+                },
+                {
+                  "label": "Trade Union Rights - Action short of dismissal",
+                  "value": "trade-union-rights-action-short-of-dismissal"
+                },
+                {
+                  "label": "Trade Union Rights - Dismissal",
+                  "value": "trade-union-rights-dismissal"
+                },
+                {
+                  "label": "Trade Union Rights - Interim relief",
+                  "value": "trade-union-rights-interim-relief"
+                },
+                {
+                  "label": "Transfer of Undertakings - Acquired rights directive",
+                  "value": "transfer-of-undertakings-acquired-rights-directive"
+                },
+                {
+                  "label": "Transfer of Undertakings - Consultation and other information",
+                  "value": "transfer-of-undertakings-consultation-and-other-information"
+                },
+                {
+                  "label": "Transfer of Undertakings - Continuity of employment",
+                  "value": "transfer-of-undertakings-continuity-of-employment"
+                },
+                {
+                  "label": "Transfer of Undertakings - Dismissal/automatically unfair dismissal",
+                  "value": "transfer-of-undertakings-dismissal-automatically-unfair-dismissal"
+                },
+                {
+                  "label": "Transfer of Undertakings - Economic technical or organisational reason",
+                  "value": "transfer-of-undertakings-economic-technical-or-organisational-reason"
+                },
+                {
+                  "label": "Transfer of Undertakings - Entity",
+                  "value": "transfer-of-undertakings-entity"
+                },
+                {
+                  "label": "Transfer of Undertakings - Insolvency",
+                  "value": "transfer-of-undertakings-insolvency"
+                },
+                {
+                  "label": "Transfer of Undertakings - Insolvent Employer",
+                  "value": "transfer-of-undertakings-insolvent-employer"
+                },
+                {
+                  "label": "Transfer of Undertakings - Objection to transfer",
+                  "value": "transfer-of-undertakings-objection-to-transfer"
+                },
+                {
+                  "label": "Transfer of Undertakings - Pensions and other terms",
+                  "value": "transfer-of-undertakings-pensions-and-other-terms"
+                },
+                {
+                  "label": "Transfer of Undertakings - Service Provision Change",
+                  "value": "transfer-of-undertakings-service-provision-change"
+                },
+                {
+                  "label": "Transfer of Undertakings - Transfer",
+                  "value": "transfer-of-undertakings-transfer"
+                },
+                {
+                  "label": "Transfer of Undertakings - Varying terms of employment",
+                  "value": "transfer-of-undertakings-varying-terms-of-employment"
+                },
+                {
+                  "label": "Unfair Dismissal - Automatically unfair reasons",
+                  "value": "unfair-dismissal-automatically-unfair-reasons"
+                },
+                {
+                  "label": "Unfair Dismissal - Compensation",
+                  "value": "unfair-dismissal-compensation"
+                },
+                {
+                  "label": "Unfair Dismissal - Constructive dismissal",
+                  "value": "unfair-dismissal-constructive-dismissal"
+                },
+                {
+                  "label": "Unfair Dismissal - Contributory fault",
+                  "value": "unfair-dismissal-contributory-fault"
+                },
+                {
+                  "label": "Unfair Dismissal - Dismissal/ambiguous resignation",
+                  "value": "unfair-dismissal-dismissal-ambiguous-resignation"
+                },
+                {
+                  "label": "Unfair Dismissal - Exclusions including worker/jurisdiction",
+                  "value": "unfair-dismissal-exclusions-including-worker-jurisdiction"
+                },
+                {
+                  "label": "Unfair Dismissal - Illegality/Fraud",
+                  "value": "unfair-dismissal-illegality-fraud"
+                },
+                {
+                  "label": "Unfair Dismissal - Mitigation of loss",
+                  "value": "unfair-dismissal-mitigation-of-loss"
+                },
+                {
+                  "label": "Unfair Dismissal - National Security",
+                  "value": "unfair-dismissal-national-security"
+                },
+                {
+                  "label": "Unfair Dismissal - Polkey deduction",
+                  "value": "unfair-dismissal-polkey-deduction"
+                },
+                {
+                  "label": "Unfair Dismissal - Procedural fairness/automatically unfair dismissal",
+                  "value": "unfair-dismissal-procedural-fairness-automatically-unfair-dismissal"
+                },
+                {
+                  "label": "Unfair Dismissal - Reason for dismissal including substantial other reason",
+                  "value": "unfair-dismissal-reason-for-dismissal-including-substantial-other-reason"
+                },
+                {
+                  "label": "Unfair Dismissal - Reasonableness of dismissal",
+                  "value": "unfair-dismissal-reasonableness-of-dismissal"
+                },
+                {
+                  "label": "Unfair Dismissal - Reinstatement/re-engagement",
+                  "value": "unfair-dismissal-reinstatement-re-engagement"
+                },
+                {
+                  "label": "Unfair Dismissal - Retirement",
+                  "value": "unfair-dismissal-retirement"
+                },
+                {
+                  "label": "Unfair Dismissal - S.98A(2) ERA",
+                  "value": "unfair-dismissal-s-98a-2-era"
+                },
+                {
+                  "label": "Unlawful Deduction from Wages - Exclusions",
+                  "value": "unlawful-deduction-from-wages-exclusions"
+                },
+                {
+                  "label": "Unlawful Deduction from Wages - Out of Time",
+                  "value": "unlawful-deduction-from-wages-out-of-time"
+                },
+                {
+                  "label": "Unlawful Deduction from Wages - Ready, Willing and Able to Work",
+                  "value": "unlawful-deduction-from-wages-ready-willing-and-able-to-work"
+                },
+                {
+                  "label": "Victimisation Discrimination - Detriment",
+                  "value": "victimisation-discrimination-detriment"
+                },
+                {
+                  "label": "Victimisation Discrimination - Dismissal",
+                  "value": "victimisation-discrimination-dismissal"
+                },
+                {
+                  "label": "Victimisation Discrimination - Health and safety",
+                  "value": "victimisation-discrimination-health-and-safety"
+                },
+                {
+                  "label": "Victimisation Discrimination - Interim relief",
+                  "value": "victimisation-discrimination-interim-relief"
+                },
+                {
+                  "label": "Victimisation Discrimination - Other forms of victimisation",
+                  "value": "victimisation-discrimination-other-forms-of-victimisation"
+                },
+                {
+                  "label": "Victimisation Discrimination - Protected disclosure",
+                  "value": "victimisation-discrimination-protected-disclosure"
+                },
+                {
+                  "label": "Victimisation Discrimination - Whistleblowing",
+                  "value": "victimisation-discrimination-whistleblowing"
+                },
+                {
+                  "label": "Working Time Regulations - Holiday pay",
+                  "value": "working-time-regulations-holiday-pay"
+                },
+                {
+                  "label": "Working Time Regulations - S.43A detriment",
+                  "value": "working-time-regulations-s-43a-detriment"
+                },
+                {
+                  "label": "Working Time Regulations - Worker",
+                  "value": "working-time-regulations-worker"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_sub_categories_name",
+              "name": "Sub-category name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_landmark",
+              "name": "Landmark",
+              "type": "text",
+              "display_as_result_metadata": false,
+              "filterable": false,
+              "allowed_values": [
+                {
+                  "label": "Landmark",
+                  "value": "landmark"
+                },
+                {
+                  "label": "Not landmark",
+                  "value": "not-landmark"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_landmark_name",
+              "name": "Landmark name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_decision_date",
+              "name": "Decision date",
+              "short_name": "Decided",
+              "type": "date",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/employment-appeal-tribunal-decisions",
+        "web_url": "https://www.gov.uk/employment-appeal-tribunal-decisions"
+      }
+    ],
     "available_translations": [
       {
         "content_id": "3917cb0e-0928-45b7-bf63-20f9bc113a7a",

--- a/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/employment-tribunal-decision.json
@@ -47,6 +47,299 @@
     ]
   },
   "links": {
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/employment-tribunal-decisions",
+        "base_path": "/employment-tribunal-decisions",
+        "content_id": "1b5e08c8-ddde-4637-9375-f79e085ba6d5",
+        "description": "Find decisions on Employment Tribunal cases in England, Wales and Scotland.",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Employment tribunal decisions",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "decision",
+          "filter": {
+            "document_type": "employment_tribunal_decision"
+          },
+          "format_name": "Employment tribunal decision",
+          "show_summaries": true,
+          "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland.</p>",
+          "facets": [
+            {
+              "key": "tribunal_decision_country",
+              "name": "Country",
+              "type": "text",
+              "preposition": "by country",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "England and Wales",
+                  "value": "england-and-wales"
+                },
+                {
+                  "label": "Scotland",
+                  "value": "scotland"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_country_name",
+              "name": "Country name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_categories",
+              "name": "Jurisdiction code",
+              "type": "text",
+              "preposition": "by jurisdiction",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Age Discrimination",
+                  "value": "age-discrimination"
+                },
+                {
+                  "label": "Agency Workers",
+                  "value": "agency-workers"
+                },
+                {
+                  "label": "Blacklisting Regulations",
+                  "value": "blacklisting-regulations"
+                },
+                {
+                  "label": "Breach of Contract",
+                  "value": "breach-of-contract"
+                },
+                {
+                  "label": "Central Arbitration Committee (CAC)",
+                  "value": "central-arbitration-committee-cac"
+                },
+                {
+                  "label": "Certification Officer",
+                  "value": "certification-officer"
+                },
+                {
+                  "label": "Contract of Employment",
+                  "value": "contract-of-employment"
+                },
+                {
+                  "label": "Disability Discrimination",
+                  "value": "disability-discrimination"
+                },
+                {
+                  "label": "Employment Agencies Act 1973",
+                  "value": "employment-agencies-act-1973"
+                },
+                {
+                  "label": "Equal Pay Act",
+                  "value": "equal-pay-act"
+                },
+                {
+                  "label": "European Material",
+                  "value": "european-material"
+                },
+                {
+                  "label": "Fixed Term Regulations",
+                  "value": "fixed-term-regulations"
+                },
+                {
+                  "label": "Flexible Working",
+                  "value": "flexible-working"
+                },
+                {
+                  "label": "Harassment",
+                  "value": "harassment"
+                },
+                {
+                  "label": "Health & Safety",
+                  "value": "health-safety"
+                },
+                {
+                  "label": "Human Rights",
+                  "value": "human-rights"
+                },
+                {
+                  "label": "Improvement Notice",
+                  "value": "improvement-notice"
+                },
+                {
+                  "label": "Interim Relief",
+                  "value": "interim-relief"
+                },
+                {
+                  "label": "Jurisdictional Points",
+                  "value": "jurisdictional-points"
+                },
+                {
+                  "label": "Maternity and Pregnancy Rights",
+                  "value": "maternity-and-pregnancy-rights"
+                },
+                {
+                  "label": "National Minimum Wage",
+                  "value": "national-minimum-wage"
+                },
+                {
+                  "label": "National Security",
+                  "value": "national-security"
+                },
+                {
+                  "label": "Parental and Maternity Leave",
+                  "value": "parental-and-maternity-leave"
+                },
+                {
+                  "label": "Part Time Workers",
+                  "value": "part-time-workers"
+                },
+                {
+                  "label": "Pension",
+                  "value": "pension"
+                },
+                {
+                  "label": "Practice and Procedure Issues",
+                  "value": "practice-and-procedure-issues"
+                },
+                {
+                  "label": "Protective Award",
+                  "value": "protective-award"
+                },
+                {
+                  "label": "Public Interest Disclosure",
+                  "value": "public-interest-disclosure"
+                },
+                {
+                  "label": "Race Discrimination",
+                  "value": "race-discrimination"
+                },
+                {
+                  "label": "Redundancy",
+                  "value": "redundancy"
+                },
+                {
+                  "label": "Religion or Belief Discrimination",
+                  "value": "religion-or-belief-discrimination"
+                },
+                {
+                  "label": "Renumeration",
+                  "value": "renumeration"
+                },
+                {
+                  "label": "Reorganisation",
+                  "value": "reorganisation"
+                },
+                {
+                  "label": "Reserved Forces Act",
+                  "value": "reserved-forces-act"
+                },
+                {
+                  "label": "Right To Be Accompanied",
+                  "value": "right-to-be-accompanied"
+                },
+                {
+                  "label": "Rights on Insolvency",
+                  "value": "rights-on-insolvency"
+                },
+                {
+                  "label": "Sex Discrimination",
+                  "value": "sex-discrimination"
+                },
+                {
+                  "label": "Sexual Orientation Discrimination/Transexualism",
+                  "value": "sexual-orientation-discrimination-transexualism"
+                },
+                {
+                  "label": "Statutory Discipline and Grievance Procedures",
+                  "value": "statutory-discipline-and-grievance-procedures"
+                },
+                {
+                  "label": "Tax",
+                  "value": "tax"
+                },
+                {
+                  "label": "Temporary Employment",
+                  "value": "temporary-employment"
+                },
+                {
+                  "label": "Time Limits",
+                  "value": "time-limits"
+                },
+                {
+                  "label": "Time Off",
+                  "value": "time-off"
+                },
+                {
+                  "label": "Time to Train",
+                  "value": "time-to-train"
+                },
+                {
+                  "label": "Trade Union Membership",
+                  "value": "trade-union-membership"
+                },
+                {
+                  "label": "Trade Union Rights",
+                  "value": "trade-union-rights"
+                },
+                {
+                  "label": "Transfer of Undertakings",
+                  "value": "transfer-of-undertakings"
+                },
+                {
+                  "label": "Unfair Dismissal",
+                  "value": "unfair-dismissal"
+                },
+                {
+                  "label": "Unlawful Deduction from Wages",
+                  "value": "unlawful-deduction-from-wages"
+                },
+                {
+                  "label": "Victimisation Discrimination",
+                  "value": "victimisation-discrimination"
+                },
+                {
+                  "label": "Working Time Regulations",
+                  "value": "working-time-regulations"
+                },
+                {
+                  "label": "Written Pay Statement",
+                  "value": "written-pay-statement"
+                },
+                {
+                  "label": "Written Statements",
+                  "value": "written-statements"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_categories_name",
+              "name": "Jurisdiction code name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_decision_date",
+              "name": "Decision date",
+              "short_name": "Decided",
+              "type": "date",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/employment-tribunal-decisions",
+        "web_url": "https://www.gov.uk/employment-tribunal-decisions"
+      }
+    ],
     "available_translations": [
       {
         "content_id": "a66a167f-081b-4b0c-bd8e-3bb1242507df",

--- a/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
+++ b/formats/specialist_document/frontend/examples/european-structural-investment-funds.json
@@ -124,5 +124,192 @@
   "schema_name": "specialist_document",
   "document_type": "esi_fund",
   "links": {
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/european-structural-investment-funds",
+        "base_path": "/european-structural-investment-funds",
+        "content_id": "78cedbfe-d3aa-41c3-b8c0-aeb5d9035d6a",
+        "description": "Find and apply to run projects backed by ESIF",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "European Structural and Investment Funds (ESIF)",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "call",
+          "filter": {
+            "document_type": "european_structural_investment_fund"
+          },
+          "format_name": "ESIF call for proposals",
+          "show_summaries": false,
+          "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"https://www.dfpni.gov.uk/topics/finance/european-funding-2014-2020\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Structural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
+          "facets": [
+            {
+              "key": "fund_state",
+              "name": "Fund state",
+              "type": "text",
+              "preposition": "which are",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Open",
+                  "value": "open"
+                },
+                {
+                  "label": "Closed",
+                  "value": "closed"
+                }
+              ]
+            },
+            {
+              "key": "fund_type",
+              "name": "Type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Access to employment",
+                  "value": "access-to-work"
+                },
+                {
+                  "label": "Business support",
+                  "value": "business-support"
+                },
+                {
+                  "label": "Climate change",
+                  "value": "climate-change"
+                },
+                {
+                  "label": "Environment",
+                  "value": "environment"
+                },
+                {
+                  "label": "IT and broadband",
+                  "value": "it-and-broadband"
+                },
+                {
+                  "label": "Learning and skills",
+                  "value": "learning-and-skills"
+                },
+                {
+                  "label": "Low carbon",
+                  "value": "low-carbon"
+                },
+                {
+                  "label": "Renewable energy",
+                  "value": "renewable-energy"
+                },
+                {
+                  "label": "Research and innovation",
+                  "value": "research-and-innovation"
+                },
+                {
+                  "label": "Social inclusion",
+                  "value": "social-inclusion"
+                },
+                {
+                  "label": "Transport",
+                  "value": "transport"
+                },
+                {
+                  "label": "Technical assistance",
+                  "value": "techincal-assistance"
+                },
+                {
+                  "label": "Tourism",
+                  "value": "tourism"
+                }
+              ]
+            },
+            {
+              "key": "location",
+              "name": "Location",
+              "type": "text",
+              "preposition": "in",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "North East",
+                  "value": "north-east"
+                },
+                {
+                  "label": "North West",
+                  "value": "north-west"
+                },
+                {
+                  "label": "Yorkshire and Humber",
+                  "value": "yorkshire-and-humber"
+                },
+                {
+                  "label": "East Midlands",
+                  "value": "east-midlands"
+                },
+                {
+                  "label": "West Midlands",
+                  "value": "west-midlands"
+                },
+                {
+                  "label": "East of England",
+                  "value": "east-of-england"
+                },
+                {
+                  "label": "South East",
+                  "value": "south-east"
+                },
+                {
+                  "label": "South West",
+                  "value": "south-west"
+                },
+                {
+                  "label": "London",
+                  "value": "london"
+                }
+              ]
+            },
+            {
+              "key": "funding_source",
+              "name": "Funding source",
+              "type": "text",
+              "preposition": "from",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "European Social Fund",
+                  "value": "european-social-fund"
+                },
+                {
+                  "label": "European Regional Development Fund",
+                  "value": "european-regional-development-fund"
+                },
+                {
+                  "label": "European Agricultural Fund for Rural Development",
+                  "value": "european-agricoltural-fund-for-rural"
+                }
+              ]
+            },
+            {
+              "key": "closing_date",
+              "name": "Closing date",
+              "type": "date",
+              "display_as_result_metadata": true,
+              "filterable": false
+            }
+          ],
+          "default_order": "-closing_date",
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/european-structural-investment-funds",
+        "web_url": "https://www.gov.uk/european-structural-investment-funds"
+      }
+    ]
   }
 }

--- a/formats/specialist_document/frontend/examples/international-development-funding.json
+++ b/formats/specialist_document/frontend/examples/international-development-funding.json
@@ -109,5 +109,313 @@
   "schema_name": "specialist_document",
   "document_type": "international_development_fund",
   "links": {
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/international-development-funding",
+        "base_path": "/international-development-funding",
+        "content_id": "5583057c-7c57-4cfe-b70d-dad6f4762831",
+        "description": "Find and apply for funds to run international development projects",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "International development funding",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "fund",
+          "filter": {
+            "document_type": "international_development_fund"
+          },
+          "format_name": "International development funding",
+          "show_summaries": true,
+          "facets": [
+            {
+              "key": "fund_state",
+              "name": "Funds",
+              "type": "text",
+              "preposition": "which are",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Open",
+                  "value": "open"
+                },
+                {
+                  "label": "Closed",
+                  "value": "closed"
+                }
+              ]
+            },
+            {
+              "key": "location",
+              "name": "Countries",
+              "type": "text",
+              "preposition": "for",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Afghanistan",
+                  "value": "afghanistan"
+                },
+                {
+                  "label": "Bangladesh",
+                  "value": "bangladesh"
+                },
+                {
+                  "label": "Burma",
+                  "value": "burma"
+                },
+                {
+                  "label": "Democratic Republic of the Congo",
+                  "value": "democratic-republic-of-congo"
+                },
+                {
+                  "label": "Ethiopia",
+                  "value": "ethiopia"
+                },
+                {
+                  "label": "Ghana",
+                  "value": "ghana"
+                },
+                {
+                  "label": "India",
+                  "value": "india"
+                },
+                {
+                  "label": "Kenya",
+                  "value": "kenya"
+                },
+                {
+                  "label": "Kyrgyzstan",
+                  "value": "kyrgyzstan"
+                },
+                {
+                  "label": "Liberia",
+                  "value": "liberia"
+                },
+                {
+                  "label": "Malawi",
+                  "value": "malawi"
+                },
+                {
+                  "label": "Mozambique",
+                  "value": "mozambique"
+                },
+                {
+                  "label": "Nepal",
+                  "value": "nepal"
+                },
+                {
+                  "label": "Nigeria",
+                  "value": "nigeria"
+                },
+                {
+                  "label": "The Occupied Palestinian Territories",
+                  "value": "the-occupied-palestinian-territories"
+                },
+                {
+                  "label": "Pakistan",
+                  "value": "pakistan"
+                },
+                {
+                  "label": "Rwanda",
+                  "value": "rwanda"
+                },
+                {
+                  "label": "Sierra Leone",
+                  "value": "sierra-leone"
+                },
+                {
+                  "label": "Somalia",
+                  "value": "somalia"
+                },
+                {
+                  "label": "South Africa",
+                  "value": "south-africa"
+                },
+                {
+                  "label": "Sudan",
+                  "value": "sudan"
+                },
+                {
+                  "label": "South Sudan",
+                  "value": "south-sudan"
+                },
+                {
+                  "label": "Tajikistan",
+                  "value": "tajikistan"
+                },
+                {
+                  "label": "Tanzania",
+                  "value": "tanzania"
+                },
+                {
+                  "label": "Uganda",
+                  "value": "uganda"
+                },
+                {
+                  "label": "Yemen",
+                  "value": "yemen"
+                },
+                {
+                  "label": "Zambia",
+                  "value": "zambia"
+                },
+                {
+                  "label": "Zimbabwe",
+                  "value": "zimbabwe"
+                }
+              ]
+            },
+            {
+              "key": "development_sector",
+              "name": "Sector",
+              "type": "text",
+              "preposition": "for",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Agriculture",
+                  "value": "agriculture"
+                },
+                {
+                  "label": "Climate change",
+                  "value": "climate-change"
+                },
+                {
+                  "label": "Disabilities",
+                  "value": "disabilities"
+                },
+                {
+                  "label": "Education",
+                  "value": "education"
+                },
+                {
+                  "label": "Empowerment and accountability",
+                  "value": "empowerment-and-accountability"
+                },
+                {
+                  "label": "Environment",
+                  "value": "environment"
+                },
+                {
+                  "label": "Girls and women",
+                  "value": "girls-and-women"
+                },
+                {
+                  "label": "Health",
+                  "value": "health"
+                },
+                {
+                  "label": "Humanitarian emergencies/disasters",
+                  "value": "humanitarian-emergencies-disasters"
+                },
+                {
+                  "label": "Livelihoods",
+                  "value": "livelihoods"
+                },
+                {
+                  "label": "Peace and access to justice",
+                  "value": "peace-and-access-to-justice"
+                },
+                {
+                  "label": "Private sector/business",
+                  "value": "private-sector-business"
+                },
+                {
+                  "label": "Technology",
+                  "value": "technology"
+                },
+                {
+                  "label": "Trade",
+                  "value": "trade"
+                },
+                {
+                  "label": "Water and sanitation",
+                  "value": "water-and-sanitation"
+                }
+              ]
+            },
+            {
+              "key": "eligible_entities",
+              "name": "Eligible organisations",
+              "type": "text",
+              "preposition": "open to",
+              "filterable": true,
+              "display_as_result_metadata": false,
+              "allowed_values": [
+                {
+                  "label": "Non-governmental organisations (NGOs)",
+                  "value": "non-governmental-organisations"
+                },
+                {
+                  "label": "UK-based non-profit organisations",
+                  "value": "uk-based-non-profit-organisations"
+                },
+                {
+                  "label": "UK-based small and diaspora organisations",
+                  "value": "uk-based-small-and-diaspora-organisations"
+                },
+                {
+                  "label": "Companies",
+                  "value": "companies"
+                },
+                {
+                  "label": "Local government",
+                  "value": "local-government"
+                },
+                {
+                  "label": "Educational institutions",
+                  "value": "educational-institutions"
+                },
+                {
+                  "label": "Individuals",
+                  "value": "individuals"
+                },
+                {
+                  "label": "Humanitarian relief organisations",
+                  "value": "humanitarian-relief-organisations"
+                }
+              ]
+            },
+            {
+              "key": "value_of_funding",
+              "name": "Value of funding",
+              "type": "text",
+              "preposition": "with value",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Up to £100,000",
+                  "value": "up-to-100000"
+                },
+                {
+                  "label": "£100,001 to £500,000",
+                  "value": "100001-500000"
+                },
+                {
+                  "label": "£500,001 to £1,000,000",
+                  "value": "500001-to-1000000"
+                },
+                {
+                  "label": "More than £1,000,000",
+                  "value": "more-than-1000000"
+                }
+              ]
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/international-development-funding",
+        "web_url": "https://www.gov.uk/international-development-funding"
+      }
+    ]
   }
 }

--- a/formats/specialist_document/frontend/examples/maib-reports.json
+++ b/formats/specialist_document/frontend/examples/maib-reports.json
@@ -63,5 +63,104 @@
   "schema_name": "specialist_document",
   "document_type": "maib_report",
   "links": {
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/maib-reports",
+        "base_path": "/maib-reports",
+        "content_id": "33eb214a-9291-49d3-8789-445c1e97b586",
+        "description": "Find reports of MAIB investigations into marine accidents and incidents",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Marine Accident Investigation Branch reports",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "report",
+          "filter": {
+            "document_type": "maib_report"
+          },
+          "format_name": "Marine Accident Investigation Branch report",
+          "show_summaries": true,
+          "facets": [
+            {
+              "key": "vessel_type",
+              "name": "Vessel type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Merchant vessel 100 gross tons or over",
+                  "value": "merchant-vessel-100-gross-tons-or-over"
+                },
+                {
+                  "label": "Merchant vessel under 100 gross tons",
+                  "value": "merchant-vessel-under-100-gross-tons"
+                },
+                {
+                  "label": "Fishing vessel",
+                  "value": "fishing-vessel"
+                },
+                {
+                  "label": "Recreational craft - sail",
+                  "value": "recreational-craft-sail"
+                },
+                {
+                  "label": "Recreational craft - power",
+                  "value": "recreational-craft-power"
+                }
+              ]
+            },
+            {
+              "key": "report_type",
+              "name": "Report type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Investigation report",
+                  "value": "investigation-report"
+                },
+                {
+                  "label": "Safety bulletin",
+                  "value": "safety-bulletin"
+                },
+                {
+                  "label": "Completed preliminary examination",
+                  "value": "completed-preliminary-examination"
+                },
+                {
+                  "label": "Overseas report",
+                  "value": "overseas-report"
+                },
+                {
+                  "label": "Discontinued investigation",
+                  "value": "discontinued-investigation"
+                }
+              ]
+            },
+            {
+              "key": "date_of_occurrence",
+              "name": "Date of occurrence",
+              "short_name": "Occurred",
+              "type": "date",
+              "preposition": "occurred",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/maib-reports",
+        "web_url": "https://www.gov.uk/maib-reports"
+      }
+    ]
   }
 }

--- a/formats/specialist_document/frontend/examples/raib-reports.json
+++ b/formats/specialist_document/frontend/examples/raib-reports.json
@@ -43,5 +43,100 @@
   "schema_name": "specialist_document",
   "document_type": "raib_report",
   "links": {
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/raib-reports",
+        "base_path": "/raib-reports",
+        "content_id": "e3ff7fc5-6788-45de-83f0-cbf34e9fe8bd",
+        "description": "Find reports of RAIB investigations into rail accidents and incidents",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Rail Accident Investigation Branch reports",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "report",
+          "filter": {
+            "document_type": "raib_report"
+          },
+          "format_name": "Rail Accident Investigation Branch report",
+          "show_summaries": false,
+          "facets": [
+            {
+              "key": "railway_type",
+              "name": "Railway type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Heavy rail",
+                  "value": "heavy-rail"
+                },
+                {
+                  "label": "Light rail",
+                  "value": "light-rail"
+                },
+                {
+                  "label": "Metros",
+                  "value": "metros"
+                },
+                {
+                  "label": "Heritage railways",
+                  "value": "heritage-railways"
+                }
+              ]
+            },
+            {
+              "key": "report_type",
+              "name": "Report type",
+              "type": "text",
+              "preposition": "of type",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Investigation report",
+                  "value": "investigation-report"
+                },
+                {
+                  "label": "Bulletin",
+                  "value": "bulletin"
+                },
+                {
+                  "label": "Interim report",
+                  "value": "interim-report"
+                },
+                {
+                  "label": "Discontinuation report",
+                  "value": "discontinuation-report"
+                },
+                {
+                  "label": "Safety digest",
+                  "value": "safety-digest"
+                }
+              ]
+            },
+            {
+              "key": "date_of_occurrence",
+              "name": "Date of occurrence",
+              "short_name": "Occurred",
+              "type": "date",
+              "preposition": "occurred",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/raib-reports",
+        "web_url": "https://www.gov.uk/raib-reports"
+      }
+    ]
   }
 }

--- a/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
+++ b/formats/specialist_document/frontend/examples/tax-tribunal-decision.json
@@ -54,6 +54,88 @@
         "web_url": "https://www.gov.uk/tax-and-chancery-tribunal-decisions/why-pay-more-for-cars-limited-v-the-commissioners-for-her-majesty-s-revenue-and-customs",
         "locale": "en"
       }
+    ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/tax-and-chancery-tribunal-decisions",
+        "base_path": "/tax-and-chancery-tribunal-decisions",
+        "content_id": "632290ae-aad8-4895-b135-1e0a72a6bdeb",
+        "description": "Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Tax and Chancery tribunal decisions",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "decision",
+          "filter": {
+            "document_type": "tax_tribunal_decision"
+          },
+          "format_name": "Tax and Chancery tribunal decision",
+          "show_summaries": true,
+          "summary": "<p>Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).</p>",
+          "facets": [
+            {
+              "key": "tribunal_decision_category",
+              "name": "Category",
+              "short_name": "category",
+              "type": "text",
+              "preposition": "categorised as",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Banking",
+                  "value": "banking"
+                },
+                {
+                  "label": "Charity",
+                  "value": "charity"
+                },
+                {
+                  "label": "Financial Services",
+                  "value": "financial-services"
+                },
+                {
+                  "label": "Land Registration",
+                  "value": "land-registration"
+                },
+                {
+                  "label": "Pensions",
+                  "value": "pensions"
+                },
+                {
+                  "label": "Tax",
+                  "value": "tax"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_category_name",
+              "name": "Category name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_decision_date",
+              "name": "Release date",
+              "short_name": "Released",
+              "type": "date",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_order": "-tribunal_decision_decision_date",
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/tax-and-chancery-tribunal-decisions",
+        "web_url": "https://www.gov.uk/tax-and-chancery-tribunal-decisions"
+      }
     ]
   },
   "schema_name": "specialist_document",

--- a/formats/specialist_document/frontend/examples/utaac-decision.json
+++ b/formats/specialist_document/frontend/examples/utaac-decision.json
@@ -49,6 +49,2440 @@
         "web_url": "https://www.gov.uk/administrative-appeals-tribunal-decisions/example-utaac-decision",
         "locale": "en"
       }
+    ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/administrative-appeals-tribunal-decisions",
+        "base_path": "/administrative-appeals-tribunal-decisions",
+        "content_id": "e9e7fcff-bb0d-4723-af25-9f78d730f6f8",
+        "description": "Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Administrative appeals tribunal decisions",
+        "withdrawn": false,
+        "details": {
+          "document_noun": "decision",
+          "filter": {
+            "document_type": "utaac_decision"
+          },
+          "format_name": "Administrative appeals tribunal decision",
+          "show_summaries": true,
+          "summary": "<p>Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.</p><p>This includes decisions made from January 2016 onwards. You can find details of <a rel=\"external\" href=\"http://administrativeappeals.decisions.tribunals.gov.uk/Aspx/default.aspx\">decisions made in 2015 or earlier</a> on the Courts and Tribunals Judiciary website.</p>",
+          "facets": [
+            {
+              "key": "tribunal_decision_categories",
+              "name": "Categories",
+              "type": "text",
+              "preposition": "categorised as",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Benefits for children",
+                  "value": "benefits-for-children"
+                },
+                {
+                  "label": "Bereavement and death benefits",
+                  "value": "bereavement-and-death-benefits"
+                },
+                {
+                  "label": "Capital",
+                  "value": "capital"
+                },
+                {
+                  "label": "Care standards",
+                  "value": "care-standards"
+                },
+                {
+                  "label": "Child support",
+                  "value": "child-support"
+                },
+                {
+                  "label": "Claims and payments",
+                  "value": "claims-and-payments"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice ",
+                  "value": "commissioners-procedure-and-practice"
+                },
+                {
+                  "label": "Compensation recovery",
+                  "value": "compensation-recovery"
+                },
+                {
+                  "label": "Consumer credit",
+                  "value": "consumer-credit"
+                },
+                {
+                  "label": "Contributions and credits",
+                  "value": "contributions-and-credits"
+                },
+                {
+                  "label": "Criminal injuries compensation",
+                  "value": "criminal-injuries-compensation"
+                },
+                {
+                  "label": "Disability discrimination in schools",
+                  "value": "disability-discrimination-schools"
+                },
+                {
+                  "label": "DLA, AA, MA: general",
+                  "value": "dla-aa-ma-general"
+                },
+                {
+                  "label": "DLA, AA: personal care",
+                  "value": "dla-aa-personal-care"
+                },
+                {
+                  "label": "DLA, MA: mobility",
+                  "value": "dla-ma-mobility"
+                },
+                {
+                  "label": "Earnings and other income",
+                  "value": "earnings-and-other-income"
+                },
+                {
+                  "label": "Employment and support allowance",
+                  "value": "employment-and-support-allowance"
+                },
+                {
+                  "label": "Environment",
+                  "value": "environment"
+                },
+                {
+                  "label": "Equality Act",
+                  "value": "equality-act"
+                },
+                {
+                  "label": "Estate agents",
+                  "value": "estate-agents"
+                },
+                {
+                  "label": "European Union law",
+                  "value": "european-union-law"
+                },
+                {
+                  "label": "Forfeiture",
+                  "value": "forfeiture"
+                },
+                {
+                  "label": "Gambling",
+                  "value": "gambling"
+                },
+                {
+                  "label": "Housing and council tax benefits",
+                  "value": "housing-and-council-tax-benefits"
+                },
+                {
+                  "label": "Human rights law",
+                  "value": "human-rights-law"
+                },
+                {
+                  "label": "Immigration services",
+                  "value": "immigration-services"
+                },
+                {
+                  "label": "Incapacity benefits",
+                  "value": "incapacity-benefits"
+                },
+                {
+                  "label": "Income support and state pension credits",
+                  "value": "income-support-and-state-pension-credits"
+                },
+                {
+                  "label": "Industrial accidents",
+                  "value": "industrial-accidents"
+                },
+                {
+                  "label": "Industrial diseases",
+                  "value": "industrial-diseases"
+                },
+                {
+                  "label": "Industrial injuries benefits",
+                  "value": "industrial-injuries-benefits"
+                },
+                {
+                  "label": "Information rights",
+                  "value": "information-rights"
+                },
+                {
+                  "label": "Jobseekers allowance",
+                  "value": "jobseekers-allowance"
+                },
+                {
+                  "label": "Local government standards in England",
+                  "value": "local-government-standards-in-england"
+                },
+                {
+                  "label": "Marriage, civil partnerships and living together",
+                  "value": "marriage-civil-partnerships-and-living-together"
+                },
+                {
+                  "label": "Maternity benefits",
+                  "value": "maternity-benefits"
+                },
+                {
+                  "label": "Members of a household",
+                  "value": "members-of-a-household"
+                },
+                {
+                  "label": "Mental health",
+                  "value": "mental-health"
+                },
+                {
+                  "label": "Other current benefits",
+                  "value": "other-current-benefits"
+                },
+                {
+                  "label": "Other general regulatory appeals",
+                  "value": "other-general-regulatory-appeals"
+                },
+                {
+                  "label": "Other previous benefits",
+                  "value": "other-previous-benefits"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities",
+                  "value": "personal-independence-payment-daily-living-activities"
+                },
+                {
+                  "label": "Personal independence payment – general",
+                  "value": "personal-independence-payment-general"
+                },
+                {
+                  "label": "Personal independence payment – mobility activities",
+                  "value": "personal-independence-payment-mobility-activities"
+                },
+                {
+                  "label": "Primary health lists",
+                  "value": "primary-health-lists"
+                },
+                {
+                  "label": "Recovery of overpayments",
+                  "value": "recovery-of-overpayments"
+                },
+                {
+                  "label": "Remunerative work",
+                  "value": "remunerative-work"
+                },
+                {
+                  "label": "Residence and presence conditions",
+                  "value": "residence-and-presence-conditions"
+                },
+                {
+                  "label": "Retirement pensions",
+                  "value": "retirement-pensions"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews",
+                  "value": "revisions-supersessions-and-reviews"
+                },
+                {
+                  "label": "Safeguarding vulnerable groups",
+                  "value": "safeguarding-vulnerable-groups"
+                },
+                {
+                  "label": "Special educational needs",
+                  "value": "special-educational-needs"
+                },
+                {
+                  "label": "Students",
+                  "value": "students"
+                },
+                {
+                  "label": "Tax credits and family credit",
+                  "value": "tax-credits-and-family-credit"
+                },
+                {
+                  "label": "Transport",
+                  "value": "transport"
+                },
+                {
+                  "label": "Tribunal procedure and practice",
+                  "value": "tribunal-procedure-and-practice"
+                },
+                {
+                  "label": "Universal Credit",
+                  "value": "universal-credit"
+                },
+                {
+                  "label": "Vaccine damage payments",
+                  "value": "vaccine-damage-payments"
+                },
+                {
+                  "label": "War pensions and armed forces compensation",
+                  "value": "war-pensions-and-armed-forces-compensation"
+                },
+                {
+                  "label": "Winter fuel payments",
+                  "value": "winter-fuel-payments"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases",
+                  "value": "transport-driving-instructor-cases"
+                },
+                {
+                  "label": "Transport - Quality Contract Schemes",
+                  "value": "transport-quality-contract-schemes"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_categories_name",
+              "name": "Categories name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_sub_categories",
+              "name": "Sub-categories",
+              "type": "text",
+              "preposition": "sub-categorised as",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Benefits for children - benefit increases for children",
+                  "value": "benefits-for-children-benefit-increases-for-children"
+                },
+                {
+                  "label": "Benefits for children - child benefit",
+                  "value": "benefits-for-children-child-benefit"
+                },
+                {
+                  "label": "Benefits for children - child care credit",
+                  "value": "benefits-for-children-child-care-credit"
+                },
+                {
+                  "label": "Benefits for children - guardians allowance",
+                  "value": "benefits-for-children-guardians-allowance"
+                },
+                {
+                  "label": "Benefits for children - other",
+                  "value": "benefits-for-children-other"
+                },
+                {
+                  "label": "Bereavement and death benefits - bereaved parents allowance",
+                  "value": "bereavement-and-death-benefits-bereaved-parents-allowance"
+                },
+                {
+                  "label": "Bereavement and death benefits - bereavement payments",
+                  "value": "bereavement-and-death-benefits-bereavement-payments"
+                },
+                {
+                  "label": "Bereavement and death benefits - other",
+                  "value": "bereavement-and-death-benefits-other"
+                },
+                {
+                  "label": "Bereavement and death benefits - social fund funeral payments",
+                  "value": "bereavement-and-death-benefits-social-fund-funeral-payments"
+                },
+                {
+                  "label": "Bereavement and death benefits - widowed mothers allowance",
+                  "value": "bereavement-and-death-benefits-widowed-mothers-allowance"
+                },
+                {
+                  "label": "Bereavement and death benefits - widowers allowance",
+                  "value": "bereavement-and-death-benefits-widowers-allowance"
+                },
+                {
+                  "label": "Bereavement and death benefits - widowers pension",
+                  "value": "bereavement-and-death-benefits-widowers-pension"
+                },
+                {
+                  "label": "Bereavement and death benefits - widows allowance",
+                  "value": "bereavement-and-death-benefits-widows-allowance"
+                },
+                {
+                  "label": "Bereavement and death benefits - widows payments",
+                  "value": "bereavement-and-death-benefits-widows-payments"
+                },
+                {
+                  "label": "Bereavement and death benefits - widows pension",
+                  "value": "bereavement-and-death-benefits-widows-pension"
+                },
+                {
+                  "label": "Capital - Children's capital",
+                  "value": "capital-children-s-capital"
+                },
+                {
+                  "label": "Capital - Disregards: business assets",
+                  "value": "capital-disregards-business-assets"
+                },
+                {
+                  "label": "Capital - Disregards: home and other premises",
+                  "value": "capital-disregards-home-and-other-premises"
+                },
+                {
+                  "label": "Capital - Disregards: other",
+                  "value": "capital-disregards-other"
+                },
+                {
+                  "label": "Capital - Disregards: pensions, policies and similar",
+                  "value": "capital-disregards-pensions-policies-and-similar"
+                },
+                {
+                  "label": "Capital - Disregards: personal injury/other compensation",
+                  "value": "capital-disregards-personal-injury-other-compensation"
+                },
+                {
+                  "label": "Capital - Income as capital",
+                  "value": "capital-income-as-capital"
+                },
+                {
+                  "label": "Capital - Joint holdings",
+                  "value": "capital-joint-holdings"
+                },
+                {
+                  "label": "Capital - Notional Capital: deprivation",
+                  "value": "capital-notional-capital-deprivation"
+                },
+                {
+                  "label": "Capital - Notional Capital: diminishment",
+                  "value": "capital-notional-capital-diminishment"
+                },
+                {
+                  "label": "Capital - Notional Capital: other",
+                  "value": "capital-notional-capital-other"
+                },
+                {
+                  "label": "Capital - Other",
+                  "value": "capital-other"
+                },
+                {
+                  "label": "Capital - Ownership/Possession",
+                  "value": "capital-ownership-possession"
+                },
+                {
+                  "label": "Capital - Valuation",
+                  "value": "capital-valuation"
+                },
+                {
+                  "label": "Care standards - other",
+                  "value": "care-standards-other"
+                },
+                {
+                  "label": "Care standards - registration of childcare providers",
+                  "value": "care-standards-registration-of-childcare-providers"
+                },
+                {
+                  "label": "Care Standards - registration of children's homes, residential family centres or fostering or adoption agencies",
+                  "value": "care-standards-registration-of-children-s-homes-residential-family-centres-or-fostering-or-adoption-agencies"
+                },
+                {
+                  "label": "Care standards - registration of health care",
+                  "value": "care-standards-registration-of-health-care"
+                },
+                {
+                  "label": "Care standards - registration of independent schools",
+                  "value": "care-standards-registration-of-independent-schools"
+                },
+                {
+                  "label": "Care standards - registration of social care (including nursing agencies)",
+                  "value": "care-standards-registration-of-social-care-including-nursing-agencies"
+                },
+                {
+                  "label": "Care standards - registration of social workers and other social care workers",
+                  "value": "care-standards-registration-of-social-workers-and-other-social-care-workers"
+                },
+                {
+                  "label": "Child support - applications",
+                  "value": "child-support-applications"
+                },
+                {
+                  "label": "Child support - calculation of income",
+                  "value": "child-support-calculation-of-income"
+                },
+                {
+                  "label": "Child support - cancellation",
+                  "value": "child-support-cancellation"
+                },
+                {
+                  "label": "Child support - child",
+                  "value": "child-support-child"
+                },
+                {
+                  "label": "Child support - effective date",
+                  "value": "child-support-effective-date"
+                },
+                {
+                  "label": "Child support - housing costs",
+                  "value": "child-support-housing-costs"
+                },
+                {
+                  "label": "Child support - interim maintenance assessments/decisions",
+                  "value": "child-support-interim-maintenance-assessments-decisions"
+                },
+                {
+                  "label": "Child support - jurisdiction",
+                  "value": "child-support-jurisdiction"
+                },
+                {
+                  "label": "Child support - maintenance assessments/calculations",
+                  "value": "child-support-maintenance-assessments-calculations"
+                },
+                {
+                  "label": "Child support - other",
+                  "value": "child-support-other"
+                },
+                {
+                  "label": "Child support - periods of assessment/calculation",
+                  "value": "child-support-periods-of-assessment-calculation"
+                },
+                {
+                  "label": "Child support - property and capital transfers",
+                  "value": "child-support-property-and-capital-transfers"
+                },
+                {
+                  "label": "Child support - receipt of benefit",
+                  "value": "child-support-receipt-of-benefit"
+                },
+                {
+                  "label": "Child support - travel to work costs",
+                  "value": "child-support-travel-to-work-costs"
+                },
+                {
+                  "label": "Child support - tribunal practice",
+                  "value": "child-support-tribunal-practice"
+                },
+                {
+                  "label": "Child support - variation/departure directions: diversion of income",
+                  "value": "child-support-variation-departure-directions-diversion-of-income"
+                },
+                {
+                  "label": "Child support - variation/departure directions: just and equitable",
+                  "value": "child-support-variation-departure-directions-just-and-equitable"
+                },
+                {
+                  "label": "Child support - variation/departure directions: lifestyle inconsistent",
+                  "value": "child-support-variation-departure-directions-lifestyle-inconsistent"
+                },
+                {
+                  "label": "Child support - variation/departure directions: other",
+                  "value": "child-support-variation-departure-directions-other"
+                },
+                {
+                  "label": "Claims and payments - appointment to act",
+                  "value": "claims-and-payments-appointment-to-act"
+                },
+                {
+                  "label": "Claims and payments - benefits claimed",
+                  "value": "claims-and-payments-benefits-claimed"
+                },
+                {
+                  "label": "Claims and payments - good cause",
+                  "value": "claims-and-payments-good-cause"
+                },
+                {
+                  "label": "Claims and payments - jurisdiction",
+                  "value": "claims-and-payments-jurisdiction"
+                },
+                {
+                  "label": "Claims and payments - late claim: housing and council tax benefits",
+                  "value": "claims-and-payments-late-claim-housing-and-council-tax-benefits"
+                },
+                {
+                  "label": "Claims and payments - late claim: other benefits",
+                  "value": "claims-and-payments-late-claim-other-benefits"
+                },
+                {
+                  "label": "Claims and payments - late payment",
+                  "value": "claims-and-payments-late-payment"
+                },
+                {
+                  "label": "Claims and payments - other",
+                  "value": "claims-and-payments-other"
+                },
+                {
+                  "label": "Claims and payments - period of claim",
+                  "value": "claims-and-payments-period-of-claim"
+                },
+                {
+                  "label": "Claims and payments - required information",
+                  "value": "claims-and-payments-required-information"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice  - Commissioners practice",
+                  "value": "commissioners-procedure-and-practice-commissioners-practice"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - Commissioners jurisdiction",
+                  "value": "commissioners-procedure-and-practice-commissioners-jurisdiction"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - Commissioners/ Upper Tribunal procedure",
+                  "value": "commissioners-procedure-and-practice-commissioners-upper-tribunal-procedure"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - evidence",
+                  "value": "commissioners-procedure-and-practice-evidence"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - fair hearing",
+                  "value": "commissioners-procedure-and-practice-fair-hearing"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - lapsing of appeals",
+                  "value": "commissioners-procedure-and-practice-lapsing-of-appeals"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - leave to appeal to Commissioners",
+                  "value": "commissioners-procedure-and-practice-leave-to-appeal-to-commissioners"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - leave to appeal to higher courts",
+                  "value": "commissioners-procedure-and-practice-leave-to-appeal-to-higher-courts"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - notice requirements",
+                  "value": "commissioners-procedure-and-practice-notice-requirements"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - other",
+                  "value": "commissioners-procedure-and-practice-other"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - precedence of decisions",
+                  "value": "commissioners-procedure-and-practice-precedence-of-decisions"
+                },
+                {
+                  "label": "Commissioners’ procedure and practice - representatives",
+                  "value": "commissioners-procedure-and-practice-representatives"
+                },
+                {
+                  "label": "Compensation recovery - cause of payment of benefits",
+                  "value": "compensation-recovery-cause-of-payment-of-benefits"
+                },
+                {
+                  "label": "Compensation recovery - other",
+                  "value": "compensation-recovery-other"
+                },
+                {
+                  "label": "Compensation recovery - scope of appeal",
+                  "value": "compensation-recovery-scope-of-appeal"
+                },
+                {
+                  "label": "Consumer credit - licensing",
+                  "value": "consumer-credit-licensing"
+                },
+                {
+                  "label": "Consumer credit - money laundering",
+                  "value": "consumer-credit-money-laundering"
+                },
+                {
+                  "label": "Consumer credit - other",
+                  "value": "consumer-credit-other"
+                },
+                {
+                  "label": "Contributions and credits - contribution conditions",
+                  "value": "contributions-and-credits-contribution-conditions"
+                },
+                {
+                  "label": "Contributions and credits - contributions",
+                  "value": "contributions-and-credits-contributions"
+                },
+                {
+                  "label": "Contributions and credits - credits and credited earnings",
+                  "value": "contributions-and-credits-credits-and-credited-earnings"
+                },
+                {
+                  "label": "Contributions and credits - other",
+                  "value": "contributions-and-credits-other"
+                },
+                {
+                  "label": "Criminal injuries compensation - claims",
+                  "value": "criminal-injuries-compensation-claims"
+                },
+                {
+                  "label": "Criminal injuries compensation - other",
+                  "value": "criminal-injuries-compensation-other"
+                },
+                {
+                  "label": "Criminal injuries compensation - reduction and withholding of awards",
+                  "value": "criminal-injuries-compensation-reduction-and-withholding-of-awards"
+                },
+                {
+                  "label": "DLA, AA, MA: general - accommodation costs",
+                  "value": "dla-aa-ma-general-accommodation-costs"
+                },
+                {
+                  "label": "DLA, AA, MA: general - age conditions",
+                  "value": "dla-aa-ma-general-age-conditions"
+                },
+                {
+                  "label": "DLA, AA, MA: general - other",
+                  "value": "dla-aa-ma-general-other"
+                },
+                {
+                  "label": "DLA, AA, MA: general - qualifying periods",
+                  "value": "dla-aa-ma-general-qualifying-periods"
+                },
+                {
+                  "label": "DLA, AA, MA: general - severe behavioural problems",
+                  "value": "dla-aa-ma-general-severe-behavioural-problems"
+                },
+                {
+                  "label": "DLA, AA, MA: general - severe mental disablement",
+                  "value": "dla-aa-ma-general-severe-mental-disablement"
+                },
+                {
+                  "label": "DLA, AA, MA: general - severe physical disablement",
+                  "value": "dla-aa-ma-general-severe-physical-disablement"
+                },
+                {
+                  "label": "DLA, AA, MA: general - terminal illness",
+                  "value": "dla-aa-ma-general-terminal-illness"
+                },
+                {
+                  "label": "DLA, AA: personal care - “cooking test”",
+                  "value": "dla-aa-personal-care-cooking-test"
+                },
+                {
+                  "label": "DLA, AA: personal care - attention: children under 16",
+                  "value": "dla-aa-personal-care-attention-children-under-16"
+                },
+                {
+                  "label": "DLA, AA: personal care - attention: daytime",
+                  "value": "dla-aa-personal-care-attention-daytime"
+                },
+                {
+                  "label": "DLA, AA: personal care - attention: night",
+                  "value": "dla-aa-personal-care-attention-night"
+                },
+                {
+                  "label": "DLA, AA: personal care - bodily functions",
+                  "value": "dla-aa-personal-care-bodily-functions"
+                },
+                {
+                  "label": "DLA, AA: personal care - other",
+                  "value": "dla-aa-personal-care-other"
+                },
+                {
+                  "label": "DLA, AA: personal care - supervision: children",
+                  "value": "dla-aa-personal-care-supervision-children"
+                },
+                {
+                  "label": "DLA, AA: personal care - supervision: continual daytime",
+                  "value": "dla-aa-personal-care-supervision-continual-daytime"
+                },
+                {
+                  "label": "DLA, AA: personal care - supervision: watching over at night",
+                  "value": "dla-aa-personal-care-supervision-watching-over-at-night"
+                },
+                {
+                  "label": "DLA, MA: mobility - children under 16",
+                  "value": "dla-ma-mobility-children-under-16"
+                },
+                {
+                  "label": "DLA, MA: mobility - exertion endangering life",
+                  "value": "dla-ma-mobility-exertion-endangering-life"
+                },
+                {
+                  "label": "DLA, MA: mobility - guidance or supervision",
+                  "value": "dla-ma-mobility-guidance-or-supervision"
+                },
+                {
+                  "label": "DLA, MA: mobility - inability to walk",
+                  "value": "dla-ma-mobility-inability-to-walk"
+                },
+                {
+                  "label": "DLA, MA: mobility - other",
+                  "value": "dla-ma-mobility-other"
+                },
+                {
+                  "label": "DLA, MA: mobility - virtual inability to walk",
+                  "value": "dla-ma-mobility-virtual-inability-to-walk"
+                },
+                {
+                  "label": "Earnings and other income - benefits",
+                  "value": "earnings-and-other-income-benefits"
+                },
+                {
+                  "label": "Earnings and other income - calculation: employed",
+                  "value": "earnings-and-other-income-calculation-employed"
+                },
+                {
+                  "label": "Earnings and other income - calculation: self employed",
+                  "value": "earnings-and-other-income-calculation-self-employed"
+                },
+                {
+                  "label": "Earnings and other income - capital treated as income",
+                  "value": "earnings-and-other-income-capital-treated-as-income"
+                },
+                {
+                  "label": "Earnings and other income - children's Income",
+                  "value": "earnings-and-other-income-children-s-income"
+                },
+                {
+                  "label": "Earnings and other income - Councillors",
+                  "value": "earnings-and-other-income-councillors"
+                },
+                {
+                  "label": "Earnings and other income - disregards",
+                  "value": "earnings-and-other-income-disregards"
+                },
+                {
+                  "label": "Earnings and other income - notional earnings",
+                  "value": "earnings-and-other-income-notional-earnings"
+                },
+                {
+                  "label": "Earnings and other income - notional income",
+                  "value": "earnings-and-other-income-notional-income"
+                },
+                {
+                  "label": "Earnings and other income - other",
+                  "value": "earnings-and-other-income-other"
+                },
+                {
+                  "label": "Earnings and other income - other income and payments",
+                  "value": "earnings-and-other-income-other-income-and-payments"
+                },
+                {
+                  "label": "Earnings and other income - termination and compensation payments",
+                  "value": "earnings-and-other-income-termination-and-compensation-payments"
+                },
+                {
+                  "label": "Employment and support allowance - attending medical examination",
+                  "value": "employment-and-support-allowance-attending-medical-examination"
+                },
+                {
+                  "label": "Employment and support allowance - contributory ESA",
+                  "value": "employment-and-support-allowance-contributory-esa"
+                },
+                {
+                  "label": "Employment and support allowance - effect of work",
+                  "value": "employment-and-support-allowance-effect-of-work"
+                },
+                {
+                  "label": "Employment and support allowance - exemptions from test",
+                  "value": "employment-and-support-allowance-exemptions-from-test"
+                },
+                {
+                  "label": "Employment and support allowance - income-related ESA",
+                  "value": "employment-and-support-allowance-income-related-esa"
+                },
+                {
+                  "label": "Employment and support allowance - medical evidence",
+                  "value": "employment-and-support-allowance-medical-evidence"
+                },
+                {
+                  "label": "Employment and support allowance - other",
+                  "value": "employment-and-support-allowance-other"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 1: mobilising unaided",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-1-mobilising-unaided"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 2: standing and sitting",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-2-standing-and-sitting"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 3: reaching",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-3-reaching"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 4: picking up and moving/transferring",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-4-picking-up-and-moving-transferring"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 5: manual dexterity",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-5-manual-dexterity"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 6: making self understood",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-6-making-self-understood"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 7: understanding communication",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-7-understanding-communication"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 8: navigation and maintaining safety",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-8-navigation-and-maintaining-safety"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 9: absence or loss of bowel/bladder control",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-9-absence-or-loss-of-bowel-bladder-control"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 10 :consiousness during waking moments",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-10-consiousness-during-waking-moments"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 11: learning tasks",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-11-learning-tasks"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 12: awareness of everyday hazards",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-12-awareness-of-everyday-hazards"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 13: initiating and completing personal action",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-13-initiating-and-completing-personal-action"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 14: coping with change",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-14-coping-with-change"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 15: getting about",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-15-getting-about"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 16: coping with social engagement",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-16-coping-with-social-engagement"
+                },
+                {
+                  "label": "Employment and support allowance - Post 28.3.11 WCA activity 17: appropriateness of behaviour with other people",
+                  "value": "employment-and-support-allowance-post-28-3-11-wca-activity-17-appropriateness-of-behaviour-with-other-people"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 1: walking",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-1-walking"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 2: standing and sitting",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-2-standing-and-sitting"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 3: bending or kneeling",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-3-bending-or-kneeling"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 4: reaching",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-4-reaching"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 5: picking up and moving",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-5-picking-up-and-moving"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 6: manual dexterity",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-6-manual-dexterity"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 7: speech",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-7-speech"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 8: hearing",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-8-hearing"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 9: vision",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-9-vision"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 10: continence",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-10-continence"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 11: remaining conscious",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-11-remaining-conscious"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 12: learning or comprehension",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-12-learning-or-comprehension"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 13: hazard awareness",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-13-hazard-awareness"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 14: memory and concentration",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-14-memory-and-concentration"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 15: execution of tasks",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-15-execution-of-tasks"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 16: initiating and sustaining personal action",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-16-initiating-and-sustaining-personal-action"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 17: coping with change",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-17-coping-with-change"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 18: getting about",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-18-getting-about"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 19: coping with social situations",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-19-coping-with-social-situations"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 20: propriety of behaviour",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-20-propriety-of-behaviour"
+                },
+                {
+                  "label": "Employment and support allowance - Pre 28.3.11 WCA activity 21: dealing with other people",
+                  "value": "employment-and-support-allowance-pre-28-3-11-wca-activity-21-dealing-with-other-people"
+                },
+                {
+                  "label": "Employment and support allowance - Regulation 29",
+                  "value": "employment-and-support-allowance-regulation-29"
+                },
+                {
+                  "label": "Employment and support allowance - Regulation 35",
+                  "value": "employment-and-support-allowance-regulation-35"
+                },
+                {
+                  "label": "Employment and support allowance - the assessment phase",
+                  "value": "employment-and-support-allowance-the-assessment-phase"
+                },
+                {
+                  "label": "Employment and support allowance - WCA: general",
+                  "value": "employment-and-support-allowance-wca-general"
+                },
+                {
+                  "label": "Employment and support allowance - Work-Focused Health Related Assessment (WFHRA): general",
+                  "value": "employment-and-support-allowance-work-focused-health-related-assessment-wfhra-general"
+                },
+                {
+                  "label": "Employment and support allowance - Work-Related Activity Assessment (WRAA): general",
+                  "value": "employment-and-support-allowance-work-related-activity-assessment-wraa-general"
+                },
+                {
+                  "label": "Employment and support allowance - WRAA Schedule 3 prescribed activities",
+                  "value": "employment-and-support-allowance-wraa-schedule-3-prescribed-activities"
+                },
+                {
+                  "label": "European Union law - Agreement on European Economic Area",
+                  "value": "european-union-law-agreement-on-european-economic-area"
+                },
+                {
+                  "label": "European Union law - Association and Cooperation Agreements",
+                  "value": "european-union-law-association-and-cooperation-agreements"
+                },
+                {
+                  "label": "European Union law - Council directive 76/207/EEC",
+                  "value": "european-union-law-council-directive-76-207-eec"
+                },
+                {
+                  "label": "European Union law - Council directive 79/7/EEC",
+                  "value": "european-union-law-council-directive-79-7-eec"
+                },
+                {
+                  "label": "European Union law - Council directive 86/378",
+                  "value": "european-union-law-council-directive-86-378"
+                },
+                {
+                  "label": "European Union law - Council regulation 574/72/EEC",
+                  "value": "european-union-law-council-regulation-574-72-eec"
+                },
+                {
+                  "label": "European Union law - Council regulations 1408/71/EEC and (EC) 883/2004",
+                  "value": "european-union-law-council-regulations-1408-71-eec-and-ec-883-2004"
+                },
+                {
+                  "label": "European Union law - discrimination by gender",
+                  "value": "european-union-law-discrimination-by-gender"
+                },
+                {
+                  "label": "European Union law - discrimination by nationality",
+                  "value": "european-union-law-discrimination-by-nationality"
+                },
+                {
+                  "label": "European Union law - free movement",
+                  "value": "european-union-law-free-movement"
+                },
+                {
+                  "label": "European Union law - other",
+                  "value": "european-union-law-other"
+                },
+                {
+                  "label": "European Union law - references to European Court",
+                  "value": "european-union-law-references-to-european-court"
+                },
+                {
+                  "label": "European Union law - workers",
+                  "value": "european-union-law-workers"
+                },
+                {
+                  "label": "Housing and council tax benefits - backdating",
+                  "value": "housing-and-council-tax-benefits-backdating"
+                },
+                {
+                  "label": "Housing and council tax benefits - council tax benefit",
+                  "value": "housing-and-council-tax-benefits-council-tax-benefit"
+                },
+                {
+                  "label": "Housing and council tax benefits - liability, commerciality and contrivance [regulations 8 and 9]",
+                  "value": "housing-and-council-tax-benefits-liability-commerciality-and-contrivance-regulations-8-and-9"
+                },
+                {
+                  "label": "Housing and council tax benefits - non-dependants",
+                  "value": "housing-and-council-tax-benefits-non-dependants"
+                },
+                {
+                  "label": "Housing and council tax benefits - occupation of the home, two homes and temporary absence [regulation 7]",
+                  "value": "housing-and-council-tax-benefits-occupation-of-the-home-two-homes-and-temporary-absence-regulation-7"
+                },
+                {
+                  "label": "Housing and council tax benefits - other",
+                  "value": "housing-and-council-tax-benefits-other"
+                },
+                {
+                  "label": "Housing and council tax benefits - payments that are eligible for HB [regulation 12 and Schedule 1]",
+                  "value": "housing-and-council-tax-benefits-payments-that-are-eligible-for-hb-regulation-12-and-schedule-1"
+                },
+                {
+                  "label": "Housing and council tax benefits - recovery of overpayments",
+                  "value": "housing-and-council-tax-benefits-recovery-of-overpayments"
+                },
+                {
+                  "label": "Housing and council tax benefits - rent restrictions",
+                  "value": "housing-and-council-tax-benefits-rent-restrictions"
+                },
+                {
+                  "label": "Human rights law - application of Human Rights Act",
+                  "value": "human-rights-law-application-of-human-rights-act"
+                },
+                {
+                  "label": "Human rights law - article 3 (torture)",
+                  "value": "human-rights-law-article-3-torture"
+                },
+                {
+                  "label": "Human rights law - article 6 (fair hearing)",
+                  "value": "human-rights-law-article-6-fair-hearing"
+                },
+                {
+                  "label": "Human rights law - article 8 (private and family life)",
+                  "value": "human-rights-law-article-8-private-and-family-life"
+                },
+                {
+                  "label": "Human rights law - article 9 (freedom of thought)",
+                  "value": "human-rights-law-article-9-freedom-of-thought"
+                },
+                {
+                  "label": "Human rights law - article 10 (freedom of expression)",
+                  "value": "human-rights-law-article-10-freedom-of-expression"
+                },
+                {
+                  "label": "Human rights law - article 12 (right to marry)",
+                  "value": "human-rights-law-article-12-right-to-marry"
+                },
+                {
+                  "label": "Human rights law - article 13 (redress)",
+                  "value": "human-rights-law-article-13-redress"
+                },
+                {
+                  "label": "Human rights law - article 14 (non-discrimination)",
+                  "value": "human-rights-law-article-14-non-discrimination"
+                },
+                {
+                  "label": "Human rights law - other",
+                  "value": "human-rights-law-other"
+                },
+                {
+                  "label": "Human rights law - other Convention articles",
+                  "value": "human-rights-law-other-convention-articles"
+                },
+                {
+                  "label": "Human rights law - Protocol 1 (protection of property)",
+                  "value": "human-rights-law-protocol-1-protection-of-property"
+                },
+                {
+                  "label": "Incapacity benefits - activity 1: walking",
+                  "value": "incapacity-benefits-activity-1-walking"
+                },
+                {
+                  "label": "Incapacity benefits - activity 2: stairs",
+                  "value": "incapacity-benefits-activity-2-stairs"
+                },
+                {
+                  "label": "Incapacity benefits -  activity 3: sitting",
+                  "value": "incapacity-benefits-activity-3-sitting"
+                },
+                {
+                  "label": "Incapacity benefits - activity 4: standing",
+                  "value": "incapacity-benefits-activity-4-standing"
+                },
+                {
+                  "label": "Incapacity benefits - activity 5: rising",
+                  "value": "incapacity-benefits-activity-5-rising"
+                },
+                {
+                  "label": "Incapacity benefits - activity 6: bending or kneeling",
+                  "value": "incapacity-benefits-activity-6-bending-or-kneeling"
+                },
+                {
+                  "label": "Incapacity benefits - activity 7: hands",
+                  "value": "incapacity-benefits-activity-7-hands"
+                },
+                {
+                  "label": "Incapacity benefits - activity 8: lifting and carrying",
+                  "value": "incapacity-benefits-activity-8-lifting-and-carrying"
+                },
+                {
+                  "label": "Incapacity benefits - activity 9: reaching",
+                  "value": "incapacity-benefits-activity-9-reaching"
+                },
+                {
+                  "label": "Incapacity benefits - activity 10: speech",
+                  "value": "incapacity-benefits-activity-10-speech"
+                },
+                {
+                  "label": "Incapacity benefits - activity 11: hearing",
+                  "value": "incapacity-benefits-activity-11-hearing"
+                },
+                {
+                  "label": "Incapacity benefits - activity 12: vision",
+                  "value": "incapacity-benefits-activity-12-vision"
+                },
+                {
+                  "label": "Incapacity benefits - activity 13: continence",
+                  "value": "incapacity-benefits-activity-13-continence"
+                },
+                {
+                  "label": "Incapacity benefits - activity 14: consciousness",
+                  "value": "incapacity-benefits-activity-14-consciousness"
+                },
+                {
+                  "label": "Incapacity benefits - attending medical examination",
+                  "value": "incapacity-benefits-attending-medical-examination"
+                },
+                {
+                  "label": "Incapacity benefits - awt/pca: general",
+                  "value": "incapacity-benefits-awt-pca-general"
+                },
+                {
+                  "label": "Incapacity benefits - exemptions from test",
+                  "value": "incapacity-benefits-exemptions-from-test"
+                },
+                {
+                  "label": "Incapacity benefits - incapable of work",
+                  "value": "incapacity-benefits-incapable-of-work"
+                },
+                {
+                  "label": "Incapacity benefits - increase for adult dependant",
+                  "value": "incapacity-benefits-increase-for-adult-dependant"
+                },
+                {
+                  "label": "Incapacity benefits - medical evidence",
+                  "value": "incapacity-benefits-medical-evidence"
+                },
+                {
+                  "label": "Incapacity benefits - mental health descriptors",
+                  "value": "incapacity-benefits-mental-health-descriptors"
+                },
+                {
+                  "label": "Incapacity benefits - other",
+                  "value": "incapacity-benefits-other"
+                },
+                {
+                  "label": "Incapacity benefits - periods of incapacity",
+                  "value": "incapacity-benefits-periods-of-incapacity"
+                },
+                {
+                  "label": "Income support and state pension credits - applicable amounts",
+                  "value": "income-support-and-state-pension-credits-applicable-amounts"
+                },
+                {
+                  "label": "Income support and state pension credits - deductions",
+                  "value": "income-support-and-state-pension-credits-deductions"
+                },
+                {
+                  "label": "Income support and state pension credits - housing costs",
+                  "value": "income-support-and-state-pension-credits-housing-costs"
+                },
+                {
+                  "label": "Income support and state pension credits - other: income support",
+                  "value": "income-support-and-state-pension-credits-other-income-support"
+                },
+                {
+                  "label": "Income support and state pension credits - other: state pension credit",
+                  "value": "income-support-and-state-pension-credits-other-state-pension-credit"
+                },
+                {
+                  "label": "Income support and state pension credits - urgent cases",
+                  "value": "income-support-and-state-pension-credits-urgent-cases"
+                },
+                {
+                  "label": "Industrial accidents - arising out of employment",
+                  "value": "industrial-accidents-arising-out-of-employment"
+                },
+                {
+                  "label": "Industrial accidents - declaration of accident",
+                  "value": "industrial-accidents-declaration-of-accident"
+                },
+                {
+                  "label": "Industrial accidents - in the course of employment",
+                  "value": "industrial-accidents-in-the-course-of-employment"
+                },
+                {
+                  "label": "Industrial accidents - industrial accident",
+                  "value": "industrial-accidents-industrial-accident"
+                },
+                {
+                  "label": "Industrial accidents - other",
+                  "value": "industrial-accidents-other"
+                },
+                {
+                  "label": "Industrial accidents - treated as in employment",
+                  "value": "industrial-accidents-treated-as-in-employment"
+                },
+                {
+                  "label": "Industrial diseases - A10 (deafness)",
+                  "value": "industrial-diseases-a10-deafness"
+                },
+                {
+                  "label": "Industrial diseases - A11 (vibration white finger)",
+                  "value": "industrial-diseases-a11-vibration-white-finger"
+                },
+                {
+                  "label": "Industrial diseases - A12 (carpel tunnel syndrome)",
+                  "value": "industrial-diseases-a12-carpel-tunnel-syndrome"
+                },
+                {
+                  "label": "Industrial diseases - A4 (task-specific focal dystonia)",
+                  "value": "industrial-diseases-a4-task-specific-focal-dystonia"
+                },
+                {
+                  "label": "Industrial diseases - A6 (beat knee)",
+                  "value": "industrial-diseases-a6-beat-knee"
+                },
+                {
+                  "label": "Industrial diseases - A8 (tenosynovitis)",
+                  "value": "industrial-diseases-a8-tenosynovitis"
+                },
+                {
+                  "label": "Industrial diseases - B diseases (biological agents)",
+                  "value": "industrial-diseases-b-diseases-biological-agents"
+                },
+                {
+                  "label": "Industrial diseases - C diseases (chemical agents)",
+                  "value": "industrial-diseases-c-diseases-chemical-agents"
+                },
+                {
+                  "label": "Industrial diseases - D1 (pneumoconiosis)",
+                  "value": "industrial-diseases-d1-pneumoconiosis"
+                },
+                {
+                  "label": "Industrial diseases - D1, D3 (asbestosis, silicosis)",
+                  "value": "industrial-diseases-d1-d3-asbestosis-silicosis"
+                },
+                {
+                  "label": "Industrial diseases - D12 (bronchitis and emphysema)",
+                  "value": "industrial-diseases-d12-bronchitis-and-emphysema"
+                },
+                {
+                  "label": "Industrial diseases - D4 (allergic rhinitis)",
+                  "value": "industrial-diseases-d4-allergic-rhinitis"
+                },
+                {
+                  "label": "Industrial diseases - D6 (nasal cancer)",
+                  "value": "industrial-diseases-d6-nasal-cancer"
+                },
+                {
+                  "label": "Industrial diseases - D7 (asthma)",
+                  "value": "industrial-diseases-d7-asthma"
+                },
+                {
+                  "label": "Industrial diseases - D8-11 (lung cancer)",
+                  "value": "industrial-diseases-d8-11-lung-cancer"
+                },
+                {
+                  "label": "Industrial diseases - date of onset",
+                  "value": "industrial-diseases-date-of-onset"
+                },
+                {
+                  "label": "Industrial diseases - other",
+                  "value": "industrial-diseases-other"
+                },
+                {
+                  "label": "Industrial diseases - other A diseases (physical agents)",
+                  "value": "industrial-diseases-other-a-diseases-physical-agents"
+                },
+                {
+                  "label": "Industrial diseases - other D diseases (miscellaneous)",
+                  "value": "industrial-diseases-other-d-diseases-miscellaneous"
+                },
+                {
+                  "label": "Industrial injuries benefits - aggregation of assessments",
+                  "value": "industrial-injuries-benefits-aggregation-of-assessments"
+                },
+                {
+                  "label": "Industrial injuries benefits - assessment of disablement",
+                  "value": "industrial-injuries-benefits-assessment-of-disablement"
+                },
+                {
+                  "label": "Industrial injuries benefits - industrial death benefit",
+                  "value": "industrial-injuries-benefits-industrial-death-benefit"
+                },
+                {
+                  "label": "Industrial injuries benefits - other",
+                  "value": "industrial-injuries-benefits-other"
+                },
+                {
+                  "label": "Industrial injuries benefits - reduced earnings allowance",
+                  "value": "industrial-injuries-benefits-reduced-earnings-allowance"
+                },
+                {
+                  "label": "Industrial injuries benefits - special hardship allowance",
+                  "value": "industrial-injuries-benefits-special-hardship-allowance"
+                },
+                {
+                  "label": "Industrial injuries benefits - workmen’s compensation supplement",
+                  "value": "industrial-injuries-benefits-workmen-s-compensation-supplement"
+                },
+                {
+                  "label": "Information rights - Data protection",
+                  "value": "information-rights-data-protection"
+                },
+                {
+                  "label": "Information rights - Environmental information - exceptions",
+                  "value": "information-rights-environmental-information-exceptions"
+                },
+                {
+                  "label": "Information rights - Environmental information - general",
+                  "value": "information-rights-environmental-information-general"
+                },
+                {
+                  "label": "Information rights - Freedom of information - absolute exemptions",
+                  "value": "information-rights-freedom-of-information-absolute-exemptions"
+                },
+                {
+                  "label": "Information rights - Freedom of Information - exceptions",
+                  "value": "information-rights-freedom-of-information-exceptions"
+                },
+                {
+                  "label": "Information rights - Freedom of information - public authority response",
+                  "value": "information-rights-freedom-of-information-public-authority-response"
+                },
+                {
+                  "label": "Information rights - Freedom of information - public interest test",
+                  "value": "information-rights-freedom-of-information-public-interest-test"
+                },
+                {
+                  "label": "Information rights - Freedom of information - qualified exemptions",
+                  "value": "information-rights-freedom-of-information-qualified-exemptions"
+                },
+                {
+                  "label": "Information rights - Freedom of information - right of access",
+                  "value": "information-rights-freedom-of-information-right-of-access"
+                },
+                {
+                  "label": "Information rights - Information rights: practice and procedure",
+                  "value": "information-rights-information-rights-practice-and-procedure"
+                },
+                {
+                  "label": "Jobseekers allowance - applicable amounts",
+                  "value": "jobseekers-allowance-applicable-amounts"
+                },
+                {
+                  "label": "Jobseekers allowance - availability for employment",
+                  "value": "jobseekers-allowance-availability-for-employment"
+                },
+                {
+                  "label": "Jobseekers allowance - deductions",
+                  "value": "jobseekers-allowance-deductions"
+                },
+                {
+                  "label": "Jobseekers allowance - housing costs",
+                  "value": "jobseekers-allowance-housing-costs"
+                },
+                {
+                  "label": "Jobseekers allowance - joint claims",
+                  "value": "jobseekers-allowance-joint-claims"
+                },
+                {
+                  "label": "Jobseekers allowance - other",
+                  "value": "jobseekers-allowance-other"
+                },
+                {
+                  "label": "Jobseekers allowance - urgent cases",
+                  "value": "jobseekers-allowance-urgent-cases"
+                },
+                {
+                  "label": "Jobseekers allowance - voluntary unemployment",
+                  "value": "jobseekers-allowance-voluntary-unemployment"
+                },
+                {
+                  "label": "Marriage, civil partnerships and living together - joint claims",
+                  "value": "marriage-civil-partnerships-and-living-together-joint-claims"
+                },
+                {
+                  "label": "Marriage, civil partnerships and living together - living together as husband and wife or civil partners",
+                  "value": "marriage-civil-partnerships-and-living-together-living-together-as-husband-and-wife-or-civil-partners"
+                },
+                {
+                  "label": "Marriage, civil partnerships and living together - other",
+                  "value": "marriage-civil-partnerships-and-living-together-other"
+                },
+                {
+                  "label": "Marriage, civil partnerships and living together - validity of marriage",
+                  "value": "marriage-civil-partnerships-and-living-together-validity-of-marriage"
+                },
+                {
+                  "label": "Maternity benefits - other",
+                  "value": "maternity-benefits-other"
+                },
+                {
+                  "label": "Maternity benefits - social fund maternity payment",
+                  "value": "maternity-benefits-social-fund-maternity-payment"
+                },
+                {
+                  "label": "Maternity benefits - state maternity allowance",
+                  "value": "maternity-benefits-state-maternity-allowance"
+                },
+                {
+                  "label": "Members of a household - children",
+                  "value": "members-of-a-household-children"
+                },
+                {
+                  "label": "Members of a household - other",
+                  "value": "members-of-a-household-other"
+                },
+                {
+                  "label": "Members of a household - temporarily living away",
+                  "value": "members-of-a-household-temporarily-living-away"
+                },
+                {
+                  "label": "Members of a household - treated as not being members",
+                  "value": "members-of-a-household-treated-as-not-being-members"
+                },
+                {
+                  "label": "Other current benefits - carer’s allowance",
+                  "value": "other-current-benefits-carer-s-allowance"
+                },
+                {
+                  "label": "Other current benefits - severe disablement allowance",
+                  "value": "other-current-benefits-severe-disablement-allowance"
+                },
+                {
+                  "label": "Other previous benefits - family income supplement",
+                  "value": "other-previous-benefits-family-income-supplement"
+                },
+                {
+                  "label": "Other previous benefits - industrial death benefit",
+                  "value": "other-previous-benefits-industrial-death-benefit"
+                },
+                {
+                  "label": "Other previous benefits - industrial injury benefit",
+                  "value": "other-previous-benefits-industrial-injury-benefit"
+                },
+                {
+                  "label": "Other previous benefits - invalidity benefit",
+                  "value": "other-previous-benefits-invalidity-benefit"
+                },
+                {
+                  "label": "Other previous benefits - other",
+                  "value": "other-previous-benefits-other"
+                },
+                {
+                  "label": "Other previous benefits - sickness benefit",
+                  "value": "other-previous-benefits-sickness-benefit"
+                },
+                {
+                  "label": "Other previous benefits - supplementary benefit",
+                  "value": "other-previous-benefits-supplementary-benefit"
+                },
+                {
+                  "label": "Other previous benefits - unemployment benefit",
+                  "value": "other-previous-benefits-unemployment-benefit"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 1: preparing food",
+                  "value": "personal-independence-payment-daily-living-activities-activity-1-preparing-food"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 2: taking nutrition",
+                  "value": "personal-independence-payment-daily-living-activities-activity-2-taking-nutrition"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 3: managing therapy or monitoring a health condition",
+                  "value": "personal-independence-payment-daily-living-activities-activity-3-managing-therapy-or-monitoring-a-health-condition"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 4: washing and bathing",
+                  "value": "personal-independence-payment-daily-living-activities-activity-4-washing-and-bathing"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 5: managing toilet needs or incontinence",
+                  "value": "personal-independence-payment-daily-living-activities-activity-5-managing-toilet-needs-or-incontinence"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 6: dressing and undressing",
+                  "value": "personal-independence-payment-daily-living-activities-activity-6-dressing-and-undressing"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 7: communicating verbally",
+                  "value": "personal-independence-payment-daily-living-activities-activity-7-communicating-verbally"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 8: reading and understanding signs, symbols and words",
+                  "value": "personal-independence-payment-daily-living-activities-activity-8-reading-and-understanding-signs-symbols-and-words"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 9: engaging with other people face to face",
+                  "value": "personal-independence-payment-daily-living-activities-activity-9-engaging-with-other-people-face-to-face"
+                },
+                {
+                  "label": "Personal independence payment – daily living activities - Activity 10: making budgeting decisions",
+                  "value": "personal-independence-payment-daily-living-activities-activity-10-making-budgeting-decisions"
+                },
+                {
+                  "label": "Personal independence payment – mobility activities - Mobility activity 1: planning and following journeys",
+                  "value": "personal-independence-payment-mobility-activities-mobility-activity-1-planning-and-following-journeys"
+                },
+                {
+                  "label": "Personal independence payment – mobility activities - Mobility activity 2: moving around",
+                  "value": "personal-independence-payment-mobility-activities-mobility-activity-2-moving-around"
+                },
+                {
+                  "label": "Recovery of overpayments - amount recoverable",
+                  "value": "recovery-of-overpayments-amount-recoverable"
+                },
+                {
+                  "label": "Recovery of overpayments - civil penalties",
+                  "value": "recovery-of-overpayments-civil-penalties"
+                },
+                {
+                  "label": "Recovery of overpayments - excess council tax benefit",
+                  "value": "recovery-of-overpayments-excess-council-tax-benefit"
+                },
+                {
+                  "label": "Recovery of overpayments - failure to disclose",
+                  "value": "recovery-of-overpayments-failure-to-disclose"
+                },
+                {
+                  "label": "Recovery of overpayments - liability of third parties",
+                  "value": "recovery-of-overpayments-liability-of-third-parties"
+                },
+                {
+                  "label": "Recovery of overpayments - misrepresentation",
+                  "value": "recovery-of-overpayments-misrepresentation"
+                },
+                {
+                  "label": "Recovery of overpayments - offset of benefits",
+                  "value": "recovery-of-overpayments-offset-of-benefits"
+                },
+                {
+                  "label": "Recovery of overpayments - other",
+                  "value": "recovery-of-overpayments-other"
+                },
+                {
+                  "label": "Remunerative work - calculation of hours of work",
+                  "value": "remunerative-work-calculation-of-hours-of-work"
+                },
+                {
+                  "label": "Remunerative work - engaged in work",
+                  "value": "remunerative-work-engaged-in-work"
+                },
+                {
+                  "label": "Remunerative work - expectation of payment",
+                  "value": "remunerative-work-expectation-of-payment"
+                },
+                {
+                  "label": "Remunerative work - other",
+                  "value": "remunerative-work-other"
+                },
+                {
+                  "label": "Remunerative work - treated as not in remunerative work",
+                  "value": "remunerative-work-treated-as-not-in-remunerative-work"
+                },
+                {
+                  "label": "Residence and presence conditions - habitual residence",
+                  "value": "residence-and-presence-conditions-habitual-residence"
+                },
+                {
+                  "label": "Residence and presence conditions - ordinary residence",
+                  "value": "residence-and-presence-conditions-ordinary-residence"
+                },
+                {
+                  "label": "Residence and presence conditions - other",
+                  "value": "residence-and-presence-conditions-other"
+                },
+                {
+                  "label": "Residence and presence conditions - persons from abroad",
+                  "value": "residence-and-presence-conditions-persons-from-abroad"
+                },
+                {
+                  "label": "Residence and presence conditions - persons subject to immigration control",
+                  "value": "residence-and-presence-conditions-persons-subject-to-immigration-control"
+                },
+                {
+                  "label": "Residence and presence conditions - presence",
+                  "value": "residence-and-presence-conditions-presence"
+                },
+                {
+                  "label": "Residence and presence conditions - residence",
+                  "value": "residence-and-presence-conditions-residence"
+                },
+                {
+                  "label": "Residence and presence conditions - right to reside",
+                  "value": "residence-and-presence-conditions-right-to-reside"
+                },
+                {
+                  "label": "Residence and presence conditions - temporary absence from Great Britain",
+                  "value": "residence-and-presence-conditions-temporary-absence-from-great-britain"
+                },
+                {
+                  "label": "Retirement pensions - deferred retirement",
+                  "value": "retirement-pensions-deferred-retirement"
+                },
+                {
+                  "label": "Retirement pensions - increases for spouse or dependant",
+                  "value": "retirement-pensions-increases-for-spouse-or-dependant"
+                },
+                {
+                  "label": "Retirement pensions - other",
+                  "value": "retirement-pensions-other"
+                },
+                {
+                  "label": "Retirement pensions -additional pensions and SERPS",
+                  "value": "retirement-pensions-additional-pensions-and-serps"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - change of circumstances",
+                  "value": "revisions-supersessions-and-reviews-change-of-circumstances"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - date of effect of decision",
+                  "value": "revisions-supersessions-and-reviews-date-of-effect-of-decision"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - ignorance of material fact",
+                  "value": "revisions-supersessions-and-reviews-ignorance-of-material-fact"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - late applications",
+                  "value": "revisions-supersessions-and-reviews-late-applications"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - mistake as to material fact",
+                  "value": "revisions-supersessions-and-reviews-mistake-as-to-material-fact"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - official error",
+                  "value": "revisions-supersessions-and-reviews-official-error"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - other",
+                  "value": "revisions-supersessions-and-reviews-other"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - reviews under the 1992 Act",
+                  "value": "revisions-supersessions-and-reviews-reviews-under-the-1992-act"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - revision: general",
+                  "value": "revisions-supersessions-and-reviews-revision-general"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - supersession: general",
+                  "value": "revisions-supersessions-and-reviews-supersession-general"
+                },
+                {
+                  "label": "Revisions, supersessions and reviews - supersession: incapacity",
+                  "value": "revisions-supersessions-and-reviews-supersession-incapacity"
+                },
+                {
+                  "label": "Safeguarding vulnerable groups - Adults’ barred list",
+                  "value": "safeguarding-vulnerable-groups-adults-barred-list"
+                },
+                {
+                  "label": "Safeguarding vulnerable groups - Children’s barred list",
+                  "value": "safeguarding-vulnerable-groups-children-s-barred-list"
+                },
+                {
+                  "label": "Safeguarding vulnerable groups - other lists",
+                  "value": "safeguarding-vulnerable-groups-other-lists"
+                },
+                {
+                  "label": "Special educational needs - description of special educational needs",
+                  "value": "special-educational-needs-description-of-special-educational-needs"
+                },
+                {
+                  "label": "Special educational needs - discontinuing a statement",
+                  "value": "special-educational-needs-discontinuing-a-statement"
+                },
+                {
+                  "label": "Special educational needs - failure to make a statement",
+                  "value": "special-educational-needs-failure-to-make-a-statement"
+                },
+                {
+                  "label": "Special educational needs - other",
+                  "value": "special-educational-needs-other"
+                },
+                {
+                  "label": "Special educational needs - special educational provision - naming school",
+                  "value": "special-educational-needs-special-educational-provision-naming-school"
+                },
+                {
+                  "label": "Special educational needs - failure to prepare an EHC plan under Children & Families Act 2014",
+                  "value": "special-educational-needs-failure-to-prepare-an-ehc-plan-under-children-families-act-2014"
+                },
+                {
+                  "label": "Special educational needs - special educational provision - naming school or other institution in EHC plan",
+                  "value": "special-educational-needs-special-educational-provision-naming-school-or-other-institution-in-ehc-plan"
+                },
+                {
+                  "label": "Special educational needs - ceasing to maintain EHC plan",
+                  "value": "special-educational-needs-ceasing-to-maintain-ehc-plan"
+                },
+                {
+                  "label": "Special educational needs - special educational provision - other",
+                  "value": "special-educational-needs-special-educational-provision-other"
+                },
+                {
+                  "label": "Students - full-time course",
+                  "value": "students-full-time-course"
+                },
+                {
+                  "label": "Students - housing benefit exemption",
+                  "value": "students-housing-benefit-exemption"
+                },
+                {
+                  "label": "Students - loans and grant income",
+                  "value": "students-loans-and-grant-income"
+                },
+                {
+                  "label": "Students - other",
+                  "value": "students-other"
+                },
+                {
+                  "label": "Tax credits and family credit - couples and joint claims",
+                  "value": "tax-credits-and-family-credit-couples-and-joint-claims"
+                },
+                {
+                  "label": "Tax credits and family credit - deductions and income assessments",
+                  "value": "tax-credits-and-family-credit-deductions-and-income-assessments"
+                },
+                {
+                  "label": "Tax credits and family credit - disabled workers",
+                  "value": "tax-credits-and-family-credit-disabled-workers"
+                },
+                {
+                  "label": "Tax credits and family credit - housing costs",
+                  "value": "tax-credits-and-family-credit-housing-costs"
+                },
+                {
+                  "label": "Tax credits and family credit - other",
+                  "value": "tax-credits-and-family-credit-other"
+                },
+                {
+                  "label": "Tax credits and family credit - recovery, penalties and interest",
+                  "value": "tax-credits-and-family-credit-recovery-penalties-and-interest"
+                },
+                {
+                  "label": "Tax credits and family credit - responsible for child and child care credits",
+                  "value": "tax-credits-and-family-credit-responsible-for-child-and-child-care-credits"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Check tests",
+                  "value": "transport-driving-instructor-cases-check-tests"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Fit and proper person – assault",
+                  "value": "transport-driving-instructor-cases-fit-and-proper-person-assault"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Fit and proper person – dishonesty",
+                  "value": "transport-driving-instructor-cases-fit-and-proper-person-dishonesty"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Fit and proper person – drugs",
+                  "value": "transport-driving-instructor-cases-fit-and-proper-person-drugs"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Fit and proper person – general",
+                  "value": "transport-driving-instructor-cases-fit-and-proper-person-general"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Fit and proper person – imprisonment",
+                  "value": "transport-driving-instructor-cases-fit-and-proper-person-imprisonment"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Fit and proper person – indecency",
+                  "value": "transport-driving-instructor-cases-fit-and-proper-person-indecency"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Fit and proper person – motoring offences",
+                  "value": "transport-driving-instructor-cases-fit-and-proper-person-motoring-offences"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases - Trainee licences",
+                  "value": "transport-driving-instructor-cases-trainee-licences"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases – Other",
+                  "value": "transport-driving-instructor-cases-other"
+                },
+                {
+                  "label": "Transport - Driving Instructor cases – Procedure",
+                  "value": "transport-driving-instructor-cases-procedure"
+                },
+                {
+                  "label": "Transport - driving standards",
+                  "value": "transport-driving-standards"
+                },
+                {
+                  "label": "Transport - other",
+                  "value": "transport-other"
+                },
+                {
+                  "label": "Transport - Quality Contract Schemes - Bus",
+                  "value": "transport-quality-contract-schemes-bus"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Call-up letters",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-call-up-letters"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Decisions and reasons",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-decisions-and-reasons"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Discretionary Issues",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-discretionary-issues"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Disqualification   ",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-disqualification"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Financial Standing",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-financial-standing"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - International issues",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-international-issues"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Professional Competence",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-professional-competence"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Public Inquiries and Impounding Hearings",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-public-inquiries-and-impounding-hearings"
+                },
+                {
+                  "label": "Transport - traffic Commissioner and DoE (NI) Appeals - Public Service Vehicles",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-public-service-vehicles"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Regulatory Action",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-regulatory-action"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Repute & Fitness",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-repute-fitness"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Restricted Licences",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-restricted-licences"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Revocation, Suspension and Curtailment",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-revocation-suspension-and-curtailment"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Termination by law, withdrawal or surrender",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-termination-by-law-withdrawal-or-surrender"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals - Transport Managers",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-transport-managers"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals – Applications",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-applications"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals – Directors",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-directors"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals – Establishment",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-establishment"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals – Impounding",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-impounding"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner and DoE (NI) Appeals – Other",
+                  "value": "transport-traffic-commissioner-and-doe-ni-appeals-other"
+                },
+                {
+                  "label": "Transport - Traffic Commissioner cases",
+                  "value": "transport-traffic-commissioner-cases"
+                },
+                {
+                  "label": "Tribunal procedure and practice - costs",
+                  "value": "tribunal-procedure-and-practice-costs"
+                },
+                {
+                  "label": "Tribunal procedure and practice - evidence",
+                  "value": "tribunal-procedure-and-practice-evidence"
+                },
+                {
+                  "label": "Tribunal procedure and practice - fair hearing",
+                  "value": "tribunal-procedure-and-practice-fair-hearing"
+                },
+                {
+                  "label": "Tribunal procedure and practice - judicial review",
+                  "value": "tribunal-procedure-and-practice-judicial-review"
+                },
+                {
+                  "label": "Tribunal procedure and practice - lapsing of appeals",
+                  "value": "tribunal-procedure-and-practice-lapsing-of-appeals"
+                },
+                {
+                  "label": "Tribunal procedure and practice - leave/permission to appeal",
+                  "value": "tribunal-procedure-and-practice-leave-permission-to-appeal"
+                },
+                {
+                  "label": "Tribunal procedure and practice - notice requirements",
+                  "value": "tribunal-procedure-and-practice-notice-requirements"
+                },
+                {
+                  "label": "Tribunal procedure and practice - other",
+                  "value": "tribunal-procedure-and-practice-other"
+                },
+                {
+                  "label": "Tribunal procedure and practice - precedence of decisions",
+                  "value": "tribunal-procedure-and-practice-precedence-of-decisions"
+                },
+                {
+                  "label": "Tribunal procedure and practice - record of proceedings",
+                  "value": "tribunal-procedure-and-practice-record-of-proceedings"
+                },
+                {
+                  "label": "Tribunal procedure and practice - representatives",
+                  "value": "tribunal-procedure-and-practice-representatives"
+                },
+                {
+                  "label": "Tribunal procedure and practice - set aside applications",
+                  "value": "tribunal-procedure-and-practice-set-aside-applications"
+                },
+                {
+                  "label": "Tribunal procedure and practice - statements of reasons",
+                  "value": "tribunal-procedure-and-practice-statements-of-reasons"
+                },
+                {
+                  "label": "Tribunal procedure and practice - tribunal jurisdiction",
+                  "value": "tribunal-procedure-and-practice-tribunal-jurisdiction"
+                },
+                {
+                  "label": "Tribunal procedure and practice - tribunal membership and procedure",
+                  "value": "tribunal-procedure-and-practice-tribunal-membership-and-procedure"
+                },
+                {
+                  "label": "Tribunal procedure and practice - tribunal practice",
+                  "value": "tribunal-procedure-and-practice-tribunal-practice"
+                },
+                {
+                  "label": "War pensions and armed forces compensation - Armed Forces Compensation Scheme",
+                  "value": "war-pensions-and-armed-forces-compensation-armed-forces-compensation-scheme"
+                },
+                {
+                  "label": "War pensions and armed forces compensation - other",
+                  "value": "war-pensions-and-armed-forces-compensation-other"
+                },
+                {
+                  "label": "War pensions and armed forces compensation - procedure",
+                  "value": "war-pensions-and-armed-forces-compensation-procedure"
+                },
+                {
+                  "label": "War pensions and armed forces compensation - war pensions – assessment",
+                  "value": "war-pensions-and-armed-forces-compensation-war-pensions-assessment"
+                },
+                {
+                  "label": "War pensions and armed forces compensation - war pensions – entitlement",
+                  "value": "war-pensions-and-armed-forces-compensation-war-pensions-entitlement"
+                },
+                {
+                  "label": "War pensions and armed forces compensation - war pensions – specified decisions",
+                  "value": "war-pensions-and-armed-forces-compensation-war-pensions-specified-decisions"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_sub_categories_name",
+              "name": "Sub-categories name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_judges",
+              "name": "Judges",
+              "type": "text",
+              "preposition": "by judge",
+              "display_as_result_metadata": false,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Agnew, C",
+                  "value": "agnew-c"
+                },
+                {
+                  "label": "Angus, R",
+                  "value": "angus-r"
+                },
+                {
+                  "label": "Bano, A",
+                  "value": "bano-a"
+                },
+                {
+                  "label": "Beech, J",
+                  "value": "beech-j"
+                },
+                {
+                  "label": "Broderick, M",
+                  "value": "broderick-m"
+                },
+                {
+                  "label": "Brown, M",
+                  "value": "brown-m"
+                },
+                {
+                  "label": "Brunner, K",
+                  "value": "brunner-k"
+                },
+                {
+                  "label": "Burns, D",
+                  "value": "burns-d"
+                },
+                {
+                  "label": "Burton, F",
+                  "value": "burton-f"
+                },
+                {
+                  "label": "Caldwell, M",
+                  "value": "Caldwell-m"
+                },
+                {
+                  "label": "Carlisle, H",
+                  "value": "carlisle-h"
+                },
+                {
+                  "label": "Carnwath, R",
+                  "value": "carnwath-r"
+                },
+                {
+                  "label": "Charles, W",
+                  "value": "charles-w"
+                },
+                {
+                  "label": "Cole, G",
+                  "value": "cole-g"
+                },
+                {
+                  "label": "Farbey, J",
+                  "value": "farbey-j"
+                },
+                {
+                  "label": "Fellner, C",
+                  "value": "fellner-c"
+                },
+                {
+                  "label": "Fordham, M",
+                  "value": "fordham-m"
+                },
+                {
+                  "label": "Gamble, A",
+                  "value": "gamble-a"
+                },
+                {
+                  "label": "Goodman, M",
+                  "value": "goodman-m"
+                },
+                {
+                  "label": "Gray, P",
+                  "value": "gray-p"
+                },
+                {
+                  "label": "Green, A",
+                  "value": "green-a"
+                },
+                {
+                  "label": "Grey, E",
+                  "value": "grey-e"
+                },
+                {
+                  "label": "Hallett, V",
+                  "value": "hallett-v"
+                },
+                {
+                  "label": "Harris, M",
+                  "value": "harris-m"
+                },
+                {
+                  "label": "Heald, M",
+                  "value": "heald-m"
+                },
+                {
+                  "label": "Heggs, R",
+                  "value": "heggs-r"
+                },
+                {
+                  "label": "Hemingway, M",
+                  "value": "hemingway-m"
+                },
+                {
+                  "label": "Henty, J",
+                  "value": "henty-j"
+                },
+                {
+                  "label": "Hickinbottom, G",
+                  "value": "hickinbottom-g"
+                },
+                {
+                  "label": "Hinchliffe, M",
+                  "value": "hinchliffe-m"
+                },
+                {
+                  "label": "Hoolahan, A",
+                  "value": "hoolahan-a"
+                },
+                {
+                  "label": "Howell, P",
+                  "value": "howell-p"
+                },
+                {
+                  "label": "Humphrey, A",
+                  "value": "humphrey-a"
+                },
+                {
+                  "label": "Jacobs, E",
+                  "value": "jacobs-e"
+                },
+                {
+                  "label": "Johnson, M",
+                  "value": "johnson-m"
+                },
+                {
+                  "label": "Jupp, E",
+                  "value": "jupp-e"
+                },
+                {
+                  "label": "Knowles, G",
+                  "value": "knowles-g"
+                },
+                {
+                  "label": "Lane, S",
+                  "value": "lane-s"
+                },
+                {
+                  "label": "Levenson, H",
+                  "value": "levenson-h"
+                },
+                {
+                  "label": "Lloyd-Davies, A",
+                  "value": "lloyd-davies-a"
+                },
+                {
+                  "label": "Lunney, J",
+                  "value": "lunney-j"
+                },
+                {
+                  "label": "Machin, K",
+                  "value": "machin-k"
+                },
+                {
+                  "label": "Mark, M",
+                  "value": "mark-m"
+                },
+                {
+                  "label": "Markus, K",
+                  "value": "markus-k"
+                },
+                {
+                  "label": "Martin, J",
+                  "value": "martin-j"
+                },
+                {
+                  "label": "May, D",
+                  "value": "may-d"
+                },
+                {
+                  "label": "McKenna, A",
+                  "value": "mckenna-a"
+                },
+                {
+                  "label": "Mesher, J",
+                  "value": "mesher-j"
+                },
+                {
+                  "label": "Mitchell, E",
+                  "value": "mitchell-e"
+                },
+                {
+                  "label": "Mitchell, J",
+                  "value": "mitchell-j"
+                },
+                {
+                  "label": "Mitchell, JG",
+                  "value": "mitchell-jg"
+                },
+                {
+                  "label": "Morcom, J",
+                  "value": "morcom-j"
+                },
+                {
+                  "label": "Mullan, K",
+                  "value": "mullan-k"
+                },
+                {
+                  "label": "Ovey, E",
+                  "value": "ovey-e"
+                },
+                {
+                  "label": "Pacey, S",
+                  "value": "pacey-s"
+                },
+                {
+                  "label": "Paines, N",
+                  "value": "paines-n"
+                },
+                {
+                  "label": "Parker, T",
+                  "value": "parker-t"
+                },
+                {
+                  "label": "Pearl, D",
+                  "value": "pearl-d"
+                },
+                {
+                  "label": "Perez, R",
+                  "value": "perez-r"
+                },
+                {
+                  "label": "Powell, J",
+                  "value": "powell-j"
+                },
+                {
+                  "label": "Poynter, R",
+                  "value": "poynter-r"
+                },
+                {
+                  "label": "Ramsay, A",
+                  "value": "ramsay-a"
+                },
+                {
+                  "label": "Reith, D",
+                  "value": "reith-d"
+                },
+                {
+                  "label": "Rice, D",
+                  "value": "rice-d"
+                },
+                {
+                  "label": "Rowland, M",
+                  "value": "rowland-m"
+                },
+                {
+                  "label": "Rowley, A",
+                  "value": "rowley-a"
+                },
+                {
+                  "label": "Sanders, R",
+                  "value": "sanders-r"
+                },
+                {
+                  "label": "Skinner, J",
+                  "value": "skinner-j"
+                },
+                {
+                  "label": "Smith, R",
+                  "value": "smith-r"
+                },
+                {
+                  "label": "Sutherland Williams, M",
+                  "value": "sutherland-williams-m"
+                },
+                {
+                  "label": "Stockman, O",
+                  "value": "stockman-o"
+                },
+                {
+                  "label": "Thomas, J",
+                  "value": "thomas-j"
+                },
+                {
+                  "label": "Three Judge Panel",
+                  "value": "three-judge-panel"
+                },
+                {
+                  "label": "Turnbull, C",
+                  "value": "turnbull-c"
+                },
+                {
+                  "label": "Walker, P",
+                  "value": "walker-p"
+                },
+                {
+                  "label": "Walker, W",
+                  "value": "walker-w"
+                },
+                {
+                  "label": "Ward, C",
+                  "value": "ward-c"
+                },
+                {
+                  "label": "West, M",
+                  "value": "west-m"
+                },
+                {
+                  "label": "Wheeler, A",
+                  "value": "wheeler-a"
+                },
+                {
+                  "label": "White, R",
+                  "value": "white-r"
+                },
+                {
+                  "label": "Wikeley, N",
+                  "value": "wikeley-n"
+                },
+                {
+                  "label": "Williams, D",
+                  "value": "williams-d"
+                },
+                {
+                  "label": "Wright, S",
+                  "value": "wright-s"
+                }
+              ]
+            },
+            {
+              "key": "tribunal_decision_judges_name",
+              "name": "Judges name",
+              "type": "text",
+              "display_as_result_metadata": true,
+              "filterable": false
+            },
+            {
+              "key": "tribunal_decision_decision_date",
+              "name": "Decision date",
+              "short_name": "Decided",
+              "type": "date",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ],
+          "default_documents_per_page": 50
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/administrative-appeals-tribunal-decisions",
+        "web_url": "https://www.gov.uk/administrative-appeals-tribunal-decisions"
+      }
     ]
   },
   "schema_name": "specialist_document",

--- a/formats/specialist_document/publisher/edition_links.json
+++ b/formats/specialist_document/publisher/edition_links.json
@@ -2,10 +2,14 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "additionalProperties": false,
+  "required": [
+    "finder"
+  ],
   "properties": {
     "finder": {
       "description": "The finder for this specialist document.",
       "$ref": "#/definitions/guid_list",
+      "minItems": 1,
       "maxItems": 1
     }
   }


### PR DESCRIPTION
This is built on top of https://github.com/alphagov/govuk-content-schemas/pull/582 so won't be mergable until that is merged in and this is rebased against any changes.

This includes edition links inside frontend and notification schemas.

It also includes description and maxItems values in those schemas. Logic being that description is useful for people reading these schemas to know the purpose of the links, maxItems is useful as can anticipate how to handle the link. Originally I had it include required and minItems but I realised that we can't guarantee these are included. If this aspect of this PR is controversial let me know and I can break it out into a separate one for discussion.