### PR TITLE
Add Life Sciences industry to specialist_document schema

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -484,6 +484,7 @@
               "health",
               "hospitality-and-catering",
               "information-technology-digital-and-creative",
+              "life-sciences",
               "manufacturing",
               "mining",
               "real-estate-and-property",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -553,6 +553,7 @@
               "health",
               "hospitality-and-catering",
               "information-technology-digital-and-creative",
+              "life-sciences",
               "manufacturing",
               "mining",
               "real-estate-and-property",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -425,6 +425,7 @@
               "health",
               "hospitality-and-catering",
               "information-technology-digital-and-creative",
+              "life-sciences",
               "manufacturing",
               "mining",
               "real-estate-and-property",

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -238,6 +238,7 @@
             "health",
             "hospitality-and-catering",
             "information-technology-digital-and-creative",
+            "life-sciences",
             "manufacturing",
             "mining",
             "real-estate-and-property",


### PR DESCRIPTION
For [Trello](https://trello.com/c/PeyfXTmT/112-ability-to-add-industry-tag-life-sciences-to-a-business-finance-support-scheme-upload-form)

A user has discovered a bug in Specialist Publisher where an error occurs upon saving a document which is tagged with the "Life Sciences" industry (see [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/2418667)).  

It turns out that "Life Sciences" was not present as a permitted industry in the `specialist_document` schema, so this PR adds `life-sciences` to the list of allowed industries.

- [x] Tested on integration