### PR TITLE
Add Visiblity property to taxon schema

### DIFF
--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -438,6 +438,10 @@
           "type": "string",
           "description": "Usage notes for editors when tagging content to a taxon."
         },
+        "visible_to_departmental_editors": {
+          "type": "boolean",
+          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state."
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -411,6 +411,10 @@
           "type": "string",
           "description": "Usage notes for editors when tagging content to a taxon."
         },
+        "visible_to_departmental_editors": {
+          "type": "boolean",
+          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state."
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -288,6 +288,10 @@
         "notes_for_editors": {
           "type": "string",
           "description": "Usage notes for editors when tagging content to a taxon."
+        },
+        "visible_to_departmental_editors": {
+          "type": "boolean",
+          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state."
         }
       }
     },

--- a/formats/taxon/frontend/examples/taxon.json
+++ b/formats/taxon/frontend/examples/taxon.json
@@ -6,6 +6,7 @@
   "public_updated_at": "2015-12-09T11:11:11.000+00:00",
   "locale": "en",
   "details": {
+    "visible_to_departmental_editors": false
   },
   "links": {
     "parent_taxons": [

--- a/formats/taxon/publisher/details.json
+++ b/formats/taxon/publisher/details.json
@@ -9,6 +9,10 @@
     "notes_for_editors": {
       "type": "string",
       "description": "Usage notes for editors when tagging content to a taxon."
+    },
+    "visible_to_departmental_editors": {
+      "type": "boolean",
+      "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state."
     }
   }
 }


### PR DESCRIPTION
For Taxons that are ready to come out of development but shouldn't be viewable by the general public yet. Use the `visible_to_departmental_editors` flag to make the `draft` taxon appear in the `Draft Taxonomies` section of the new tagging interface. 

Note that this is only relevant for taxons at the root of their taxonomy tree.

[Trello](https://trello.com/c/3xt6aNdb/73-make-certain-taxons-visible-as-drafts-to-whitehall-editors)
