### PR TITLE
Remove business_support as allowed document type

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -43,7 +43,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -58,7 +58,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -43,7 +43,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -58,7 +58,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -43,7 +43,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -58,7 +58,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -61,7 +61,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support",
         "business_support_finder",
         "calculator",
         "calendar",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -7,7 +7,6 @@
 - asylum_support_decision
 - authored_article
 - business_finance_support_scheme
-- business_support
 - business_support_finder
 - calculator
 - calendar


### PR DESCRIPTION
For: https://trello.com/c/RRJOTFQo/252-remove-business-support-code-that-still-exist-in-publisher

This is part 4 of the work for this card to remove business support documents - this PR removes `business_support` from the schemas. Part 1 does the redirects (see: alphagov/publisher#648), part 2 removed the code from publisher (see: alphagov/publisher#649), and part 3 removes the old redirects from router-data (see: alphagov/router-data#5).

There aren't any examples or a specific schema for `business_support`; they're all `generic_with_external_related_links` with document_type of `business_support`.