### PR TITLE
Remove Content API

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -579,7 +579,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -556,7 +556,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -437,7 +437,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -619,7 +619,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -587,7 +587,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -197,7 +197,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -471,7 +471,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -583,7 +583,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -560,7 +560,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -441,7 +441,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -596,7 +596,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -573,7 +573,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -454,7 +454,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -671,7 +671,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -631,7 +631,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -205,7 +205,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -545,7 +545,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -776,7 +776,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -750,7 +750,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -191,7 +191,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -628,7 +628,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -594,7 +594,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -568,7 +568,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -191,7 +191,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -461,7 +461,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -628,7 +628,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -596,7 +596,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -197,7 +197,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -480,7 +480,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -630,7 +630,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -602,7 +602,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -198,7 +198,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -504,7 +504,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -619,7 +619,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -596,7 +596,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -477,7 +477,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -603,7 +603,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -565,7 +565,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -204,7 +204,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -469,7 +469,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -626,7 +626,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -597,7 +597,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -197,7 +197,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -478,7 +478,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -662,7 +662,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -636,7 +636,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -191,7 +191,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -517,7 +517,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -573,7 +573,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -550,7 +550,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -431,7 +431,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -576,7 +576,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -553,7 +553,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -434,7 +434,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -580,7 +580,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -557,7 +557,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -438,7 +438,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -579,7 +579,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -556,7 +556,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -437,7 +437,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -591,7 +591,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -568,7 +568,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -449,7 +449,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -595,7 +595,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -572,7 +572,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -453,7 +453,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -576,7 +576,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -549,7 +549,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -192,7 +192,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -430,7 +430,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -601,7 +601,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -581,7 +581,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -468,7 +468,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -598,7 +598,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -575,7 +575,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -456,7 +456,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -622,7 +622,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -599,7 +599,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -480,7 +480,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -605,7 +605,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -566,7 +566,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -204,7 +204,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -447,7 +447,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -591,7 +591,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -565,7 +565,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -194,7 +194,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -446,7 +446,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -593,7 +593,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -567,7 +567,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -194,7 +194,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -448,7 +448,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -640,7 +640,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -617,7 +617,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -498,7 +498,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -623,7 +623,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -577,7 +577,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -211,7 +211,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -461,7 +461,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -588,7 +588,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -565,7 +565,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -446,7 +446,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -638,7 +638,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -611,7 +611,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -496,7 +496,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -661,7 +661,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -622,7 +622,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -207,7 +207,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -503,7 +503,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -623,7 +623,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -581,7 +581,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -211,7 +211,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -497,7 +497,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -615,7 +615,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -584,7 +584,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -196,7 +196,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -468,7 +468,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -572,7 +572,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -549,7 +549,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -430,7 +430,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -585,7 +585,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -558,7 +558,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -192,7 +192,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -439,7 +439,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -622,7 +622,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -599,7 +599,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -480,7 +480,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -595,7 +595,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -560,7 +560,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -200,7 +200,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -441,7 +441,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -641,7 +641,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -618,7 +618,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -499,7 +499,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -573,7 +573,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -550,7 +550,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -431,7 +431,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -602,7 +602,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -574,7 +574,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -466,7 +466,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -640,7 +640,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -592,7 +592,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -213,7 +213,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -476,7 +476,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -597,7 +597,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -574,7 +574,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -458,7 +458,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -609,7 +609,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -586,7 +586,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -467,7 +467,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -583,7 +583,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -560,7 +560,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -441,7 +441,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -588,7 +588,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -561,7 +561,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -192,7 +192,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -446,7 +446,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -583,7 +583,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -556,7 +556,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -192,7 +192,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -437,7 +437,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -583,7 +583,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -560,7 +560,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -441,7 +441,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -604,7 +604,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -581,7 +581,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -462,7 +462,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -627,7 +627,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -601,7 +601,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -191,7 +191,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -482,7 +482,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -588,7 +588,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -562,7 +562,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -191,7 +191,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -443,7 +443,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -596,7 +596,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -573,7 +573,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -454,7 +454,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -579,7 +579,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -556,7 +556,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -188,7 +188,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -437,7 +437,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -606,7 +606,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -574,7 +574,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -197,7 +197,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -458,7 +458,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -140,7 +140,6 @@
         "external-link-tracker",
         "feedback",
         "frontend",
-        "govuk_content_api",
         "hmrc-manuals-api",
         "info-frontend",
         "licencefinder",


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api