### PR TITLE
Re-bundle with new ruby and bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,5 +52,8 @@ DEPENDENCIES
   rake
   rspec
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.14.5


### PR DESCRIPTION
This puts a RUBY_VERSION and updates BUNDLED_WITH to the correct version
as per our puppet infrastructure. Having these left out means useful
scripts in the development VM won't run on this repo because of
uncommitted local changes.