### PR TITLE
Remove Need API

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -1371,7 +1371,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -1336,7 +1336,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -1153,7 +1153,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -1411,7 +1411,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -1367,7 +1367,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -917,7 +917,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -1187,7 +1187,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -1375,7 +1375,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -1340,7 +1340,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -1157,7 +1157,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -1388,7 +1388,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -1353,7 +1353,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -1170,7 +1170,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -1463,7 +1463,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -1411,7 +1411,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -925,7 +925,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -1266,7 +1266,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -1568,7 +1568,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -1530,7 +1530,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -911,7 +911,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -1344,7 +1344,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -1386,7 +1386,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -1348,7 +1348,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -911,7 +911,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -1182,7 +1182,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -1420,7 +1420,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -1376,7 +1376,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -917,7 +917,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -1196,7 +1196,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -1422,7 +1422,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -1382,7 +1382,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -918,7 +918,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -1225,7 +1225,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -1411,7 +1411,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -1376,7 +1376,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -1193,7 +1193,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -1395,7 +1395,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -1345,7 +1345,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -924,7 +924,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -1190,7 +1190,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -1418,7 +1418,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -1377,7 +1377,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -917,7 +917,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -1194,7 +1194,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -1454,7 +1454,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -1416,7 +1416,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -911,7 +911,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -1233,7 +1233,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -1365,7 +1365,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -1330,7 +1330,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -1147,7 +1147,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -1368,7 +1368,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -1333,7 +1333,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -1150,7 +1150,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -1372,7 +1372,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -1337,7 +1337,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -1154,7 +1154,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -1371,7 +1371,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -1336,7 +1336,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -1153,7 +1153,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -1383,7 +1383,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -1348,7 +1348,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -1165,7 +1165,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -1387,7 +1387,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -1352,7 +1352,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -1169,7 +1169,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -1368,7 +1368,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -1329,7 +1329,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -912,7 +912,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -1146,7 +1146,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -1393,7 +1393,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -1361,7 +1361,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -1189,7 +1189,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -1390,7 +1390,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -1355,7 +1355,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -1172,7 +1172,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -1414,7 +1414,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -1379,7 +1379,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -1196,7 +1196,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -1397,7 +1397,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -1346,7 +1346,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -924,7 +924,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -1163,7 +1163,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -1383,7 +1383,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -1345,7 +1345,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -914,7 +914,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -1162,7 +1162,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -1385,7 +1385,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -1347,7 +1347,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -914,7 +914,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -1164,7 +1164,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -1432,7 +1432,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -1397,7 +1397,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -1214,7 +1214,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -1415,7 +1415,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -1357,7 +1357,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -931,7 +931,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -1177,7 +1177,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -1380,7 +1380,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -1345,7 +1345,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -1162,7 +1162,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -1430,7 +1430,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -1391,7 +1391,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -1212,7 +1212,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -1453,7 +1453,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -1402,7 +1402,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -927,7 +927,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -1219,7 +1219,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -1415,7 +1415,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -1361,7 +1361,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -931,7 +931,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -1218,7 +1218,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -1412,7 +1412,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -1369,7 +1369,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -916,7 +916,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -1189,7 +1189,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -1364,7 +1364,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -1329,7 +1329,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -1146,7 +1146,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -1377,7 +1377,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -1338,7 +1338,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -912,7 +912,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -1155,7 +1155,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -1414,7 +1414,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -1379,7 +1379,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -1196,7 +1196,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -1387,7 +1387,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -1340,7 +1340,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -920,7 +920,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -1157,7 +1157,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -1433,7 +1433,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -1398,7 +1398,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -1215,7 +1215,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -1365,7 +1365,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -1330,7 +1330,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -1147,7 +1147,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -2495,7 +2495,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -2455,7 +2455,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2283,7 +2283,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -1432,7 +1432,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -1372,7 +1372,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -933,7 +933,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -1192,7 +1192,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -1389,7 +1389,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -1354,7 +1354,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -1174,7 +1174,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -1401,7 +1401,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -1366,7 +1366,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -1183,7 +1183,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -1375,7 +1375,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -1340,7 +1340,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -1157,7 +1157,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -1384,7 +1384,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -1341,7 +1341,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -912,7 +912,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -1166,7 +1166,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -1375,7 +1375,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -1336,7 +1336,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -912,7 +912,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -1153,7 +1153,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -1375,7 +1375,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -1340,7 +1340,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -1157,7 +1157,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -1399,7 +1399,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -1364,7 +1364,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -1181,7 +1181,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -1419,7 +1419,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -1381,7 +1381,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -911,7 +911,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -1198,7 +1198,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -1380,7 +1380,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -1342,7 +1342,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -911,7 +911,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -1159,7 +1159,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -1388,7 +1388,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -1353,7 +1353,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -1170,7 +1170,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -1371,7 +1371,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -1336,7 +1336,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -1153,7 +1153,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -1381,7 +1381,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -1342,7 +1342,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -908,7 +908,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -1160,7 +1160,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -1398,7 +1398,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -1354,7 +1354,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -917,7 +917,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -1174,7 +1174,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",

--- a/formats/definitions.json
+++ b/formats/definitions.json
@@ -146,7 +146,6 @@
         "manuals-frontend",
         "manuals-publisher",
         "maslow",
-        "need-api",
         "performanceplatform-big-screen-view",
         "policy-publisher",
         "publisher",


### PR DESCRIPTION
Need API is being retired so we're removing references to it.

For: https://trello.com/c/ClCFMBlG/217-retire-need-api