### PR TITLE
Don't wait for manuals-frontend to finish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ def dependentApplications = [
   ['government-frontend', true],
   ['hmrc-manuals-api', false],
   ['licencefinder', false],
-  ['manuals-frontend', false],
+  ['manuals-frontend', true],
   ['manuals-publisher', false],
   ['policy-publisher', true],
   ['publisher', true],


### PR DESCRIPTION
This application uses the shared Jenkinsfile, so it reports its status independently. We don't have to wait for this to finish in the main jenkins run.