### PR TITLE
Support edition links for corporate information pages

### DIFF
--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -307,6 +307,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "corporate_information_pages": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "maxItems": 1,
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "$ref": "#/definitions/guid_list"
         }

--- a/formats/corporate_information_page/publisher/edition_links.json
+++ b/formats/corporate_information_page/publisher/edition_links.json
@@ -14,6 +14,6 @@
       "description": "The parent content item.",
       "maxItems": 1,
       "$ref": "#/definitions/guid_list"
-		}
-	}
+    }
+  }
 }

--- a/formats/corporate_information_page/publisher/edition_links.json
+++ b/formats/corporate_information_page/publisher/edition_links.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "corporate_information_pages": {
+      "$ref": "#/definitions/guid_list"
+    },
+    "organisations": {
+      "description": "All organisations linked to this content item. This should include lead organisations.",
+      "$ref": "#/definitions/guid_list"
+    },
+    "parent": {
+      "description": "The parent content item.",
+      "maxItems": 1,
+      "$ref": "#/definitions/guid_list"
+		}
+	}
+}


### PR DESCRIPTION
Corporate information pages have `parent` and `organisation` links that are not currently being sent with first draft versions. This is causing 500s in preview as the organisation brand cannot be determined.

This commit adds edition level links to allow them to be sent with the drafts.