### PR TITLE
Add info-frontend to downstream builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ stage("Check dependent projects against updated schema") {
     dependentBuilds[app] = {
       start = System.currentTimeMillis()
 
-      build job: "${app}/deployed-to-production",
+      build job: "/${app}/deployed-to-production",
         parameters: [
           [$class: 'BooleanParameterValue',
             name: 'IS_SCHEMA_TEST',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ def dependentApplications = [
   ['finder-frontend', true],
   ['frontend', false],
   ['hmrc-manuals-api', false],
+  ['info-frontend', true],
   ['licencefinder', false],
   ['manuals-frontend', false],
   ['manuals-publisher', false],


### PR DESCRIPTION
The info-frontend project depends on the schemas, so it should be built when the schemas change.