### PR TITLE
[DO NOT MERGE] Updates schema for html publications

### DIFF
--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -445,6 +445,10 @@
         },
         "isbn": {
           "type": "string",
+          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
+        },
+        "web_isbn": {
+          "type": "string",
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
         },
         "print_meta_data_contact_address": {

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -425,6 +425,10 @@
         },
         "isbn": {
           "type": "string",
+          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
+        },
+        "web_isbn": {
+          "type": "string",
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
         },
         "print_meta_data_contact_address": {

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -303,6 +303,10 @@
         },
         "isbn": {
           "type": "string",
+          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
+        },
+        "web_isbn": {
+          "type": "string",
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
         },
         "print_meta_data_contact_address": {

--- a/formats/html_publication/frontend/examples/print_with_meta_data.json
+++ b/formats/html_publication/frontend/examples/print_with_meta_data.json
@@ -7,6 +7,7 @@
     "public_timestamp": "2016-01-17T14:19:42.460Z",
     "first_published_version": true,
     "isbn": "978-1-4098-4066-4",
+    "web_isbn": "978-1-78246-569-0",
     "print_meta_data_contact_address": "Department for Communities and Local Government\r\n2nd floor NW, Fry Building \r\n2 Marsham Street \r\nLondon \r\nSW1P 4DF"
   },
   "format": "html_publication",

--- a/formats/html_publication/publisher/details.json
+++ b/formats/html_publication/publisher/details.json
@@ -24,6 +24,10 @@
     },
     "isbn": {
       "type": "string",
+      "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
+    },
+    "web_isbn": {
+      "type": "string",
       "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
     },
     "print_meta_data_contact_address": {


### PR DESCRIPTION
[Trello card](https://trello.com/c/OEZIdXTE/135-separate-file-attachment-form-and-html-attachment-form)

Depends on: 
https://github.com/alphagov/whitehall/pull/3170
https://github.com/alphagov/government-frontend/pull/325

## Background
It was pointed out that the "ISBN (web version)" field is showing up not only in the HTML Attachments form, but also in the File Attachments form. Additionally, this was becoming confusing to people because they were entering the Print ISBN in that field. 

NB: HTML Attachments are called HTML Publications in this project, but are still called "attachments" in whitehall. 

## What this PR does
This updates the schema to separate the ISBN field into "Print ISBN" and "Web ISBN".
The HTML attachment will show both Print and Web ISBN, when printed.
The File attachment will not need to display the ISBN when printed. This was a requirement for HTML attachments only.
