### PR TITLE
Add "start_button_text" to transaction schema

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -1562,6 +1562,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -1534,6 +1534,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -1368,6 +1368,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -1602,6 +1602,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -1565,6 +1565,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -1132,6 +1132,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -1402,6 +1402,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -1566,6 +1566,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -1538,6 +1538,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -1372,6 +1372,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -1579,6 +1579,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -1551,6 +1551,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -1385,6 +1385,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -1654,6 +1654,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -1609,6 +1609,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -1140,6 +1140,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -1481,6 +1481,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -1759,6 +1759,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -1728,6 +1728,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -1126,6 +1126,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -1559,6 +1559,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -1577,6 +1577,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -1546,6 +1546,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -1126,6 +1126,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -1397,6 +1397,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -1611,6 +1611,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -1574,6 +1574,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -1132,6 +1132,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -1411,6 +1411,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -1613,6 +1613,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -1580,6 +1580,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -1133,6 +1133,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -1440,6 +1440,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -1602,6 +1602,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -1574,6 +1574,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -1408,6 +1408,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -1586,6 +1586,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -1543,6 +1543,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -1139,6 +1139,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -1405,6 +1405,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -1609,6 +1609,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -1575,6 +1575,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -1132,6 +1132,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -1409,6 +1409,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -1645,6 +1645,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -1614,6 +1614,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -1126,6 +1126,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -1448,6 +1448,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -1556,6 +1556,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -1528,6 +1528,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -1362,6 +1362,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -1559,6 +1559,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -1531,6 +1531,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -1365,6 +1365,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -1563,6 +1563,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -1535,6 +1535,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -1369,6 +1369,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -1562,6 +1562,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -1534,6 +1534,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -1368,6 +1368,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -1574,6 +1574,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -1546,6 +1546,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -1380,6 +1380,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -1578,6 +1578,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -1550,6 +1550,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -1384,6 +1384,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -1559,6 +1559,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -1527,6 +1527,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -1127,6 +1127,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -1361,6 +1361,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -1584,6 +1584,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -1559,6 +1559,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -1404,6 +1404,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -1581,6 +1581,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -1553,6 +1553,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -1387,6 +1387,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -1605,6 +1605,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -1577,6 +1577,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -1411,6 +1411,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -1588,6 +1588,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -1544,6 +1544,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -1139,6 +1139,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -1378,6 +1378,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -1574,6 +1574,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -1543,6 +1543,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -1129,6 +1129,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -1377,6 +1377,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -1576,6 +1576,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -1545,6 +1545,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -1129,6 +1129,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -1379,6 +1379,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -1623,6 +1623,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -1595,6 +1595,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -1429,6 +1429,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -1606,6 +1606,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -1555,6 +1555,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -1146,6 +1146,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -1392,6 +1392,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -1571,6 +1571,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -1543,6 +1543,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -1377,6 +1377,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -1621,6 +1621,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -1589,6 +1589,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -1427,6 +1427,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -1644,6 +1644,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -1600,6 +1600,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -1142,6 +1142,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -1434,6 +1434,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -1606,6 +1606,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -1559,6 +1559,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -1146,6 +1146,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -1433,6 +1433,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -1599,6 +1599,10 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
     "anchor_href": {
       "type": "string",
       "pattern": "^#.+$",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -1563,6 +1563,10 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
     "anchor_href": {
       "type": "string",
       "pattern": "^#.+$",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -1131,6 +1131,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -1400,6 +1400,10 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
     "anchor_href": {
       "type": "string",
       "pattern": "^#.+$",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -1555,6 +1555,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -1527,6 +1527,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -1361,6 +1361,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -1568,6 +1568,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -1536,6 +1536,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -1127,6 +1127,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -1370,6 +1370,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -1605,6 +1605,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -1577,6 +1577,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -1411,6 +1411,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -1578,6 +1578,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -1538,6 +1538,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -1135,6 +1135,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -1372,6 +1372,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -488,7 +488,7 @@
       ],
       "properties": {
         "start_button_text": {
-          "type": "string"
+          "$ref": "#/definitions/start_button_text"
         },
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"
@@ -1623,6 +1623,10 @@
     },
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
     }
   }

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -460,7 +460,7 @@
       ],
       "properties": {
         "start_button_text": {
-          "type": "string"
+          "$ref": "#/definitions/start_button_text"
         },
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"
@@ -1595,6 +1595,10 @@
     },
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
     }
   }

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -288,7 +288,7 @@
       ],
       "properties": {
         "start_button_text": {
-          "type": "string"
+          "$ref": "#/definitions/start_button_text"
         },
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"
@@ -1429,6 +1429,10 @@
     },
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
     }
   }

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -1556,6 +1556,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -1528,6 +1528,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -1362,6 +1362,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1586,6 +1586,10 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
     "any_metadata": {
       "type": "object",
       "anyOf": [

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -1553,6 +1553,10 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
     "any_metadata": {
       "type": "object",
       "anyOf": [

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1398,6 +1398,10 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
     "any_metadata": {
       "type": "object",
       "anyOf": [

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -1623,6 +1623,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -1570,6 +1570,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -1148,6 +1148,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -1407,6 +1407,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -1580,6 +1580,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -1552,6 +1552,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -1389,6 +1389,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -1592,6 +1592,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -1564,6 +1564,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -1398,6 +1398,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -1566,6 +1566,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -1538,6 +1538,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -1372,6 +1372,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -1575,6 +1575,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -1539,6 +1539,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -1127,6 +1127,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -1381,6 +1381,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -1566,6 +1566,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -1534,6 +1534,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -1127,6 +1127,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -1368,6 +1368,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -1566,6 +1566,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -1538,6 +1538,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -1372,6 +1372,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -515,6 +515,9 @@
           "description": "Text of the message alerting the user of service downtime",
           "type": "string"
         },
+        "start_button_text": {
+          "$ref": "#/definitions/start_button_text"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }
@@ -1586,6 +1589,10 @@
     },
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
     }
   }

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -487,6 +487,9 @@
           "description": "Text of the message alerting the user of service downtime",
           "type": "string"
         },
+        "start_button_text": {
+          "$ref": "#/definitions/start_button_text"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }
@@ -1558,6 +1561,10 @@
     },
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
     }
   }

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -314,6 +314,9 @@
         "downtime_message": {
           "description": "Text of the message alerting the user of service downtime",
           "type": "string"
+        },
+        "start_button_text": {
+          "$ref": "#/definitions/start_button_text"
         }
       }
     },
