### PR TITLE
Add placeholder world location news page document type

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -265,6 +265,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -273,6 +273,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -259,6 +259,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -211,6 +211,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -259,6 +259,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -265,6 +265,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -261,6 +261,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -271,6 +271,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -262,6 +262,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -259,6 +259,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -260,6 +260,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -253,6 +253,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -272,6 +272,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -259,6 +259,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -259,6 +259,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -279,6 +279,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -260,6 +260,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -272,6 +272,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -275,6 +275,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -264,6 +264,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -260,6 +260,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -268,6 +268,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -261,6 +261,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -281,6 +281,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -264,6 +264,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -260,6 +260,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -259,6 +259,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -259,6 +259,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -256,6 +256,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -260,6 +260,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -211,6 +211,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -265,6 +265,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -194,6 +194,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -214,6 +214,7 @@
         "placeholder_topical_event",
         "placeholder_working_group",
         "placeholder_world_location",
+        "placeholder_world_location_news_page",
         "placeholder_worldwide_organisation",
         "policy",
         "policy_area",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -100,6 +100,7 @@
 - placeholder_topical_event
 - placeholder_working_group
 - placeholder_world_location
+- placeholder_world_location_news_page
 - placeholder_worldwide_organisation
 - policy
 - policy_area


### PR DESCRIPTION
Add `placeholder_world_location_news_page` to Allowed Documents so that Whitehall can send placeholder world location news pages to Publishing Api and Rummager - associated [PR 3314 in Whitehall](https://github.com/alphagov/whitehall/pull/3314)

[Trello](https://trello.com/c/WAX1kJnP/222-ensure-worldwide-organisations-and-worldwide-news-pages-display-summary-text)