### PR TITLE
Add optional publishing_request_id frontend field

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -345,6 +345,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -353,6 +353,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -339,6 +339,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -339,6 +339,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -345,6 +345,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -341,6 +341,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -351,6 +351,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -342,6 +342,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -339,6 +339,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -340,6 +340,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -333,6 +333,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -352,6 +352,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -339,6 +339,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -339,6 +339,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -356,6 +356,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -339,6 +339,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -279,6 +279,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -352,6 +352,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -355,6 +355,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -344,6 +344,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -340,6 +340,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -348,6 +348,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -341,6 +341,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -361,6 +361,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -340,6 +340,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -340,6 +340,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -339,6 +339,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -339,6 +339,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -336,6 +336,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -345,6 +345,9 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
     }
   },
   "definitions": {

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -280,6 +280,9 @@
       "type": "string",
       "format": "date-time"
     },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
     "routes": {
       "type": "array",
       "minItems": 1,

--- a/formats/answer/frontend/examples/answer.json
+++ b/formats/answer/frontend/examples/answer.json
@@ -74,5 +74,6 @@
         "title": "Gwasanaethau ar-lein"
       }
     ]
-  }
+  },
+  "publishing_request_id": "2546-1460985144476-19268198-3242"
 }

--- a/lib/schema_generator/frontend_schema_generator.rb
+++ b/lib/schema_generator/frontend_schema_generator.rb
@@ -101,6 +101,9 @@ module SchemaGenerator
           "type" => "string",
           "format" => "date-time"
         },
+        "publishing_request_id" => {
+          "$ref" => "#/definitions/publishing_request_id",
+        },
       )
 
       # TODO: This is done to make sure that this rewrite produces the exact same
@@ -111,6 +114,7 @@ module SchemaGenerator
         publishing_app rendering_app locale need_ids analytics_identifier phase
         details withdrawn_notice content_id last_edited_at links document_type
         schema_name format navigation_document_supertype user_journey_document_supertype email_document_supertype government_document_supertype updated_at
+        publishing_request_id
       ])
     end
 


### PR DESCRIPTION
This will contain the value of the request ID header, similar to how Travel Advice Publisher currently has `publishing_request_id` in the details hash.

Do not merge until https://github.com/alphagov/info-frontend/pull/68 has been merged.

[Trello Card](https://trello.com/c/JZ5Zabe9/702-remove-publishing-request-id-from-travel-advice-publisher-details-hash-2)