@@ -1392,6 +1395,10 @@
     },
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
       "type": "string"
     }
   }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -1610,6 +1610,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -1579,6 +1579,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -1126,6 +1126,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -1413,6 +1413,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -1571,6 +1571,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -1540,6 +1540,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -1126,6 +1126,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -1374,6 +1374,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -1579,6 +1579,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -1551,6 +1551,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -1385,6 +1385,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -1562,6 +1562,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -1534,6 +1534,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -1368,6 +1368,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -1572,6 +1572,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -1540,6 +1540,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -1123,6 +1123,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -1375,6 +1375,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -1589,6 +1589,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -1552,6 +1552,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -1132,6 +1132,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -1389,6 +1389,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -1070,6 +1070,10 @@
     "will_continue_on": {
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
     }
   }
 }

--- a/formats/simple_smart_answer/publisher/details.json
+++ b/formats/simple_smart_answer/publisher/details.json
@@ -7,7 +7,7 @@
   ],
   "properties": {
     "start_button_text": {
-      "type": "string"
+      "$ref": "#/definitions/start_button_text"
     },
     "body": {
       "$ref": "#/definitions/body_html_and_govspeak"

--- a/formats/transaction/frontend/examples/child-maintenance.json
+++ b/formats/transaction/frontend/examples/child-maintenance.json
@@ -1,0 +1,531 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/calculate-your-child-maintenance",
+  "content_id": "42c2e944-7977-4297-b142-aa9406756dd2",
+  "document_type": "transaction",
+  "email_document_supertype": "other",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "government_document_supertype": "other",
+  "locale": "en",
+  "navigation_document_supertype": "guidance",
+  "need_ids": [
+
+  ],
+  "phase": "live",
+  "public_updated_at": "2017-06-30T14:40:01.000+00:00",
+  "publishing_app": "smartanswers",
+  "rendering_app": "frontend",
+  "schema_name": "transaction",
+  "title": "Child maintenance calculator",
+  "updated_at": "2017-06-30T14:40:01.917Z",
+  "user_journey_document_supertype": "thing",
+  "withdrawn_notice": {
+  },
+  "publishing_request_id": "26015-1498833601.417-10.3.3.1-395",
+  "links": {
+    "mainstream_browse_pages": [
+      {
+        "api_path": "/api/content/browse/childcare-parenting/divorce-separation-legal",
+        "base_path": "/browse/childcare-parenting/divorce-separation-legal",
+        "content_id": "0d29abb4-efb3-4fd7-b798-f707b03a1e6a",
+        "description": "Child maintenance and disagreements about parentage",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-09-02T12:41:19Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Divorce, separation and legal issues",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting/divorce-separation-legal",
+        "web_url": "https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal"
+      },
+      {
+        "api_path": "/api/content/browse/births-deaths-marriages/marriage-divorce",
+        "base_path": "/browse/births-deaths-marriages/marriage-divorce",
+        "content_id": "a1c39054-4fd5-44e9-8d1d-0c7acd57a6a4",
+        "description": "Includes getting married abroad, decree absolutes and looking after children",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2017-06-08T15:46:37Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Marriage, civil partnership and divorce",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages/marriage-divorce",
+        "web_url": "https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce"
+      },
+      {
+        "api_path": "/api/content/browse/births-deaths-marriages/child-adoption",
+        "base_path": "/browse/births-deaths-marriages/child-adoption",
+        "content_id": "932a86f4-4916-4d9f-99cb-dfd34d7ee5d1",
+        "description": "Legal rights, birth certificates, parental rights and child maintenance",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-06-24T13:56:48Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Having a child, parenting and adoption",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages/child-adoption",
+        "web_url": "https://www.gov.uk/browse/births-deaths-marriages/child-adoption"
+      }
+    ],
+    "ordered_related_items": [
+      {
+        "api_path": "/api/content/child-maintenance",
+        "base_path": "/child-maintenance",
+        "content_id": "9718cd62-c165-4fc5-88cd-5d723b1bc314",
+        "description": "Child maintenance - how to work it out, how the Child Support Agency and Child Maintenance Service can help, complaints, appeals ",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2014-12-01T15:54:12Z",
+        "schema_name": "guide",
+        "title": "Use the Child Maintenance Service or Child Support Agency (CSA)",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "api_path": "/api/content/browse/births-deaths-marriages/child-adoption",
+              "base_path": "/browse/births-deaths-marriages/child-adoption",
+              "content_id": "932a86f4-4916-4d9f-99cb-dfd34d7ee5d1",
+              "description": "Legal rights, birth certificates, parental rights and child maintenance",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:48Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Having a child, parenting and adoption",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/births-deaths-marriages",
+                    "base_path": "/browse/births-deaths-marriages",
+                    "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+                    "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Births, deaths, marriages and care",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+                    "web_url": "https://www.gov.uk/browse/births-deaths-marriages"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages/child-adoption",
+              "web_url": "https://www.gov.uk/browse/births-deaths-marriages/child-adoption"
+            },
+            {
+              "api_path": "/api/content/browse/childcare-parenting/divorce-separation-legal",
+              "base_path": "/browse/childcare-parenting/divorce-separation-legal",
+              "content_id": "0d29abb4-efb3-4fd7-b798-f707b03a1e6a",
+              "description": "Child maintenance and disagreements about parentage",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-09-02T12:41:19Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Divorce, separation and legal issues",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "https://www.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting/divorce-separation-legal",
+              "web_url": "https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal"
+            },
+            {
+              "api_path": "/api/content/browse/births-deaths-marriages/marriage-divorce",
+              "base_path": "/browse/births-deaths-marriages/marriage-divorce",
+              "content_id": "a1c39054-4fd5-44e9-8d1d-0c7acd57a6a4",
+              "description": "Includes getting married abroad, decree absolutes and looking after children",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2017-06-08T15:46:37Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Marriage, civil partnership and divorce",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/births-deaths-marriages",
+                    "base_path": "/browse/births-deaths-marriages",
+                    "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+                    "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Births, deaths, marriages and care",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+                    "web_url": "https://www.gov.uk/browse/births-deaths-marriages"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages/marriage-divorce",
+              "web_url": "https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/child-maintenance",
+        "web_url": "https://www.gov.uk/child-maintenance"
+      },
+      {
+        "api_path": "/api/content/arranging-child-maintenance-yourself",
+        "base_path": "/arranging-child-maintenance-yourself",
+        "content_id": "d4e3eea4-e502-447e-a3eb-cb93cbf55a32",
+        "description": "How to arrange child maintenance yourself without using the Child Maintenance Service - family-based arrangements",
+        "document_type": "answer",
+        "locale": "en",
+        "public_updated_at": "2016-04-13T13:13:51Z",
+        "schema_name": "answer",
+        "title": "Arranging child maintenance yourself",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "api_path": "/api/content/browse/births-deaths-marriages/child-adoption",
+              "base_path": "/browse/births-deaths-marriages/child-adoption",
+              "content_id": "932a86f4-4916-4d9f-99cb-dfd34d7ee5d1",
+              "description": "Legal rights, birth certificates, parental rights and child maintenance",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:48Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Having a child, parenting and adoption",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/births-deaths-marriages",
+                    "base_path": "/browse/births-deaths-marriages",
+                    "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+                    "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Births, deaths, marriages and care",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+                    "web_url": "https://www.gov.uk/browse/births-deaths-marriages"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages/child-adoption",
+              "web_url": "https://www.gov.uk/browse/births-deaths-marriages/child-adoption"
+            },
+            {
+              "api_path": "/api/content/browse/childcare-parenting/divorce-separation-legal",
+              "base_path": "/browse/childcare-parenting/divorce-separation-legal",
+              "content_id": "0d29abb4-efb3-4fd7-b798-f707b03a1e6a",
+              "description": "Child maintenance and disagreements about parentage",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-09-02T12:41:19Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Divorce, separation and legal issues",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "https://www.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting/divorce-separation-legal",
+              "web_url": "https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal"
+            },
+            {
+              "api_path": "/api/content/browse/births-deaths-marriages/marriage-divorce",
+              "base_path": "/browse/births-deaths-marriages/marriage-divorce",
+              "content_id": "a1c39054-4fd5-44e9-8d1d-0c7acd57a6a4",
+              "description": "Includes getting married abroad, decree absolutes and looking after children",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2017-06-08T15:46:37Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Marriage, civil partnership and divorce",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/births-deaths-marriages",
+                    "base_path": "/browse/births-deaths-marriages",
+                    "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+                    "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Births, deaths, marriages and care",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+                    "web_url": "https://www.gov.uk/browse/births-deaths-marriages"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages/marriage-divorce",
+              "web_url": "https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/arranging-child-maintenance-yourself",
+        "web_url": "https://www.gov.uk/arranging-child-maintenance-yourself"
+      },
+      {
+        "api_path": "/api/content/how-child-maintenance-is-worked-out",
+        "base_path": "/how-child-maintenance-is-worked-out",
+        "content_id": "fcc24c49-45e5-4e17-bb2a-efc9a0fbc34f",
+        "description": "Use the child maintenance calculator to work out how much child maintenance to pay - or see how the Child Support Agency and Child Maintenance Service work out maintenance, and the rates they use ",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2016-02-11T15:15:25Z",
+        "schema_name": "guide",
+        "title": "How child maintenance is worked out",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "api_path": "/api/content/browse/childcare-parenting/divorce-separation-legal",
+              "base_path": "/browse/childcare-parenting/divorce-separation-legal",
+              "content_id": "0d29abb4-efb3-4fd7-b798-f707b03a1e6a",
+              "description": "Child maintenance and disagreements about parentage",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-09-02T12:41:19Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Divorce, separation and legal issues",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "https://www.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting/divorce-separation-legal",
+              "web_url": "https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal"
+            },
+            {
+              "api_path": "/api/content/browse/births-deaths-marriages/child-adoption",
+              "base_path": "/browse/births-deaths-marriages/child-adoption",
+              "content_id": "932a86f4-4916-4d9f-99cb-dfd34d7ee5d1",
+              "description": "Legal rights, birth certificates, parental rights and child maintenance",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:48Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Having a child, parenting and adoption",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/births-deaths-marriages",
+                    "base_path": "/browse/births-deaths-marriages",
+                    "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+                    "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Births, deaths, marriages and care",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+                    "web_url": "https://www.gov.uk/browse/births-deaths-marriages"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages/child-adoption",
+              "web_url": "https://www.gov.uk/browse/births-deaths-marriages/child-adoption"
+            },
+            {
+              "api_path": "/api/content/browse/births-deaths-marriages/marriage-divorce",
+              "base_path": "/browse/births-deaths-marriages/marriage-divorce",
+              "content_id": "a1c39054-4fd5-44e9-8d1d-0c7acd57a6a4",
+              "description": "Includes getting married abroad, decree absolutes and looking after children",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2017-06-08T15:46:37Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Marriage, civil partnership and divorce",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "api_path": "/api/content/browse/births-deaths-marriages",
+                    "base_path": "/browse/births-deaths-marriages",
+                    "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+                    "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Births, deaths, marriages and care",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages",
+                    "web_url": "https://www.gov.uk/browse/births-deaths-marriages"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/births-deaths-marriages/marriage-divorce",
+              "web_url": "https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/how-child-maintenance-is-worked-out",
+        "web_url": "https://www.gov.uk/how-child-maintenance-is-worked-out"
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "D10",
+        "api_path": "/api/content/government/organisations/department-for-work-pensions",
+        "base_path": "/government/organisations/department-for-work-pensions",
+        "content_id": "b548a09f-8b35-4104-89f4-f1a40bf3136d",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2016-12-16T11:37:21Z",
+        "schema_name": "placeholder",
+        "title": "Department for Work and Pensions",
+        "withdrawn": false,
+        "details": {
+          "brand": "department-for-work-pensions",
+          "logo": {
+            "formatted_title": "Department<br/>for Work &amp; <br/>Pensions",
+            "crest": "single-identity"
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-pensions",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-work-pensions"
+      }
+    ],
+    "parent": [
+      {
+        "api_path": "/api/content/browse/childcare-parenting/divorce-separation-legal",
+        "base_path": "/browse/childcare-parenting/divorce-separation-legal",
+        "content_id": "0d29abb4-efb3-4fd7-b798-f707b03a1e6a",
+        "description": "Child maintenance and disagreements about parentage",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-09-02T12:41:19Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Divorce, separation and legal issues",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "api_path": "/api/content/browse/childcare-parenting",
+              "base_path": "/browse/childcare-parenting",
+              "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+              "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-07-15T11:40:43Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Childcare and parenting",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting",
+              "web_url": "https://www.gov.uk/browse/childcare-parenting"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/browse/childcare-parenting/divorce-separation-legal",
+        "web_url": "https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Child maintenance calculator",
+        "public_updated_at": "2017-06-30T14:40:01Z",
+        "document_type": "smart_answer",
+        "schema_name": "generic_with_external_related_links",
+        "base_path": "/calculate-your-child-maintenance",
+        "api_path": "/api/content/calculate-your-child-maintenance",
+        "withdrawn": false,
+        "content_id": "42c2e944-7977-4297-b142-aa9406756dd2",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/calculate-your-child-maintenance",
+        "web_url": "https://www.gov.uk/calculate-your-child-maintenance",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": null,
+  "details": {
+    "external_related_links": [
+      {
+        "title": "Child Maintenance Options - How much should be paid",
+        "url": "http://www.cmoptions.org/en/maintenance/how-much.asp"
+      },
+      {
+        "title": "Child Maintenance Options - Ways to pay",
+        "url": "http://www.cmoptions.org/en/maintenance/ways-to-pay.asp"
+      }
+    ],
+    "start_button_text": "Calculate your child maintenance"
+  }
+}

--- a/formats/transaction/publisher/details.json
+++ b/formats/transaction/publisher/details.json
@@ -33,6 +33,9 @@
     "downtime_message": {
       "description": "Text of the message alerting the user of service downtime",
       "type": "string"
+    },
+    "start_button_text": {
+      "$ref": "#/definitions/start_button_text"
     }
   }
 }


### PR DESCRIPTION
This will allow to pass in customised text for start buttons. This also adds
child-maintenance as an example of a transaction with a custom start button, and extracts the start_button_text as a definition since it's also being used by the simple_smart_answer schema.

cc @chrisroos @h-lame @nickcolley 

@pmanrubia @ikennaokpala are you or someone from your team available to review?

https://trello.com/c/arlZczQO/423-2-republish-smart-answer-part-year-profits-to-finalise-your-tax-credits-start-page-as-a-transaction-page