### PR TITLE
Change display title of medical_specialism finder in examples

### DIFF
--- a/formats/finder/frontend/examples/drug-device-alerts.json
+++ b/formats/finder/frontend/examples/drug-device-alerts.json
@@ -125,7 +125,7 @@
         "display_as_result_metadata": true,
         "filterable": true,
         "key": "medical_specialism",
-        "name": "Medical specialism",
+        "name": "Medical speciality",
         "preposition": "about",
         "type": "text"
       },

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -210,7 +210,7 @@
             },
             {
               "key": "medical_specialism",
-              "name": "Medical specialism",
+              "name": "Medical speciality",
               "type": "text",
               "preposition": "about",
               "display_as_result_metadata": true,


### PR DESCRIPTION
For: https://trello.com/c/HbnBgaJd/208-rename-filter-title-in-mhra-finder

The real finder has the title of this field changed to "Medical
speciality" to match the words used by the audience of these alerts
so we make the same change in the schemas for consistency.

This matches up with the changes in https://github.com/alphagov/specialist-publisher/pull/1051