### PR TITLE
Add `world_news_story` support

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -312,6 +312,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -320,6 +320,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -306,6 +306,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -263,6 +263,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -306,6 +306,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -312,6 +312,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -308,6 +308,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -318,6 +318,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -309,6 +309,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -306,6 +306,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -307,6 +307,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -300,6 +300,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -319,6 +319,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -306,6 +306,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -306,6 +306,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -92,6 +92,9 @@
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
         "roles": {
           "description": "Used to power Email Alert Api subscriptions for Whitehall content",
           "$ref": "#/definitions/frontend_links"
@@ -323,6 +326,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -22,6 +22,9 @@
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
         "roles": {
           "$ref": "#/definitions/guid_list",
           "description": "Used to power Email Alert Api subscriptions for Whitehall content"

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -307,6 +307,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -319,6 +319,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -322,6 +322,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -311,6 +311,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -307,6 +307,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -315,6 +315,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -308,6 +308,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -328,6 +328,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -307,6 +307,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -307,6 +307,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -306,6 +306,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -306,6 +306,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -303,6 +303,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -312,6 +312,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -246,6 +246,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -266,6 +266,7 @@
         "working_group",
         "world_location",
         "world_location_news_article",
+        "world_news_story",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/formats/news_article/frontend/examples/world_news_story_news_article.json
+++ b/formats/news_article/frontend/examples/world_news_story_news_article.json
@@ -1,0 +1,97 @@
+{
+  "base_path": "/government/news/christmas-2016-prime-ministers-message-from-azerbaijan",
+  "content_id": "d0ee70cf-ed7a-4b04-b60e-3be2f03693af",
+  "document_type": "world_news_story",
+  "first_published_at": "2016-12-25T00:15:06.000+00:00",
+  "locale": "en",
+  "public_updated_at": "2016-12-25T00:15:02.000+00:00",
+  "schema_name": "news_article",
+  "title": "Christmas 2016: Prime Minister's message",
+  "updated_at": "2016-12-25T00:15:07.824Z",
+  "links": {
+    "ministers": [
+      {
+        "content_id": "85291e63-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon Theresa May MP",
+        "api_path": "/api/content/government/people/theresa-may",
+        "base_path": "/government/people/theresa-may",
+        "api_url": "https://www.gov.uk/api/content/government/people/theresa-may",
+        "web_url": "https://www.gov.uk/government/people/theresa-may",
+        "locale": "en"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "d0ee80cd-ed7a-4b04-b60f-3be2f03693af",
+        "title": "Christmas 2016: Prime Minister's message",
+        "api_path": "/api/content/government/news/christmas-2016-prime-ministers-message",
+        "base_path": "/government/news/christmas-2016-prime-ministers-message",
+        "api_url": "https://www.gov.uk/api/content/government/news/christmas-2016-prime-ministers-message",
+        "web_url": "https://www.gov.uk/government/news/christmas-2016-prime-ministers-message",
+        "locale": "en"
+      },
+      {
+        "content_id": "d0ee80cd-ed7a-4b04-b60f-3be2f03693af",
+        "title": "کرسمس 2016ء : وزیراعظم کا پیغام",
+        "api_path": "/api/content/government/news/christmas-2016-prime-ministers-message.ur",
+        "base_path": "/government/news/christmas-2016-prime-ministers-message.ur",
+        "api_url": "https://www.gov.uk/api/content/government/news/christmas-2016-prime-ministers-message.ur",
+        "web_url": "https://www.gov.uk/government/news/christmas-2016-prime-ministers-message.ur",
+        "locale": "ur"
+      }
+    ],
+    "worldwide_organisations": [
+      {
+        "content_id": "f4c3a876-7a30-11e4-a3cb-005056011aef",
+        "title": "British High Commission Singapore",
+        "base_path": "/government/world/organisations/british-high-commission-singapore",
+        "api_path": "/api/content/government/world/organisations/british-high-commission-singapore",
+        "api_url": "https://www.gov.uk/api/content/government/world/organisations/british-high-commission-singapore",
+        "web_url": "https://www.gov.uk/government/world/organisations/british-high-commission-singapore",
+        "locale": "en",
+        "analytics_identifier": "WO88"
+      }
+    ],
+    "world_locations": [
+      {
+        "content_id": "5e9ed112-7706-11e4-a3cb-005056011aef",
+        "title": "Azerbaijan",
+        "base_path": "/government/world/azerbaijan",
+        "api_path": "/api/content/government/world/azerbaijan",
+        "api_url": "https://www.gov.uk/api/content/government/world/azerbaijan",
+        "web_url": "https://www.gov.uk/government/world/azerbaijan",
+        "locale": "en",
+        "analytics_identifier": "WL10"
+      }
+    ]
+  },
+  "description": "Theresa May sends her best wishes to everyone celebrating Christmas in the UK and around the world.",
+  "details": {
+    "image": {
+      "alt_text": "Christmas",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/59695/s465_Christmas.jpg"
+    },
+    "body": "<div class=\"govspeak\"><p>Prime Minister Theresa May said:</p><blockquote>  <p>This year, the United Kingdom has had much to celebrate. Her Majesty The Queen celebrated her 90th birthday, surrounded by the Royal Family and well-wishers from across our four nations, the Commonwealth, and the world.</p>  <p>Four years after the success of London 2012, our Olympic and Paralympic athletes continued to work and train –  and they were rewarded by coming second in the medal table, <a href=\"https://www.gov.uk/government/news/rio-2016-message-from-prime-minister-theresa-may\">becoming the first team ever to increase its medal haul four years after hosting the Games</a>.  Many of us will have more personal memories too, of happy times with family and friends.  These are precious moments when people from many backgrounds, with different beliefs, come together to celebrate in families and communities.</p>  <p>Coming together is also important for us as a country. As <a href=\"https://www.gov.uk/government/topics/europe\">we leave the European Union</a> we must seize an historic opportunity to forge a bold new role for ourselves in the world and to unite our country as we move forward into the future.  And, with our international partners, we must work together to promote trade, increase prosperity and face the challenges to peace and security around the world.</p>  <p>As we gather with our friends and families at this time of year we proudly celebrate the birth of Christ and the message of forgiveness, love and hope that he brings.  We also think of Christians in other parts of the world who face persecution this Christmas and re-affirm our determination to stand up for the freedom of people of all religions to practise their beliefs in peace and safety.</p>  <p>Having grown up in a vicarage, I know how demanding it can be for those who have to work over the Christmas period.  So it’s right for all of us to express our gratitude to those who will have to spend Christmas away from the people they love in looking after others: those in our health and care services, those who work with the vulnerable, as well as those who will be caring for a loved one.</p>  <p>And <a href=\"https://www.gov.uk/government/news/prime-ministers-christmas-2016-message-to-the-armed-forces\">we thank those in our Armed Forces, security agencies, and emergency services who work all year round to keep our country safe</a> – especially those who will be separated by their duty from their families and friends.</p>  <p class=\"last-child\">Wherever you are this Christmas, I wish you joy and peace in this season of celebration, along with health and happiness in the year ahead.</p></blockquote></div>",
+    "first_public_at": "2016-12-25T00:15:02.000+00:00",
+    "government": {
+      "current": true,
+      "slug": "2015-conservative-government",
+      "title": "2015 Conservative government"
+    },
+    "emphasised_organisations": [
+      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+    ],
+    "political": true,
+    "tags": {
+      "browse_pages": [
+
+      ],
+      "policies": [
+
+      ],
+      "topics": [
+
+      ]
+    }
+  }
+}

--- a/formats/news_article/publisher/links.json
+++ b/formats/news_article/publisher/links.json
@@ -15,6 +15,9 @@
     "world_locations": {
       "$ref": "#/definitions/guid_list"
     },
+    "worldwide_organisations": {
+      "$ref": "#/definitions/guid_list"
+    },
     "roles": {
       "$ref": "#/definitions/guid_list",
       "description": "Used to power Email Alert Api subscriptions for Whitehall content"

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -152,5 +152,6 @@
 - working_group
 - world_location
 - world_location_news_article
+- world_news_story
 - worldwide_organisation
 - written_statement


### PR DESCRIPTION
As part of the work to merge the `WorldLocationNewsArticle` format into `NewsArticle` this PR updates the `NewsArticle` links and examples. The new `world_news_story` document type has been added too which is the `NewsArticle` sub-type that `WorldLocationNewsArticle` will be migrated to. It is essentially a `NewsArticle` that can also be linked to a `WorldwideOrganisaiton`.

[Trello](https://trello.com/c/waIW6Y3i/91-update-the-content-schema-for-news-articles)