### PR TITLE
Update redirect to allow any .gov.uk subdomain

### DIFF
--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -60,10 +60,10 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
       "description": "A path with optional query string and/or fragment."
     },
-    "govuk_campaign_url": {
+    "govuk_subdomain_url": {
       "type": "string",
-      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)+campaign\\.gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$",
-      "description": "A gov.uk campaign URL with optional query string and/or fragment."
+      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$",
+      "description": "A URL under the gov.uk domain with optional query string and/or fragment."
     },
     "guid": {
       "type": "string",
@@ -89,12 +89,12 @@
         },
         "destination": {
           "type": "string",
-          "oneOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/absolute_fullpath"
             },
             {
-              "$ref": "#/definitions/govuk_campaign_url"
+              "$ref": "#/definitions/govuk_subdomain_url"
             }
           ]
         },

--- a/formats/redirect/publisher_v2/examples/govuk-subdomain-redirect.json
+++ b/formats/redirect/publisher_v2/examples/govuk-subdomain-redirect.json
@@ -1,12 +1,12 @@
 {
-  "base_path": "/campaign-slug",
+  "base_path": "/some-slug",
   "publishing_app": "short-url-manager",
   "public_updated_at": "2016-09-30T12:00:00Z",
   "redirects": [
     {
-      "path": "/campaign-slug",
+      "path": "/some-slug",
       "type": "exact",
-      "destination": "https://my-campaign-title.campaign.gov.uk"
+      "destination": "https://somewhere.else.gov.uk"
     }
   ],
   "document_type": "redirect",

--- a/formats/redirect/publisher_v2/schema.json
+++ b/formats/redirect/publisher_v2/schema.json
@@ -60,10 +60,10 @@
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
       "description": "A path with optional query string and/or fragment."
     },
-    "govuk_campaign_url": {
+    "govuk_subdomain_url": {
       "type": "string",
-      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)+campaign\\.gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$",
-      "description": "A gov.uk campaign URL with optional query string and/or fragment."
+      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$",
+      "description": "A URL under the gov.uk domain with optional query string and/or fragment."
     },
     "guid": {
       "type": "string",
@@ -89,12 +89,12 @@
         },
         "destination": {
           "type": "string",
-          "oneOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/absolute_fullpath"
             },
             {
-              "$ref": "#/definitions/govuk_campaign_url"
+              "$ref": "#/definitions/govuk_subdomain_url"
             }
           ]
         },


### PR DESCRIPTION
This is part of Content Tools' 2-week blitz.

## Trello cards

* https://trello.com/c/WEZyguEc/14-2-update-govuk-content-schema
* https://trello.com/c/jmxMgLWf/21-make-it-so-that-gds-content-designers-can-implement-redirects-reliably

## In this PR

This is part of work towards allowing content designers to create
redirects without developer intervention or use of the router-data
redirect system.

Broadens the definition that allows for “external” redirects from GOV.UK
to the .campaign.gov.uk sub-domain to now allow redirects to any
.gov.uk sub-domain.

Retains the example for campaigns to ensure existing functionality
is preserved while we add a new example for another GOV.UK subdomain.