### PR TITLE
Add associated taxons

### DIFF
--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -125,6 +125,10 @@
           "maxItems": 1,
           "$ref": "#/definitions/frontend_links"
         },
+        "associated_taxons": {
+          "description": "A list of associated taxons whose children should be included as children of this taxon",
+          "$ref": "#/definitions/frontend_links"
+        },
         "available_translations": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -304,6 +304,10 @@
           "description": "The list of taxon parents.",
           "$ref": "#/definitions/guid_list"
         },
+        "associated_taxons": {
+          "description": "A list of associated taxons whose children should be included as children of this taxon",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "$ref": "#/definitions/guid_list"
         }

--- a/formats/taxon/frontend/examples/taxon_with_associated_taxons.json
+++ b/formats/taxon/frontend/examples/taxon_with_associated_taxons.json
@@ -1,0 +1,56 @@
+{
+  "content_id": "1d1e3479-6067-447d-ac85-5e9fd213197a",
+  "base_path": "/alpha-taxonomy/associates",
+  "title": "Associates",
+  "public_updated_at": "2015-12-09T11:11:11.000+00:00",
+  "locale": "en",
+  "details": {
+    "visible_to_departmental_editors": false
+  },
+  "links": {
+    "parent_taxons": [
+      {
+        "content_id": "f6eef5ca-be55-41b2-98be-f72b3e649b84",
+        "api_path": "/api/content/alpha-taxonomy/curriculum-and-qualifications",
+        "base_path": "/alpha-taxonomy/curriculum-and-qualifications",
+        "title": "Curriculum and qualifications",
+        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/curriculum-and-qualifications",
+        "web_url": "https://www.gov.uk/alpha-taxonomy/curriculum-and-qualifications",
+        "locale": "en"
+      },
+      {
+        "content_id": "6b404e13-f681-44cb-b51f-bff084710fd9",
+        "api_path": "/api/content/alpha-taxonomy/driving-and-vehicles",
+        "base_path": "/alpha-taxonomy/driving-and-vehicles",
+        "title": "Driving and vehicles",
+        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/driving-and-vehicles",
+        "web_url": "https://www.gov.uk/alpha-taxonomy/driving-and-vehicles",
+        "locale": "en"
+      }
+    ],
+    "parent": [
+      {
+        "content_id": "f6eef5ca-be55-41b2-98be-f72b3e649b84",
+        "api_path": "/api/content/alpha-taxonomy/curriculum-and-qualifications",
+        "base_path": "/alpha-taxonomy/curriculum-and-qualifications",
+        "title": "Curriculum and qualifications",
+        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/curriculum-and-qualifications",
+        "web_url": "https://www.gov.uk/alpha-taxonomy/curriculum-and-qualifications",
+        "locale": "en"
+      }
+    ],
+    "associated_taxons": [
+      {
+        "content_id": "003688db-4471-4d8b-be78-caa451bcb04c",
+        "api_path": "/api/content/alpha-taxonomy/generic-and-things",
+        "base_path": "/alpha-taxonomy/generic-and-things",
+        "title": "Generic and things",
+        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/generic-and-things",
+        "web_url": "https://www.gov.uk/alpha-taxonomy/generic-and-things",
+        "locale": "en"
+      }
+    ]
+  },
+  "schema_name": "taxon",
+  "document_type": "taxon"
+}

--- a/formats/taxon/publisher/edition_links.json
+++ b/formats/taxon/publisher/edition_links.json
@@ -6,6 +6,10 @@
     "parent_taxons": {
       "description": "The list of taxon parents.",
       "$ref": "#/definitions/guid_list"
+    },
+    "associated_taxons": {
+      "description": "A list of associated taxons whose children should be included as children of this taxon",
+      "$ref": "#/definitions/guid_list"
     }
   }
 }


### PR DESCRIPTION
This PR adds a new link type to the taxon schema `associated_taxons`

This link type will be used to link one taxon to one or more other taxons in such a way that the other taxon's children will be included as children of the taxon that declares the links.

e.g.

* `usa` taxon has `child_taxons` of `[travelling-in-the-usa]`
* `travelling-in-the-usa` has `associated_taxons` of `[travelling-abroad]` and `child_taxons` of `[usa-travel-advice]`
* `travelling-abroad` has `child_taxons` of `[driving-abroad, getting-married-abroad]`

The taxon page for `usa` would display a 'Travelling in the USA' heading containing the combined children 'USA travel advice', 'Driving abroad' and 'Getting married abroad'.

[Trello](https://trello.com/c/xegbo9qO/205-add-new-link-type-for-link-between-generic-and-specific-taxons)