### PR TITLE
Allow nil value for publishing publishing_request_id

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -1390,7 +1390,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -1355,7 +1355,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -1172,7 +1172,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -1430,7 +1430,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -1386,7 +1386,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -936,7 +936,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -1206,7 +1206,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -1394,7 +1394,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -1359,7 +1359,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -1176,7 +1176,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -1407,7 +1407,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -1372,7 +1372,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -1189,7 +1189,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -1482,7 +1482,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -1430,7 +1430,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -944,7 +944,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -1285,7 +1285,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -1587,7 +1587,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -1549,7 +1549,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -930,7 +930,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -1363,7 +1363,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -1405,7 +1405,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -1367,7 +1367,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -930,7 +930,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -1201,7 +1201,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -1439,7 +1439,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -1395,7 +1395,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -936,7 +936,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -1215,7 +1215,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -1441,7 +1441,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -1401,7 +1401,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -937,7 +937,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -1244,7 +1244,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -1430,7 +1430,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -1395,7 +1395,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -1212,7 +1212,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -1414,7 +1414,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -1364,7 +1364,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -943,7 +943,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -1209,7 +1209,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -1437,7 +1437,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -1396,7 +1396,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -936,7 +936,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -1213,7 +1213,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -1473,7 +1473,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -1435,7 +1435,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -930,7 +930,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -1252,7 +1252,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -1384,7 +1384,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -1349,7 +1349,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -1166,7 +1166,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -1387,7 +1387,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -1352,7 +1352,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -1169,7 +1169,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -1391,7 +1391,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -1356,7 +1356,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -1173,7 +1173,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -1390,7 +1390,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -1355,7 +1355,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -1172,7 +1172,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -1402,7 +1402,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -1367,7 +1367,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -1184,7 +1184,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -1406,7 +1406,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -1371,7 +1371,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -1188,7 +1188,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -1387,7 +1387,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -1348,7 +1348,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -931,7 +931,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -1165,7 +1165,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -1412,7 +1412,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -1380,7 +1380,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -1208,7 +1208,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -1409,7 +1409,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -1374,7 +1374,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -1191,7 +1191,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -1433,7 +1433,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -1398,7 +1398,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -1215,7 +1215,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -1416,7 +1416,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -1365,7 +1365,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -943,7 +943,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -1182,7 +1182,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -1402,7 +1402,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -1364,7 +1364,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -933,7 +933,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -1181,7 +1181,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -1404,7 +1404,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -1366,7 +1366,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -933,7 +933,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -1183,7 +1183,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -1451,7 +1451,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -1416,7 +1416,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -1233,7 +1233,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -1434,7 +1434,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -1376,7 +1376,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -950,7 +950,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -1196,7 +1196,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -1399,7 +1399,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -1364,7 +1364,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -1181,7 +1181,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -1449,7 +1449,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -1410,7 +1410,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -1231,7 +1231,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -1472,7 +1472,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -1421,7 +1421,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -946,7 +946,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -1238,7 +1238,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -1434,7 +1434,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -1380,7 +1380,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -950,7 +950,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -1237,7 +1237,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -1431,7 +1431,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -1388,7 +1388,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -935,7 +935,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -1208,7 +1208,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -1383,7 +1383,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -1348,7 +1348,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -1165,7 +1165,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -1396,7 +1396,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -1357,7 +1357,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -931,7 +931,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -1174,7 +1174,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -1433,7 +1433,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -1398,7 +1398,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -1215,7 +1215,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -1406,7 +1406,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -1359,7 +1359,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -939,7 +939,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -1176,7 +1176,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -1452,7 +1452,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -1417,7 +1417,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -1234,7 +1234,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -1384,7 +1384,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -1349,7 +1349,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -1166,7 +1166,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2514,7 +2514,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "raib_report_metadata": {
       "type": "object",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2474,7 +2474,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "raib_report_metadata": {
       "type": "object",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2302,7 +2302,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "raib_report_metadata": {
       "type": "object",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -1451,7 +1451,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -1391,7 +1391,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -952,7 +952,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -1211,7 +1211,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -1408,7 +1408,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -1373,7 +1373,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -1193,7 +1193,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -1420,7 +1420,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -1385,7 +1385,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -1202,7 +1202,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -1394,7 +1394,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -1359,7 +1359,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -1176,7 +1176,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -1403,7 +1403,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -1360,7 +1360,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -931,7 +931,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -1185,7 +1185,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -1394,7 +1394,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -1355,7 +1355,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -931,7 +931,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -1172,7 +1172,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -1394,7 +1394,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -1359,7 +1359,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -1176,7 +1176,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -1418,7 +1418,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -1383,7 +1383,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -1200,7 +1200,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -1438,7 +1438,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -1400,7 +1400,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -930,7 +930,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -1217,7 +1217,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -1399,7 +1399,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -1361,7 +1361,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -930,7 +930,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -1178,7 +1178,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -1407,7 +1407,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -1372,7 +1372,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -1189,7 +1189,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -1390,7 +1390,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -1355,7 +1355,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -1172,7 +1172,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -1400,7 +1400,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -1361,7 +1361,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -927,7 +927,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -1179,7 +1179,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -1417,7 +1417,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -1373,7 +1373,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -936,7 +936,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -1193,7 +1193,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "redirect_route": {
       "type": "object",

--- a/formats/case_study/frontend/examples/archived.json
+++ b/formats/case_study/frontend/examples/archived.json
@@ -2,6 +2,7 @@
   "base_path": "/government/case-studies/terence-age-33-stoke-on-trent",
   "content_id": "3933c3df-9fdd-4a56-99cd-9a9351cbbf99",
   "title": "Terence, age 33, Stoke-on-Trent",
+  "publishing_request_id": null,
   "description": "'My experience with Shaw Trust was very positive and I received all the support I needed to get back into work.'",
   "need_ids": [
 

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -595,7 +595,14 @@
     },
     "publishing_request_id": {
       "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "max_cache_time": {
       "description": "The maximum length of time the content should be cached, in seconds",


### PR DESCRIPTION
The content-store currently has a lot of nil-values for `publishing_request_id`. This is fine since that means the document wasn't published after the request id was introduced.

Context: I found this problem while investigating the content-store returning invalid content (https://trello.com/c/FesP8XSc). To get a better idea about how many items are invalid in the content-store,  https://github.com/alphagov/content-store/pull/306 was raised to allow us to build a [dashboard tracking invalid data][dash].

<img width="1415" alt="screen shot 2017-08-18 at 08 21 08" src="https://user-images.githubusercontent.com/233676/29448366-3cf84c96-83ee-11e7-910c-dc34e331a271.png">

It turns out most invalid data is related to the issue fixed in this PR, so I'm expecting the percentage of invalid content to go down a lot after this.
 
https://deploy.integration.publishing.service.gov.uk/job/check-content-store/23/consoleFull

[dash]: https://grafana.integration.publishing.service.gov.uk/dashboard/db/content-validation-content-store

https://trello.com/c/FesP8XSc
https://trello.com/c/53cyvyda