### PR TITLE
Add whitehall admin as a rendering app

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -1456,7 +1456,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -1421,7 +1421,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -1238,7 +1238,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -1496,7 +1496,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -1452,7 +1452,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -1002,7 +1002,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -1272,7 +1272,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -1460,7 +1460,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -1425,7 +1425,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -1242,7 +1242,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -1473,7 +1473,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -1438,7 +1438,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -1255,7 +1255,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -1548,7 +1548,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -1496,7 +1496,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -1010,7 +1010,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -1351,7 +1351,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -1653,7 +1653,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -1615,7 +1615,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -996,7 +996,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -1429,7 +1429,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -1471,7 +1471,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -1433,7 +1433,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -996,7 +996,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -1267,7 +1267,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -1505,7 +1505,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -1461,7 +1461,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -1002,7 +1002,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -1281,7 +1281,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -1507,7 +1507,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -1467,7 +1467,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -1003,7 +1003,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -1310,7 +1310,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -1496,7 +1496,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -1461,7 +1461,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -1278,7 +1278,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -1480,7 +1480,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -1430,7 +1430,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -1009,7 +1009,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -1275,7 +1275,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -1503,7 +1503,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -1462,7 +1462,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -1002,7 +1002,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -1279,7 +1279,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -1539,7 +1539,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -1501,7 +1501,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -996,7 +996,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -1318,7 +1318,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -1450,7 +1450,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -1415,7 +1415,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -1232,7 +1232,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -1453,7 +1453,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -1418,7 +1418,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -1235,7 +1235,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -1457,7 +1457,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -1422,7 +1422,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -1239,7 +1239,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -1456,7 +1456,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -1421,7 +1421,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -1238,7 +1238,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -1468,7 +1468,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -1433,7 +1433,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -1250,7 +1250,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -1472,7 +1472,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -1437,7 +1437,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -1254,7 +1254,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -1453,7 +1453,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -1414,7 +1414,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -997,7 +997,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -1231,7 +1231,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -1478,7 +1478,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -1446,7 +1446,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -1274,7 +1274,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -1475,7 +1475,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -1440,7 +1440,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -1257,7 +1257,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -1499,7 +1499,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -1464,7 +1464,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -1281,7 +1281,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -1482,7 +1482,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -1431,7 +1431,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -1009,7 +1009,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -1248,7 +1248,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -1468,7 +1468,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -1430,7 +1430,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -999,7 +999,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -1247,7 +1247,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -1470,7 +1470,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -1432,7 +1432,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -999,7 +999,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -1249,7 +1249,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -1517,7 +1517,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -1482,7 +1482,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -1299,7 +1299,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -1500,7 +1500,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -1442,7 +1442,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -1016,7 +1016,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -1262,7 +1262,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -1465,7 +1465,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -1430,7 +1430,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -1247,7 +1247,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -1515,7 +1515,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -1476,7 +1476,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -1297,7 +1297,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -1538,7 +1538,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -1487,7 +1487,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -1012,7 +1012,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -1304,7 +1304,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -1500,7 +1500,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -1446,7 +1446,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -1016,7 +1016,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -1303,7 +1303,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -1497,7 +1497,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -1454,7 +1454,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -1001,7 +1001,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -1274,7 +1274,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -1449,7 +1449,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -1414,7 +1414,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -1231,7 +1231,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -1462,7 +1462,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -1423,7 +1423,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -997,7 +997,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -1240,7 +1240,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -1499,7 +1499,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -1464,7 +1464,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -1281,7 +1281,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -1472,7 +1472,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -1425,7 +1425,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -1005,7 +1005,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -1242,7 +1242,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -1518,7 +1518,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -1483,7 +1483,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -1300,7 +1300,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -1450,7 +1450,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -1415,7 +1415,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -1232,7 +1232,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2615,7 +2615,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2575,7 +2575,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2403,7 +2403,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -1517,7 +1517,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -1457,7 +1457,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -1018,7 +1018,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -1277,7 +1277,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -1474,7 +1474,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -1439,7 +1439,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -1259,7 +1259,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -1486,7 +1486,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -1451,7 +1451,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -1268,7 +1268,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -1460,7 +1460,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -1425,7 +1425,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -1242,7 +1242,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -1469,7 +1469,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -1426,7 +1426,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -997,7 +997,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -1251,7 +1251,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -1460,7 +1460,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -1421,7 +1421,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -997,7 +997,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -1238,7 +1238,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -1460,7 +1460,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -1425,7 +1425,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -1242,7 +1242,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -1484,7 +1484,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -1449,7 +1449,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -1266,7 +1266,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -1504,7 +1504,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -1466,7 +1466,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -996,7 +996,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -1283,7 +1283,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -1465,7 +1465,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -1427,7 +1427,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -996,7 +996,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -1244,7 +1244,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -1473,7 +1473,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -1438,7 +1438,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -1255,7 +1255,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -1456,7 +1456,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -1421,7 +1421,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -1238,7 +1238,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -1466,7 +1466,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -1427,7 +1427,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -993,7 +993,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -1245,7 +1245,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -1483,7 +1483,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -1439,7 +1439,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -1002,7 +1002,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -1259,7 +1259,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -190,7 +190,8 @@
             "spotlight",
             "static",
             "tariff",
-            "whitehall-frontend"
+            "whitehall-frontend",
+            "whitehall-admin"
           ]
         },
         {


### PR DESCRIPTION
whitehall-admin, rather than whitehall-frontend is responsible for
responding to requests for /government/uploads. Currently,
govuk-puppet sets up the NGinx configuration such that when the
request ends up at the frontend load balancer, it reverse proxies the
request to whitehall-admin.

Adding whitehall-admin as a valid rendering app will allow creating a
special route for directly routing traffic to whitehall-admin, which
will help with simplifying the routing, and making it more explicit.