### PR TITLE
Add Rummager to downstream builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ def dependentApplications = [
   ['manuals-publisher', true],
   ['policy-publisher', true],
   ['publisher', true],
+  ['rummager', true],
   ['service-manual-publisher', true],
   ['short-url-manager', true],
   ['specialist-publisher', true],


### PR DESCRIPTION
Rummager currently tests against the schemas for payload messages from the publishing api.