### PR TITLE
Remove business support finder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,6 @@ REPOSITORY = 'govuk-content-schemas'
 // buildProject script - if so it will report its success individually, so this
 // job does not need to wait for it.
 def dependentApplications = [
-  ['businesssupportfinder', false],
   ['calendars', false],
   ['calculators', false],
   ['collections', true],

--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -570,7 +570,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -610,7 +609,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -547,7 +547,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -587,7 +586,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -431,7 +431,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -471,7 +470,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -610,7 +610,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -650,7 +649,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -578,7 +578,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -618,7 +617,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -192,7 +192,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -232,7 +231,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -465,7 +465,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -505,7 +504,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -574,7 +574,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -614,7 +613,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -551,7 +551,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -591,7 +590,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -435,7 +435,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -475,7 +474,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -587,7 +587,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -627,7 +626,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -564,7 +564,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -604,7 +603,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -448,7 +448,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -488,7 +487,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -662,7 +662,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -702,7 +701,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -622,7 +622,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -662,7 +661,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -204,7 +204,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -244,7 +243,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -509,7 +509,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -549,7 +548,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -767,7 +767,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -807,7 +806,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -741,7 +741,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -781,7 +780,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -186,7 +186,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -226,7 +225,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -622,7 +622,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -662,7 +661,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -585,7 +585,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -625,7 +624,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -559,7 +559,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -599,7 +598,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -186,7 +186,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -226,7 +225,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -443,7 +443,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -483,7 +482,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -619,7 +619,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -659,7 +658,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -587,7 +587,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -627,7 +626,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -192,7 +192,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -232,7 +231,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -474,7 +474,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -514,7 +513,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -621,7 +621,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -661,7 +660,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -593,7 +593,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -633,7 +632,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -193,7 +193,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -233,7 +232,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -498,7 +498,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -538,7 +537,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -610,7 +610,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -650,7 +649,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -587,7 +587,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -627,7 +626,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -471,7 +471,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -511,7 +510,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -594,7 +594,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -634,7 +633,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -556,7 +556,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -596,7 +595,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -199,7 +199,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -239,7 +238,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -443,7 +443,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -483,7 +482,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -617,7 +617,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -657,7 +656,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -588,7 +588,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -628,7 +627,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -192,7 +192,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -232,7 +231,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -472,7 +472,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -512,7 +511,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -653,7 +653,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -693,7 +692,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -627,7 +627,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -667,7 +666,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -186,7 +186,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -226,7 +225,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -511,7 +511,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -551,7 +550,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -564,7 +564,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -604,7 +603,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -541,7 +541,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -581,7 +580,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -425,7 +425,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -465,7 +464,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -567,7 +567,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -607,7 +606,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -544,7 +544,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -584,7 +583,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -428,7 +428,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -468,7 +467,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -571,7 +571,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -611,7 +610,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -548,7 +548,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -588,7 +587,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -432,7 +432,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -472,7 +471,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -570,7 +570,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -610,7 +609,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -547,7 +547,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -587,7 +586,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -431,7 +431,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -471,7 +470,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -582,7 +582,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -622,7 +621,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -559,7 +559,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -599,7 +598,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -443,7 +443,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -483,7 +482,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -586,7 +586,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -626,7 +625,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -563,7 +563,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -603,7 +602,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -447,7 +447,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -487,7 +486,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -588,7 +588,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -628,7 +627,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -568,7 +568,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -608,7 +607,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -458,7 +458,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -498,7 +497,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -589,7 +589,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -629,7 +628,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -566,7 +566,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -606,7 +605,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -450,7 +450,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -490,7 +489,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -602,7 +602,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -642,7 +641,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -579,7 +579,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -619,7 +618,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -463,7 +463,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -503,7 +502,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -596,7 +596,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -636,7 +635,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -557,7 +557,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -597,7 +596,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -199,7 +199,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -239,7 +238,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -441,7 +441,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -481,7 +480,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -582,7 +582,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -622,7 +621,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -556,7 +556,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -596,7 +595,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -189,7 +189,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -229,7 +228,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -440,7 +440,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -480,7 +479,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -584,7 +584,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -624,7 +623,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -558,7 +558,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -598,7 +597,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -189,7 +189,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -229,7 +228,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -442,7 +442,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -482,7 +481,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -631,7 +631,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -671,7 +670,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -608,7 +608,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -648,7 +647,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -492,7 +492,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -532,7 +531,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -611,7 +611,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -651,7 +650,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -568,7 +568,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -608,7 +607,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -207,7 +207,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -247,7 +246,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -455,7 +455,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -495,7 +494,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -579,7 +579,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -619,7 +618,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -556,7 +556,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -596,7 +595,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -440,7 +440,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -480,7 +479,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -629,7 +629,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -669,7 +668,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -602,7 +602,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -642,7 +641,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -490,7 +490,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -530,7 +529,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -652,7 +652,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -692,7 +691,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -613,7 +613,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -653,7 +652,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -202,7 +202,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -242,7 +241,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -497,7 +497,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -537,7 +536,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -614,7 +614,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -654,7 +653,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -572,7 +572,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -612,7 +611,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -206,7 +206,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -246,7 +245,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -483,7 +483,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -523,7 +522,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -606,7 +606,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -646,7 +645,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -575,7 +575,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -615,7 +614,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -191,7 +191,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -231,7 +230,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -462,7 +462,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -502,7 +501,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -563,7 +563,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -603,7 +602,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -540,7 +540,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -580,7 +579,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -424,7 +424,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -464,7 +463,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -576,7 +576,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -616,7 +615,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -549,7 +549,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -589,7 +588,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -187,7 +187,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -227,7 +226,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -433,7 +433,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -473,7 +472,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -613,7 +613,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -653,7 +652,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -590,7 +590,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -630,7 +629,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -474,7 +474,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -514,7 +513,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -586,7 +586,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -626,7 +625,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -551,7 +551,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -591,7 +590,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -195,7 +195,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -235,7 +234,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -435,7 +435,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -475,7 +474,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -632,7 +632,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -672,7 +671,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -609,7 +609,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -649,7 +648,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -493,7 +493,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -533,7 +532,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -593,7 +593,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -633,7 +632,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -565,7 +565,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -605,7 +604,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -460,7 +460,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -500,7 +499,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -631,7 +631,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -671,7 +670,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -583,7 +583,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -623,7 +622,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -212,7 +212,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -252,7 +251,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -470,7 +470,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -510,7 +509,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -588,7 +588,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -628,7 +627,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -565,7 +565,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -605,7 +604,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -452,7 +452,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -492,7 +491,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -600,7 +600,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -640,7 +639,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -577,7 +577,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -617,7 +616,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -461,7 +461,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -501,7 +500,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -574,7 +574,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -614,7 +613,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -551,7 +551,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -591,7 +590,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -435,7 +435,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -475,7 +474,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -575,7 +575,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -615,7 +614,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -548,7 +548,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -588,7 +587,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -187,7 +187,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -227,7 +226,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -436,7 +436,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -476,7 +475,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -574,7 +574,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -614,7 +613,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -547,7 +547,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -587,7 +586,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -187,7 +187,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -227,7 +226,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -431,7 +431,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -471,7 +470,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -574,7 +574,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -614,7 +613,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -551,7 +551,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -591,7 +590,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -435,7 +435,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -475,7 +474,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -595,7 +595,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -635,7 +634,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -572,7 +572,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -612,7 +611,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -456,7 +456,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -496,7 +495,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -618,7 +618,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -658,7 +657,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -592,7 +592,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -632,7 +631,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -186,7 +186,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -226,7 +225,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -476,7 +476,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -516,7 +515,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -579,7 +579,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -619,7 +618,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -553,7 +553,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -593,7 +592,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -186,7 +186,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -226,7 +225,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -437,7 +437,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -477,7 +476,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -587,7 +587,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -627,7 +626,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -564,7 +564,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -604,7 +603,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -448,7 +448,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -488,7 +487,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -570,7 +570,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -610,7 +609,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -547,7 +547,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -587,7 +586,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -183,7 +183,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -223,7 +222,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -431,7 +431,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -471,7 +470,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -597,7 +597,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -637,7 +636,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -565,7 +565,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -605,7 +604,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -192,7 +192,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -232,7 +231,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -452,7 +452,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -492,7 +491,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -135,7 +135,6 @@
       "description": "The application that published this item.",
       "type": "string",
       "enum": [
-        "businesssupportfinder",
         "calculators",
         "calendars",
         "collections-publisher",
@@ -175,7 +174,6 @@
         {
           "type": "string",
           "enum": [
-            "businesssupportfinder",
             "calculators",
             "calendars",
             "collections",


### PR DESCRIPTION
This commit removes business-support-finder as a publishing and rendering app, which has been replaced with finder-frontend.

All documents previously published and/or rendered by this app are now published by specialist-publisher and rendered by either finder-frontend or specialist-frontend.

Trello: https://trello.com/c/9O34PdXb/547-remove-business-support-finder-application