### PR TITLE
Don't allow `format` in frontends

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -314,10 +314,6 @@
         "answer"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -257,10 +257,6 @@
         "answer"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -323,10 +323,6 @@
         "case_study"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -257,10 +257,6 @@
         "case_study"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -314,10 +314,6 @@
         "coming_soon"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -257,10 +257,6 @@
         "coming_soon"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -314,10 +314,6 @@
         "completed_transaction"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -257,10 +257,6 @@
         "completed_transaction"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -331,10 +331,6 @@
         "consultation"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -257,10 +257,6 @@
         "consultation"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -317,10 +317,6 @@
         "contact"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -257,10 +257,6 @@
         "contact"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -317,10 +317,6 @@
         "corporate_information_page"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -257,10 +257,6 @@
         "corporate_information_page"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -323,10 +323,6 @@
         "detailed_guide"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -257,10 +257,6 @@
         "detailed_guide"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -319,10 +319,6 @@
         "document_collection"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -257,10 +257,6 @@
         "document_collection"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -314,10 +314,6 @@
         "email_alert_signup"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -257,10 +257,6 @@
         "email_alert_signup"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -329,10 +329,6 @@
         "fatality_notice"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -257,10 +257,6 @@
         "fatality_notice"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -320,10 +320,6 @@
         "finder"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -257,10 +257,6 @@
         "finder"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -317,10 +317,6 @@
         "finder_email_signup"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -257,10 +257,6 @@
         "finder_email_signup"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -314,10 +314,6 @@
         "generic"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -257,10 +257,6 @@
         "generic"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -314,10 +314,6 @@
         "generic_with_external_related_links"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -257,10 +257,6 @@
         "generic_with_external_related_links"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -314,10 +314,6 @@
         "guide"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -257,10 +257,6 @@
         "guide"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -314,10 +314,6 @@
         "help_page"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -257,10 +257,6 @@
         "help_page"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -314,10 +314,6 @@
         "hmrc_manual"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -257,10 +257,6 @@
         "hmrc_manual"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -314,10 +314,6 @@
         "hmrc_manual_section"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -257,10 +257,6 @@
         "hmrc_manual_section"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -318,10 +318,6 @@
         "homepage"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -257,10 +257,6 @@
         "homepage"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -311,10 +311,6 @@
         "html_publication"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -257,10 +257,6 @@
         "html_publication"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -314,10 +314,6 @@
         "licence"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -257,10 +257,6 @@
         "licence"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -314,10 +314,6 @@
         "local_transaction"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -257,10 +257,6 @@
         "local_transaction"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -330,10 +330,6 @@
         "mainstream_browse_page"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -257,10 +257,6 @@
         "mainstream_browse_page"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -317,10 +317,6 @@
         "manual"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -257,10 +257,6 @@
         "manual"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -317,10 +317,6 @@
         "manual_section"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -257,10 +257,6 @@
         "manual_section"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -314,10 +314,6 @@
         "need"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -257,10 +257,6 @@
         "need"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -337,10 +337,6 @@
         "news_article"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -257,10 +257,6 @@
         "news_article"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -314,10 +314,6 @@
         "place"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -257,10 +257,6 @@
         "place"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -317,10 +317,6 @@
       "pattern": "^(placeholder|placeholder_.+)$",
       "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -256,10 +256,6 @@
       "pattern": "^(placeholder|placeholder_.+)$",
       "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -330,10 +330,6 @@
         "policy"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -257,10 +257,6 @@
         "policy"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -333,10 +333,6 @@
         "publication"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -257,10 +257,6 @@
         "publication"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -322,10 +322,6 @@
         "service_manual_guide"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -257,10 +257,6 @@
         "service_manual_guide"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -314,10 +314,6 @@
         "service_manual_homepage"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -257,10 +257,6 @@
         "service_manual_homepage"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -318,10 +318,6 @@
         "service_manual_service_standard"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -257,10 +257,6 @@
         "service_manual_service_standard"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -314,10 +314,6 @@
         "service_manual_service_toolkit"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -257,10 +257,6 @@
         "service_manual_service_toolkit"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -326,10 +326,6 @@
         "service_manual_topic"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -257,10 +257,6 @@
         "service_manual_topic"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -314,10 +314,6 @@
         "simple_smart_answer"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -257,10 +257,6 @@
         "simple_smart_answer"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -314,10 +314,6 @@
         "special_route"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -257,10 +257,6 @@
         "special_route"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -319,10 +319,6 @@
         "specialist_document"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -257,10 +257,6 @@
         "specialist_document"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -339,10 +339,6 @@
         "speech"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -257,10 +257,6 @@
         "speech"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -314,10 +314,6 @@
         "statistical_data_set"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -257,10 +257,6 @@
         "statistical_data_set"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -314,10 +314,6 @@
         "statistics_announcement"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -257,10 +257,6 @@
         "statistics_announcement"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -314,10 +314,6 @@
         "take_part"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -257,10 +257,6 @@
         "take_part"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -318,10 +318,6 @@
         "taxon"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -257,10 +257,6 @@
         "taxon"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -318,10 +318,6 @@
         "topic"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -257,10 +257,6 @@
         "topic"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -314,10 +314,6 @@
         "topical_event_about_page"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -257,10 +257,6 @@
         "topical_event_about_page"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -314,10 +314,6 @@
         "transaction"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -257,10 +257,6 @@
         "transaction"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -317,10 +317,6 @@
         "travel_advice"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -257,10 +257,6 @@
         "travel_advice"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -317,10 +317,6 @@
         "travel_advice_index"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -257,10 +257,6 @@
         "travel_advice_index"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -314,10 +314,6 @@
         "unpublishing"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -257,10 +257,6 @@
         "unpublishing"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -314,10 +314,6 @@
         "working_group"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -257,10 +257,6 @@
         "working_group"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -323,10 +323,6 @@
         "world_location_news_article"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -257,10 +257,6 @@
         "world_location_news_article"
       ]
     },
-    "format": {
-      "type": "string",
-      "description": "DEPRECATED: use `document_type` instead. This field will be removed."
-    },
     "navigation_document_supertype": {
       "type": "string",
       "description": "Document type grouping powering the new taxonomy-based navigation pages"

--- a/lib/schema_generator/frontend_schema_generator.rb
+++ b/lib/schema_generator/frontend_schema_generator.rb
@@ -77,10 +77,6 @@ module SchemaGenerator
           "additionalProperties" => false,
           "properties" => frontend_links(publisher_content_schema, publisher_links_schema)
         },
-        "format" => {
-          "type" => "string",
-          "description" => "DEPRECATED: use `document_type` instead. This field will be removed."
-        },
         "navigation_document_supertype" => {
           "type" => "string",
           "description" => "Document type grouping powering the new taxonomy-based navigation pages",


### PR DESCRIPTION
It has been deprecated. No frontends are using it anymore.

Todo:

- [x] https://github.com/alphagov/content-store/pull/293 (stops exposing `format`)
- [x] https://github.com/alphagov/publishing-api/pull/914