### PR TITLE
Add document type 'task_list' into allowed document types

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -173,6 +173,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -188,6 +188,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -176,6 +176,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -173,6 +173,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -188,6 +188,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -176,6 +176,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -173,6 +173,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -188,6 +188,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -176,6 +176,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -176,6 +176,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -191,6 +191,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -176,6 +176,7 @@
         "statistics_announcement",
         "statutory_guidance",
         "take_part",
+        "task_list",
         "tax_tribunal_decision",
         "taxon",
         "terms_of_reference",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -137,6 +137,7 @@
 - statistics_announcement
 - statutory_guidance
 - take_part
+- task_list
 - tax_tribunal_decision
 - taxon
 - terms_of_reference


### PR DESCRIPTION
This commit adds the placeholder_task_list, that should allow us to run the BETA
version of the task list pages that we are preparing.

Trello:
https://trello.com/c/WOhDbn9e/208-publish-route-for-the-task-list-page