### PR TITLE
Add government-fronted dependent application

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ def dependentApplications = [
   ['email-alert-service', true],
   ['finder-frontend', true],
   ['frontend', false],
+  ['government-frontend', true],
   ['hmrc-manuals-api', false],
   ['licencefinder', false],
   ['manuals-frontend', false],


### PR DESCRIPTION
Run schema tests against government-frontend.

Requires https://github.com/alphagov/govuk-puppet/pull/5654 to be deployed for the tests to pass.