### PR TITLE
Replace contacts-frontend as rendering option

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -608,7 +608,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -585,7 +585,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -469,7 +469,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -648,7 +648,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -616,7 +616,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -230,7 +230,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -503,7 +503,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -612,7 +612,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -589,7 +589,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -473,7 +473,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -625,7 +625,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -602,7 +602,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -486,7 +486,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -700,7 +700,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -660,7 +660,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -238,7 +238,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -577,7 +577,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -805,7 +805,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -779,7 +779,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -224,7 +224,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -660,7 +660,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -623,7 +623,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -597,7 +597,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -224,7 +224,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -481,7 +481,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -657,7 +657,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -625,7 +625,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -230,7 +230,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -512,7 +512,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -659,7 +659,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -631,7 +631,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -231,7 +231,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -536,7 +536,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -648,7 +648,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -625,7 +625,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -509,7 +509,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -632,7 +632,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -594,7 +594,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -237,7 +237,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -501,7 +501,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -655,7 +655,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -626,7 +626,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -230,7 +230,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -510,7 +510,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -691,7 +691,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -665,7 +665,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -224,7 +224,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -549,7 +549,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -602,7 +602,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -579,7 +579,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -463,7 +463,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -605,7 +605,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -582,7 +582,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -466,7 +466,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -609,7 +609,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -586,7 +586,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -470,7 +470,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -608,7 +608,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -585,7 +585,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -469,7 +469,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -620,7 +620,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -597,7 +597,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -481,7 +481,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -624,7 +624,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -601,7 +601,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -485,7 +485,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -605,7 +605,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -578,7 +578,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -225,7 +225,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -462,7 +462,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -630,7 +630,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -610,7 +610,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -500,7 +500,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -627,7 +627,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -604,7 +604,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -488,7 +488,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -651,7 +651,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -628,7 +628,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -512,7 +512,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -634,7 +634,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -595,7 +595,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -237,7 +237,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -479,7 +479,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -620,7 +620,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -594,7 +594,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -227,7 +227,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -478,7 +478,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -622,7 +622,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -596,7 +596,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -227,7 +227,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -480,7 +480,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -669,7 +669,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -646,7 +646,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -530,7 +530,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -649,7 +649,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -606,7 +606,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -241,7 +241,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -493,7 +493,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -617,7 +617,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -594,7 +594,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -478,7 +478,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -667,7 +667,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -640,7 +640,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -528,7 +528,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -690,7 +690,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -651,7 +651,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -240,7 +240,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -535,7 +535,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -652,7 +652,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -610,7 +610,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -244,7 +244,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -529,7 +529,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -644,7 +644,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -613,7 +613,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -229,7 +229,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -500,7 +500,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -601,7 +601,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -578,7 +578,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -462,7 +462,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -614,7 +614,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -587,7 +587,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -225,7 +225,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -471,7 +471,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -651,7 +651,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -628,7 +628,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -512,7 +512,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -624,7 +624,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -589,7 +589,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -233,7 +233,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -473,7 +473,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -670,7 +670,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -647,7 +647,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -531,7 +531,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -602,7 +602,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -579,7 +579,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -463,7 +463,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -631,7 +631,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -603,7 +603,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -498,7 +498,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -669,7 +669,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -621,7 +621,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -246,7 +246,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -508,7 +508,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -626,7 +626,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -603,7 +603,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -490,7 +490,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -638,7 +638,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -615,7 +615,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -499,7 +499,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -612,7 +612,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -589,7 +589,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -473,7 +473,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -613,7 +613,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -586,7 +586,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -225,7 +225,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -474,7 +474,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -612,7 +612,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -585,7 +585,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -225,7 +225,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -469,7 +469,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -612,7 +612,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -589,7 +589,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -473,7 +473,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -633,7 +633,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -610,7 +610,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -494,7 +494,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -656,7 +656,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -630,7 +630,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -224,7 +224,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -514,7 +514,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -617,7 +617,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -591,7 +591,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -224,7 +224,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -475,7 +475,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -625,7 +625,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -602,7 +602,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -486,7 +486,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -608,7 +608,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -585,7 +585,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -221,7 +221,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -469,7 +469,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -635,7 +635,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -603,7 +603,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -230,7 +230,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -490,7 +490,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",

--- a/formats/contact/frontend/examples/contact_with_email_and_no_other_contacts.json
+++ b/formats/contact/frontend/examples/contact_with_email_and_no_other_contacts.json
@@ -12,7 +12,7 @@
   "phase": "live",
   "public_updated_at": "2015-12-03T15:13:21.000+00:00",
   "publishing_app": "contacts",
-  "rendering_app": "contacts-frontend",
+  "rendering_app": "government-frontend",
   "schema_name": "contact",
   "title": "Creative Industry Tax Reliefs",
   "updated_at": "2016-11-08T15:12:08.274Z",

--- a/formats/contact/frontend/examples/contact_with_webchat.json
+++ b/formats/contact/frontend/examples/contact_with_webchat.json
@@ -12,7 +12,7 @@
   "phase": "live",
   "public_updated_at": "2016-12-12T12:49:17.000+00:00",
   "publishing_app": "contacts",
-  "rendering_app": "contacts-frontend",
+  "rendering_app": "government-frontend",
   "schema_name": "contact",
   "title": "Income Tax: general enquiries",
   "updated_at": "2017-02-15T14:58:21.647Z",

--- a/formats/contact/frontend/examples/contact_with_welsh.json
+++ b/formats/contact/frontend/examples/contact_with_welsh.json
@@ -12,7 +12,7 @@
   "phase": "live",
   "public_updated_at": "2015-09-29T10:38:30.000+00:00",
   "publishing_app": "contacts",
-  "rendering_app": "contacts-frontend",
+  "rendering_app": "government-frontend",
   "schema_name": "contact",
   "title": "Treth Incwm, Hunanasesiad a mwy",
   "updated_at": "2017-02-10T09:51:28.022Z",

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -173,7 +173,6 @@
             "calculators",
             "calendars",
             "collections",
-            "contacts-frontend",
             "designprinciples",
             "email-alert-frontend",
             "email-campaign-frontend",


### PR DESCRIPTION
# Description
`contacts-frontend` is being retired and has been replaced with `government-frontend`.
This PR updates schema examples to `government-frontend` and removes `contacts-frontend` as a valid `rendering-app` value.