### PR TITLE
 Make contact_groups a required field for contacts

### DIFF
--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -569,7 +569,8 @@
     "details": {
       "type": "object",
       "required": [
-        "title"
+        "title",
+        "contact_groups"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -531,7 +531,8 @@
     "details": {
       "type": "object",
       "required": [
-        "title"
+        "title",
+        "contact_groups"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -423,7 +423,8 @@
     "details": {
       "type": "object",
       "required": [
-        "title"
+        "title",
+        "contact_groups"
       ],
       "additionalProperties": false,
       "properties": {

--- a/formats/contact/frontend/examples/contact_with_email_and_no_other_contacts.json
+++ b/formats/contact/frontend/examples/contact_with_email_and_no_other_contacts.json
@@ -130,6 +130,9 @@
       }
     ],
     "more_info_post_address": "\n",
-    "language": "en"
+    "language": "en",
+    "contact_groups": [
+
+    ]
   }
 }

--- a/formats/contact/frontend/examples/contact_with_webchat.json
+++ b/formats/contact/frontend/examples/contact_with_webchat.json
@@ -179,6 +179,9 @@
       }
     ],
     "more_info_post_address": "\n",
-    "language": "en"
+    "language": "en",
+    "contact_groups": [
+
+    ]
   }
 }

--- a/formats/contact/frontend/examples/contact_with_welsh.json
+++ b/formats/contact/frontend/examples/contact_with_welsh.json
@@ -155,6 +155,9 @@
 
     ],
     "more_info_post_address": "\n",
-    "language": "en"
+    "language": "en",
+    "contact_groups": [
+
+    ]
   }
 }

--- a/formats/contact/publisher/details.json
+++ b/formats/contact/publisher/details.json
@@ -3,7 +3,8 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "title"
+    "title",
+    "contact_groups"
   ],
   "properties": {
     "slug": {


### PR DESCRIPTION
Now that Contacts Admin sends the contacts_group field to the publishing API and all the contacts have been republished, this field should always be present even if it's an empty array.

Making this a required field will simplify the rummager code which depends on it.

https://trello.com/c/KX2WILnc/332-add-contactgroups-to-publishing-api

Paired with @Rosa-Fox 

The build will fail until we've deployed the latest version of publishing API.