### PR TITLE
Revert "[DO NOT MERGE] Updates schema for html publications"

### DIFF
--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -445,10 +445,6 @@
         },
         "isbn": {
           "type": "string",
-          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
-        },
-        "web_isbn": {
-          "type": "string",
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
         },
         "print_meta_data_contact_address": {

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -425,10 +425,6 @@
         },
         "isbn": {
           "type": "string",
-          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
-        },
-        "web_isbn": {
-          "type": "string",
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
         },
         "print_meta_data_contact_address": {

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -303,10 +303,6 @@
         },
         "isbn": {
           "type": "string",
-          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
-        },
-        "web_isbn": {
-          "type": "string",
           "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
         },
         "print_meta_data_contact_address": {

--- a/formats/html_publication/frontend/examples/print_with_meta_data.json
+++ b/formats/html_publication/frontend/examples/print_with_meta_data.json
@@ -7,7 +7,6 @@
     "public_timestamp": "2016-01-17T14:19:42.460Z",
     "first_published_version": true,
     "isbn": "978-1-4098-4066-4",
-    "web_isbn": "978-1-78246-569-0",
     "print_meta_data_contact_address": "Department for Communities and Local Government\r\n2nd floor NW, Fry Building \r\n2 Marsham Street \r\nLondon \r\nSW1P 4DF"
   },
   "format": "html_publication",

--- a/formats/html_publication/publisher/details.json
+++ b/formats/html_publication/publisher/details.json
@@ -24,10 +24,6 @@
     },
     "isbn": {
       "type": "string",
-      "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
-    },
-    "web_isbn": {
-      "type": "string",
       "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
     },
     "print_meta_data_contact_address": {


### PR DESCRIPTION
Reverts alphagov/govuk-content-schemas#607

Too early! This PR relies on Whitehall changes, so shouldn't have been merged.