### PR TITLE
Add contact_groups field to contacts

### DIFF
--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -594,6 +594,25 @@
             }
           }
         },
+        "contact_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "slug",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "slug": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "contact_type": {
           "type": "string"
         },

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -556,6 +556,25 @@
             }
           }
         },
+        "contact_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "slug",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "slug": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "contact_type": {
           "type": "string"
         },

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -445,6 +445,25 @@
             }
           }
         },
+        "contact_groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "slug",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "slug": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "contact_type": {
           "type": "string"
         },

--- a/formats/contact/frontend/examples/contact.json
+++ b/formats/contact/frontend/examples/contact.json
@@ -154,7 +154,13 @@
       }
     ],
     "more_info_post_address": "\n",
-    "language": "en"
+    "language": "en",
+    "contact_groups": [
+      {
+        "slug": "customs-excise",
+        "title": "Customs and Excise"
+      }
+    ]
   },
   "schema_name": "contact",
   "document_type": "contact"

--- a/formats/contact/publisher/details.json
+++ b/formats/contact/publisher/details.json
@@ -202,6 +202,25 @@
     },
     "language": {
       "type": "string"
+    },
+    "contact_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "slug",
+          "title"
+        ],
+        "properties": {
+          "slug": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/formats/contact/publisher_v2/examples/whitehall-contact.json
+++ b/formats/contact/publisher_v2/examples/whitehall-contact.json
@@ -22,6 +22,12 @@
     ],
     "email_addresses": [
 
+    ],
+    "contact_groups": [
+      {
+        "title": "Online Services",
+        "slug": "online-services"
+      }
     ]
   },
   "publishing_app": "whitehall",


### PR DESCRIPTION
The contact_groups properties are used in search:
- The title is included in the indexable content for a contact, so that users can find the contact if their search term includes the name of the contact group.
- The slug is used by the search filter in the [HMRC contacts finder](https://www.gov.uk/government/organisations/hm-revenue-customs/contact)

The contacts admin app currently sends these fields directly to rummager, but we are currently changing this process so that all data in the search index comes from the publishing API, which means these fields need to be in the schemas.

https://trello.com/c/KX2WILnc/332-add-contactgroups-to-publishing-api

Once we've republished all the contacts, we'll come back and make this contact_groups a required field.