### PR TITLE
Change the display title of medical_specialism

### DIFF
--- a/formats/finder/frontend/examples/drug-device-alerts.json
+++ b/formats/finder/frontend/examples/drug-device-alerts.json
@@ -125,7 +125,7 @@
         "display_as_result_metadata": true,
         "filterable": true,
         "key": "medical_specialism",
-        "name": "Medical speciality",
+        "name": "Medical specialty",
         "preposition": "about",
         "type": "text"
       },

--- a/formats/specialist_document/frontend/examples/drug-device-alerts.json
+++ b/formats/specialist_document/frontend/examples/drug-device-alerts.json
@@ -210,7 +210,7 @@
             },
             {
               "key": "medical_specialism",
-              "name": "Medical speciality",
+              "name": "Medical specialty",
               "type": "text",
               "preposition": "about",
               "display_as_result_metadata": true,


### PR DESCRIPTION
For: https://trello.com/c/HbnBgaJd/208-rename-filter-title-in-mhra-finder

We got it wrong in the previous commit
(b529cb1b60d9447812c85d8ec1ccda44c84c92fc - #643) it should be specialty, not
speciality.  Specialty is the medical term and medicine is the domain for
this finder, so that's the word we should use.