### PR TITLE
Remove `topic_content` and `mainstream_browse_content` reverse links

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -149,14 +149,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -157,14 +157,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -143,14 +143,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -143,14 +143,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -149,14 +149,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -145,14 +145,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -155,14 +155,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -146,14 +146,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -143,14 +143,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -144,14 +144,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -137,14 +137,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -156,14 +156,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -143,14 +143,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -143,14 +143,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -163,14 +163,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -144,14 +144,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -156,14 +156,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -159,14 +159,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -148,14 +148,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -144,14 +144,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -152,14 +152,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -145,14 +145,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -165,14 +165,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -148,14 +148,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -144,14 +144,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -143,14 +143,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -143,14 +143,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -140,14 +140,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -144,14 +144,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -149,14 +149,6 @@
         "child_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "topic_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_content": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/lib/schema_generator/frontend_schema_generator.rb
+++ b/lib/schema_generator/frontend_schema_generator.rb
@@ -41,14 +41,6 @@ module SchemaGenerator
       # Content items that are linked to with a `parent_taxon` link type will automatically
       # have a `child_taxon` link type with those items.
       "child_taxons",
-
-      # Content items that are linked to as a `topic` will automatically have a
-      # `topic_content` link type with those items.
-      "topic_content",
-
-      # Content items that are linked to as a `mainstream_browse_page` will automatically
-      # have a `mainstream_browse_content` link type with those items.
-      "mainstream_browse_content",
     ].freeze
 
     # TODO: Add all attributes that the content-store is currently sending.


### PR DESCRIPTION
These link types were added to allow the collections app to render the things linked to browse & topic pages from the content-store (https://github.com/alphagov/govuk-content-schemas/pull/535, https://trello.com/c/D8Heon8X). This didn't work, because there seemed to be too many differences between rummager and the content-store (https://github.com/alphagov/collections/pull/274). 

Since then we've had a bit of a change in thinking about this and we now accept that navigation pages can be built from search as well as the content-store. In any case, topic and browse pages will be retired at some point, so there's little value in trying to do this now.

Related in publishing-api: https://github.com/alphagov/publishing-api/pull/970