### PR TITLE
Allow `parent_taxons` in the edition links for taxons

### DIFF
--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -11,7 +11,7 @@
       "additionalProperties": false,
       "properties": {
         "parent_taxons": {
-          "description": "The list of taxon parents.",
+          "description": "The list of taxon parents (DEPRECATED: use the edition links instead)",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -295,6 +295,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "parent_taxons": {
+          "description": "The list of taxon parents.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "$ref": "#/definitions/guid_list"
         }

--- a/formats/taxon/publisher/edition_links.json
+++ b/formats/taxon/publisher/edition_links.json
@@ -4,7 +4,7 @@
   "additionalProperties": false,
   "properties": {
     "parent_taxons": {
-      "description": "The list of taxon parents (DEPRECATED: use the edition links instead)",
+      "description": "The list of taxon parents.",
       "$ref": "#/definitions/guid_list"
     }
   }


### PR DESCRIPTION
Content tagger currently has to make separate API calls to write the content and creating the links. Since we now have draft links, we'll be able to do this in one call (and have workflow).

https://trello.com/c/8YH5l9kF