### PR TITLE
Include feedback as dependent application for schema changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ def dependentApplications = [
   ['content-tagger', true],
   ['email-alert-frontend', true],
   ['email-alert-service', true],
+  ['feedback', true],
   ['finder-frontend', true],
   ['frontend', true],
   ['government-frontend', true],


### PR DESCRIPTION
Schema changes are currently not running specs against the feedback application, which resulted in a failed test when first running the feedback application.