### PR TITLE
Assign lgil codes

### DIFF
--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -436,7 +436,18 @@
           "type": "integer"
         },
         "lgil_override": {
-          "description": "The Local Government Interaction List override code for the local transaction interaction",
+          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lgil_code": {
+          "description": "The Local Government Interaction List code for the local transaction interaction",
           "anyOf": [
             {
               "type": "integer"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -413,7 +413,18 @@
           "type": "integer"
         },
         "lgil_override": {
-          "description": "The Local Government Interaction List override code for the local transaction interaction",
+          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lgil_code": {
+          "description": "The Local Government Interaction List code for the local transaction interaction",
           "anyOf": [
             {
               "type": "integer"

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -291,7 +291,18 @@
           "type": "integer"
         },
         "lgil_override": {
-          "description": "The Local Government Interaction List override code for the local transaction interaction",
+          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lgil_code": {
+          "description": "The Local Government Interaction List code for the local transaction interaction",
           "anyOf": [
             {
               "type": "integer"

--- a/formats/local_transaction/frontend/examples/local_transaction.json
+++ b/formats/local_transaction/frontend/examples/local_transaction.json
@@ -309,7 +309,7 @@
   "description": "If you find a stray dog and can't contact the owner, you must report it to the council",
   "details": {
     "lgsl_code": 432,
-    "lgil_override": null,
+    "lgil_code": 101,
     "service_tiers": [
       "county",
       "unitary"

--- a/formats/local_transaction/publisher/details.json
+++ b/formats/local_transaction/publisher/details.json
@@ -12,7 +12,18 @@
       "type": "integer"
     },
     "lgil_override": {
-      "description": "The Local Government Interaction List override code for the local transaction interaction",
+      "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "lgil_code": {
+      "description": "The Local Government Interaction List code for the local transaction interaction",
       "anyOf": [
         {
           "type": "integer"


### PR DESCRIPTION
All local transactions will be assigned to a lgil_code by default. The term
"override" is therefore misleading and we should rename this variable.

This leaves lgil_override as a deprecated field until local transactions have been
republished.

https://trello.com/c/RnJC1d7a/5-assign-lgil-codes-to-all-local-transactions