### PR TITLE
Add payload_version field to unpublishing notification schemas

### DIFF
--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -85,6 +85,10 @@
           "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
     }
   },
   "definitions": {

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -47,6 +47,10 @@
       "items": {
         "$ref": "#/definitions/redirect_route"
       }
+    },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
     }
   },
   "definitions": {

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -25,6 +25,10 @@
     },
     "publishing_app": {
       "type": "string"
+    },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
     }
   },
   "definitions": {

--- a/formats/gone/notification/schema.json
+++ b/formats/gone/notification/schema.json
@@ -85,6 +85,10 @@
           "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
     }
   },
   "definitions": {

--- a/formats/redirect/notification/schema.json
+++ b/formats/redirect/notification/schema.json
@@ -47,6 +47,10 @@
       "items": {
         "$ref": "#/definitions/redirect_route"
       }
+    },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
     }
   },
   "definitions": {

--- a/formats/vanish/notification/schema.json
+++ b/formats/vanish/notification/schema.json
@@ -25,6 +25,10 @@
     },
     "publishing_app": {
       "type": "string"
+    },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
     }
   },
   "definitions": {


### PR DESCRIPTION
This field had already been added to the notification base, which added
it to most notification schemas. But it was missing from the unpublishing
schemas: gone, redirect and vanish.

Adding a payload_version to those schemas will allow the version to be
passed from the publishing API to rummager.

https://trello.com/c/LatZVRg8/213-make-versioning-work-for-all-publishing-events

Mobbed with @binaryberry, @Rosa-Fox, @MatMoore and @suzannehamilton.