### PR TITLE
Delete fact check id attribute

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -459,10 +459,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -436,10 +436,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -320,10 +320,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -499,10 +499,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -467,10 +467,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -83,10 +83,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -354,10 +354,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -463,10 +463,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -440,10 +440,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -324,10 +324,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -476,10 +476,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -453,10 +453,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -337,10 +337,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -551,10 +551,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -511,10 +511,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -95,10 +95,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -398,10 +398,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -656,10 +656,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -630,10 +630,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -77,10 +77,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -511,10 +511,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -474,10 +474,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -448,10 +448,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -77,10 +77,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -332,10 +332,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -508,10 +508,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -476,10 +476,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -83,10 +83,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -363,10 +363,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -510,10 +510,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -482,10 +482,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -84,10 +84,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -387,10 +387,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -499,10 +499,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -476,10 +476,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -360,10 +360,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -483,10 +483,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -445,10 +445,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -90,10 +90,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -332,10 +332,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -506,10 +506,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -477,10 +477,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -83,10 +83,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -361,10 +361,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -542,10 +542,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -516,10 +516,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -77,10 +77,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -400,10 +400,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -453,10 +453,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -430,10 +430,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -314,10 +314,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -456,10 +456,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -433,10 +433,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -317,10 +317,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -460,10 +460,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -437,10 +437,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -321,10 +321,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -459,10 +459,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -436,10 +436,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -320,10 +320,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -471,10 +471,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -448,10 +448,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -332,10 +332,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -475,10 +475,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -452,10 +452,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -336,10 +336,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -477,10 +477,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -457,10 +457,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -347,10 +347,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -478,10 +478,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -455,10 +455,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -339,10 +339,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -491,10 +491,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -468,10 +468,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -352,10 +352,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -485,10 +485,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -446,10 +446,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -90,10 +90,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -330,10 +330,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -471,10 +471,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -445,10 +445,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -80,10 +80,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -329,10 +329,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -473,10 +473,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -447,10 +447,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -80,10 +80,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -331,10 +331,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -520,10 +520,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -497,10 +497,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -381,10 +381,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -500,10 +500,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -457,10 +457,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -98,10 +98,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -344,10 +344,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -468,10 +468,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -445,10 +445,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -329,10 +329,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -518,10 +518,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -491,10 +491,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -379,10 +379,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -541,10 +541,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -502,10 +502,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -93,10 +93,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -386,10 +386,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -503,10 +503,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -461,10 +461,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -97,10 +97,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -372,10 +372,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -495,10 +495,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -464,10 +464,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -82,10 +82,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -351,10 +351,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -452,10 +452,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -429,10 +429,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -313,10 +313,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -465,10 +465,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -438,10 +438,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -78,10 +78,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -322,10 +322,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -502,10 +502,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -479,10 +479,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -363,10 +363,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -475,10 +475,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -440,10 +440,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -86,10 +86,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -324,10 +324,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -521,10 +521,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -498,10 +498,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -382,10 +382,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -482,10 +482,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -454,10 +454,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -349,10 +349,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -520,10 +520,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -472,10 +472,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -103,10 +103,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -359,10 +359,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -477,10 +477,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -454,10 +454,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -341,10 +341,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -489,10 +489,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -466,10 +466,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -350,10 +350,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -463,10 +463,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -440,10 +440,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -324,10 +324,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -464,10 +464,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -437,10 +437,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -78,10 +78,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -325,10 +325,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -463,10 +463,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -436,10 +436,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -78,10 +78,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -320,10 +320,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -463,10 +463,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -440,10 +440,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -324,10 +324,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -484,10 +484,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -461,10 +461,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -345,10 +345,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -507,10 +507,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -481,10 +481,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -77,10 +77,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -365,10 +365,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -468,10 +468,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -442,10 +442,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -77,10 +77,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -326,10 +326,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -476,10 +476,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -453,10 +453,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -337,10 +337,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -459,10 +459,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -436,10 +436,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -74,10 +74,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -320,10 +320,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -486,10 +486,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -454,10 +454,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -83,10 +83,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -341,10 +341,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -26,10 +26,6 @@
         "auth_bypass_ids": {
           "$ref": "#/definitions/guid_list",
           "description": "A list of ids that will allow access to this item for non-authenticated users"
-        },
-        "fact_check_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED - A list of ids that will allow access to this item for fact checking."
         }
       }
     },

--- a/formats/transaction/publisher_v2/examples/transaction.json
+++ b/formats/transaction/publisher_v2/examples/transaction.json
@@ -1,6 +1,6 @@
 {
   "access_limited": {
-    "fact_check_ids": [
+    "auth_bypass_ids": [
       "a0454ad5-3697-4e29-bf47-c51e6ed01051"
     ]
   },


### PR DESCRIPTION
Remove reference to fact_check_ids attribute - this was replaced by auth_bypass_ids in
#541.

[DO NOT MERGE] Do not merge until https://github.com/alphagov/publishing-api/pull/842 and its related PRs have been deployed.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id