### PR TITLE
Fix publication links

### DIFF
--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -331,11 +331,19 @@
         "parent": {
           "$ref": "#/definitions/guid_list"
         },
+        "people": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+        },
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
         "related_statistical_data_sets": {
           "$ref": "#/definitions/guid_list"
+        },
+        "roles": {
+          "$ref": "#/definitions/guid_list",
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
         },
         "topical_events": {
           "$ref": "#/definitions/guid_list"

--- a/formats/publication/publisher/edition_links.json
+++ b/formats/publication/publisher/edition_links.json
@@ -12,11 +12,19 @@
     "parent": {
       "$ref": "#/definitions/guid_list"
     },
+    "people": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+    },
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },
     "related_statistical_data_sets": {
       "$ref": "#/definitions/guid_list"
+    },
+    "roles": {
+      "$ref": "#/definitions/guid_list",
+      "description": "Used to power Email Alert Api subscriptions for Whitehall content"
     },
     "topical_events": {
       "$ref": "#/definitions/guid_list"


### PR DESCRIPTION
Whitehall is now sending edition level roles and people links for the `Publication` format. These were in the document level links and consequently Whitehall was failing.

