### PR TITLE
Remove specialist-frontend from rendering apps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,6 @@ def dependentApplications = [
   ['short-url-manager', false],
   ['service-manual-frontend', false],
   ['service-manual-publisher', false],
-  ['specialist-frontend', false],
   ['smartanswers', false],
   ['specialist-publisher', true],
   ['static', false],

--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -623,7 +623,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -600,7 +600,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -484,7 +484,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -663,7 +663,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -631,7 +631,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -245,7 +245,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -518,7 +518,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -627,7 +627,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -604,7 +604,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -488,7 +488,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -640,7 +640,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -617,7 +617,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -501,7 +501,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -715,7 +715,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -675,7 +675,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -253,7 +253,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -592,7 +592,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -820,7 +820,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -794,7 +794,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -239,7 +239,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -675,7 +675,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -638,7 +638,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -612,7 +612,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -239,7 +239,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -496,7 +496,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -672,7 +672,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -640,7 +640,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -245,7 +245,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -527,7 +527,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -674,7 +674,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -646,7 +646,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -246,7 +246,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -551,7 +551,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -663,7 +663,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -640,7 +640,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -524,7 +524,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -647,7 +647,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -609,7 +609,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -252,7 +252,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -516,7 +516,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -670,7 +670,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -641,7 +641,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -245,7 +245,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -525,7 +525,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -706,7 +706,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -680,7 +680,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -239,7 +239,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -564,7 +564,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -617,7 +617,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -594,7 +594,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -478,7 +478,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -620,7 +620,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -597,7 +597,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -481,7 +481,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -624,7 +624,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -601,7 +601,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -485,7 +485,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -623,7 +623,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -600,7 +600,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -484,7 +484,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -635,7 +635,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -612,7 +612,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -496,7 +496,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -639,7 +639,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -616,7 +616,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -500,7 +500,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -620,7 +620,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -593,7 +593,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -240,7 +240,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -477,7 +477,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -645,7 +645,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -625,7 +625,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -515,7 +515,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -642,7 +642,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -619,7 +619,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -503,7 +503,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -666,7 +666,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -643,7 +643,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -527,7 +527,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -649,7 +649,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -610,7 +610,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -252,7 +252,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -494,7 +494,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -635,7 +635,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -609,7 +609,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -242,7 +242,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -493,7 +493,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -637,7 +637,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -611,7 +611,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -242,7 +242,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -495,7 +495,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -684,7 +684,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -661,7 +661,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -545,7 +545,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -664,7 +664,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -621,7 +621,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -256,7 +256,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -508,7 +508,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -632,7 +632,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -609,7 +609,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -493,7 +493,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -682,7 +682,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -655,7 +655,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -543,7 +543,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -705,7 +705,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -666,7 +666,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -255,7 +255,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -550,7 +550,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -667,7 +667,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -625,7 +625,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -259,7 +259,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -544,7 +544,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -659,7 +659,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -628,7 +628,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -244,7 +244,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -515,7 +515,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -616,7 +616,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -593,7 +593,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -477,7 +477,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -629,7 +629,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -602,7 +602,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -240,7 +240,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -486,7 +486,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -666,7 +666,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -643,7 +643,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -527,7 +527,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -639,7 +639,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -604,7 +604,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -248,7 +248,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -488,7 +488,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -685,7 +685,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -662,7 +662,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -546,7 +546,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -617,7 +617,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -594,7 +594,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -478,7 +478,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -646,7 +646,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -618,7 +618,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -513,7 +513,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -684,7 +684,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -636,7 +636,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -261,7 +261,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -523,7 +523,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -641,7 +641,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -618,7 +618,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -505,7 +505,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -653,7 +653,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -630,7 +630,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -514,7 +514,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -627,7 +627,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -604,7 +604,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -488,7 +488,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -632,7 +632,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -605,7 +605,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -240,7 +240,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -493,7 +493,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -627,7 +627,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -600,7 +600,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -240,7 +240,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -484,7 +484,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -627,7 +627,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -604,7 +604,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -488,7 +488,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -648,7 +648,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -625,7 +625,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -509,7 +509,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -671,7 +671,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -645,7 +645,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -239,7 +239,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -529,7 +529,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -632,7 +632,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -606,7 +606,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -239,7 +239,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -490,7 +490,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -640,7 +640,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -617,7 +617,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -501,7 +501,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -623,7 +623,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -600,7 +600,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -236,7 +236,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -484,7 +484,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -650,7 +650,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -618,7 +618,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -245,7 +245,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -505,7 +505,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -188,7 +188,6 @@
             "rummager",
             "service-manual-frontend",
             "smartanswers",
-            "specialist-frontend",
             "spotlight",
             "static",
             "tariff",

--- a/formats/specialist_document/publisher_v2/examples/dfid_research_output.json
+++ b/formats/specialist_document/publisher_v2/examples/dfid_research_output.json
@@ -6,7 +6,7 @@
   "schema_name": "specialist_document",
   "public_updated_at": "2015-02-11T13:45:00.000+00:00",
   "publishing_app": "specialist-publisher",
-  "rendering_app": "specialist-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "phase": "live",
   "details": {

--- a/formats/specialist_document/publisher_v2/examples/specialist_document.json
+++ b/formats/specialist_document/publisher_v2/examples/specialist_document.json
@@ -4,7 +4,7 @@
   "description": "This is the summary of an example CMA case",
   "public_updated_at": "2015-02-11T13:45:00.000+00:00",
   "publishing_app": "specialist-publisher",
-  "rendering_app": "specialist-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "phase": "live",
   "details": {


### PR DESCRIPTION
This app is being retired. Specialist documents are now rendered by government-frontend.

Part of: https://trello.com/c/UM7aecOQ/194-final-stage-decomission-specialist-frontend-2