### PR TITLE
Mandatory payload version

### DIFF
--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -4,7 +4,8 @@
   "additionalProperties": false,
   "required": [
     "publishing_app",
-    "routes"
+    "routes",
+    "payload_version"
   ],
   "properties": {
     "base_path": {

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -7,7 +7,8 @@
     "schema_name",
     "publishing_app",
     "redirects",
-    "base_path"
+    "base_path",
+    "payload_version"
   ],
   "properties": {
     "base_path": {

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -4,7 +4,8 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "publishing_app"
+    "publishing_app",
+    "payload_version"
   ],
   "properties": {
     "base_path": {

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -10,6 +10,7 @@
     "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
     "redirects",
     "routes",
     "schema_name",

--- a/formats/gone/notification/schema.json
+++ b/formats/gone/notification/schema.json
@@ -4,7 +4,8 @@
   "additionalProperties": false,
   "required": [
     "publishing_app",
-    "routes"
+    "routes",
+    "payload_version"
   ],
   "properties": {
     "base_path": {

--- a/formats/notification_base.json
+++ b/formats/notification_base.json
@@ -8,7 +8,8 @@
     "update_type",
     "links",
     "expanded_links",
-    "govuk_request_id"
+    "govuk_request_id",
+    "payload_version"
   ],
   "properties": {
     "routes": {

--- a/formats/redirect/notification/schema.json
+++ b/formats/redirect/notification/schema.json
@@ -7,7 +7,8 @@
     "schema_name",
     "publishing_app",
     "redirects",
-    "base_path"
+    "base_path",
+    "payload_version"
   ],
   "properties": {
     "base_path": {

--- a/formats/vanish/notification/schema.json
+++ b/formats/vanish/notification/schema.json
@@ -4,7 +4,8 @@
   "additionalProperties": false,
   "required": [
     "base_path",
-    "publishing_app"
+    "publishing_app",
+    "payload_version"
   ],
   "properties": {
     "base_path": {


### PR DESCRIPTION
When we added the payload_version field to the notification schemas, we made it
optional because it needed to be compatible with the old version of the
publishing API (which did not add the field) and the new version (which does).

Rummager is now relying on the presence of that field and the publishing API
always adds it, so we should make it a required field.

https://trello.com/c/i2ZJtwyQ/220-make-payloadversion-a-required-field