### PR TITLE
Remove policies links

### DIFF
--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -83,10 +83,6 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
         "ministers": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -142,6 +138,10 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -13,10 +13,6 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
-        "policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
-        },
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -388,10 +388,6 @@
           "$ref": "#/definitions/guid_list",
           "description": "Used to power Email Alert Api subscriptions for Whitehall content"
         },
-        "policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
-        },
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -83,10 +83,6 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
         "ministers": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -145,6 +141,10 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -13,10 +13,6 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
-        "policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
-        },
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -88,10 +88,6 @@
         "related_policies": {
           "$ref": "#/definitions/frontend_links"
         },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
         "ministers": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -150,6 +146,10 @@
           "$ref": "#/definitions/frontend_links"
         },
         "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -18,10 +18,6 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
-        "policies": {
-          "$ref": "#/definitions/guid_list",
-          "description": "DEPRECATED in favour of related_policies @gpeng will remove"
-        },
         "ministers": {
           "$ref": "#/definitions/guid_list"
         },

--- a/formats/consultation/publisher/edition_links.json
+++ b/formats/consultation/publisher/edition_links.json
@@ -19,10 +19,6 @@
       "$ref": "#/definitions/guid_list",
       "description": "Used to power Email Alert Api subscriptions for Whitehall content"
     },
-    "policies": {
-      "$ref": "#/definitions/guid_list",
-      "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
-    },
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },

--- a/formats/consultation/publisher/links.json
+++ b/formats/consultation/publisher/links.json
@@ -6,10 +6,6 @@
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },
-    "policies": {
-      "$ref": "#/definitions/guid_list",
-      "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
-    },
     "ministers": {
       "$ref": "#/definitions/guid_list"
     },

--- a/formats/news_article/publisher/links.json
+++ b/formats/news_article/publisher/links.json
@@ -6,10 +6,6 @@
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },
-    "policies": {
-      "$ref": "#/definitions/guid_list",
-      "description": "DEPRECATED in favour of `related_policies`. @gpeng will remove"
-    },
     "ministers": {
       "$ref": "#/definitions/guid_list"
     },

--- a/formats/speech/publisher/links.json
+++ b/formats/speech/publisher/links.json
@@ -11,10 +11,6 @@
     "related_policies": {
       "$ref": "#/definitions/guid_list"
     },
-    "policies": {
-      "$ref": "#/definitions/guid_list",
-      "description": "DEPRECATED in favour of related_policies @gpeng will remove"
-    },
     "ministers": {
       "$ref": "#/definitions/guid_list"
     },


### PR DESCRIPTION
`policies` links have been renamed to `related_policies` to avoid conflicts with `reverse_links` added by publishing api (specifically `working_groups` -> `policies`).

This PR removes remaining deprecated links now that the formats involved no longer send them.