### PR TITLE
Add search user need document supertype

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -170,6 +170,10 @@
         "answer"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -234,6 +234,10 @@
         "answer"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -179,6 +179,10 @@
         "case_study"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -252,6 +252,10 @@
         "case_study"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -170,6 +170,10 @@
         "coming_soon"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -234,6 +234,10 @@
         "coming_soon"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -170,6 +170,10 @@
         "completed_transaction"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -234,6 +234,10 @@
         "completed_transaction"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -186,6 +186,10 @@
         "consultation"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -263,6 +263,10 @@
         "consultation"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -173,6 +173,10 @@
         "contact"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -240,6 +240,10 @@
         "contact"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -164,6 +164,10 @@
         "corporate_information_page"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -203,6 +203,10 @@
         "corporate_information_page"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -180,6 +180,10 @@
         "detailed_guide"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -253,6 +253,10 @@
         "detailed_guide"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -181,6 +181,10 @@
         "document_collection"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -256,6 +256,10 @@
         "document_collection"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -170,6 +170,10 @@
         "email_alert_signup"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -234,6 +234,10 @@
         "email_alert_signup"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -185,6 +185,10 @@
         "fatality_notice"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -265,6 +265,10 @@
         "fatality_notice"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -175,6 +175,10 @@
         "finder"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -248,6 +248,10 @@
         "finder"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -172,6 +172,10 @@
         "finder_email_signup"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -238,6 +238,10 @@
         "finder_email_signup"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -330,6 +330,10 @@
         "generic"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -394,6 +394,10 @@
         "generic"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -330,6 +330,10 @@
         "generic_with_external_related_links"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -394,6 +394,10 @@
         "generic_with_external_related_links"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -128,6 +128,10 @@
         "gone"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "type": "null"
     },

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -150,6 +150,10 @@
         "gone"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "type": "null"
     },

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -170,6 +170,10 @@
         "guide"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -234,6 +234,10 @@
         "guide"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -170,6 +170,10 @@
         "help_page"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -234,6 +234,10 @@
         "help_page"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -170,6 +170,10 @@
         "hmrc_manual"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -234,6 +234,10 @@
         "hmrc_manual"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -170,6 +170,10 @@
         "hmrc_manual_section"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -234,6 +234,10 @@
         "hmrc_manual_section"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -137,6 +137,10 @@
         "homepage"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -167,6 +167,10 @@
         "homepage"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -167,6 +167,10 @@
         "html_publication"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -228,6 +228,10 @@
         "html_publication"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -170,6 +170,10 @@
         "licence"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -234,6 +234,10 @@
         "licence"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -170,6 +170,10 @@
         "local_transaction"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -234,6 +234,10 @@
         "local_transaction"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -148,6 +148,10 @@
         "mainstream_browse_page"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -190,6 +190,10 @@
         "mainstream_browse_page"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -137,6 +137,10 @@
         "manual"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -172,6 +172,10 @@
         "manual"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -171,6 +171,10 @@
         "manual_section"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -240,6 +240,10 @@
         "manual_section"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -170,6 +170,10 @@
         "need"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -234,6 +234,10 @@
         "need"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -197,6 +197,10 @@
         "news_article"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -284,6 +284,10 @@
         "news_article"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -170,6 +170,10 @@
         "place"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -234,6 +234,10 @@
         "place"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -333,6 +333,10 @@
       "type": "string",
       "pattern": "^(placeholder|placeholder_.+)$"
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -401,6 +401,10 @@
       "type": "string",
       "pattern": "^(placeholder|placeholder_.+)$"
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -185,6 +185,10 @@
         "policy"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -268,6 +268,10 @@
         "policy"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -209,6 +209,10 @@
         "publication"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -292,6 +292,10 @@
         "publication"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -131,6 +131,10 @@
         "redirect"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "type": "null"
     },

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -153,6 +153,10 @@
         "redirect"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "type": "null"
     },

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -178,6 +178,10 @@
         "service_manual_guide"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -250,6 +250,10 @@
         "service_manual_guide"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -170,6 +170,10 @@
         "service_manual_homepage"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -234,6 +234,10 @@
         "service_manual_homepage"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -174,6 +174,10 @@
         "service_manual_service_standard"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -242,6 +242,10 @@
         "service_manual_service_standard"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -170,6 +170,10 @@
         "service_manual_service_toolkit"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -234,6 +234,10 @@
         "service_manual_service_toolkit"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -182,6 +182,10 @@
         "service_manual_topic"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -258,6 +258,10 @@
         "service_manual_topic"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -170,6 +170,10 @@
         "simple_smart_answer"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -234,6 +234,10 @@
         "simple_smart_answer"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -333,6 +333,10 @@
         "special_route"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title_optional"
     },

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -397,6 +397,10 @@
         "special_route"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title_optional"
     },

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -193,6 +193,10 @@
         "specialist_document"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -263,6 +263,10 @@
         "specialist_document"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -198,6 +198,10 @@
         "speech"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -287,6 +287,10 @@
         "speech"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -170,6 +170,10 @@
         "statistical_data_set"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -234,6 +234,10 @@
         "statistical_data_set"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -173,6 +173,10 @@
         "statistics_announcement"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -236,6 +236,10 @@
         "statistics_announcement"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -170,6 +170,10 @@
         "take_part"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -234,6 +234,10 @@
         "take_part"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -178,6 +178,10 @@
         "taxon"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -250,6 +250,10 @@
         "taxon"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -174,6 +174,10 @@
         "topic"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -242,6 +242,10 @@
         "topic"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -170,6 +170,10 @@
         "topical_event_about_page"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -234,6 +234,10 @@
         "topical_event_about_page"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -170,6 +170,10 @@
         "transaction"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -234,6 +234,10 @@
         "transaction"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -173,6 +173,10 @@
         "travel_advice"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -240,6 +240,10 @@
         "travel_advice"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -173,6 +173,10 @@
         "travel_advice_index"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -240,6 +240,10 @@
         "travel_advice_index"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -170,6 +170,10 @@
         "unpublishing"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -234,6 +234,10 @@
         "unpublishing"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -153,6 +153,10 @@
         "vanish"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "type": "null"
     },

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -170,6 +170,10 @@
         "working_group"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -234,6 +234,10 @@
         "working_group"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -174,6 +174,10 @@
         "world_location"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -242,6 +242,10 @@
         "world_location"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -179,6 +179,10 @@
         "world_location_news_article"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -252,6 +252,10 @@
         "world_location_news_article"
       ]
     },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },

--- a/formats/shared/default_properties/publishing_api_out.jsonnet
+++ b/formats/shared/default_properties/publishing_api_out.jsonnet
@@ -17,6 +17,10 @@
   publishing_request_id: {
     "$ref": "#/definitions/publishing_request_id",
   },
+  search_user_need_document_supertype: {
+    type: "string",
+    description: "Document supertype grouping core and government documents",
+  },
   user_journey_document_supertype: {
     type: "string",
     description: "Document type grouping powering analytics of user journeys",

--- a/lib/schema_generator/frontend_schema_generator.rb
+++ b/lib/schema_generator/frontend_schema_generator.rb
@@ -33,6 +33,7 @@ module SchemaGenerator
       # - publishing_app
       # - publishing_request_id
       # - rendering_app
+      # - search_user_need_document_supertype
       # - user_journey_document_supertype
       # - withdrawn_notice
       %w(


### PR DESCRIPTION
Add `search_user_need_document_supertype` to group documents by core or government. In the short term this will be used in an A/B test to boost core (sometimes referred to as 'mainstream') documents in search results.

The Frontend team have been working on [grouping documents](https://gov-uk.atlassian.net/wiki/spaces/GFED/pages/187564388/Grouping+document+types+by+need) by user need however the groupings do not fit our current requirements because the document types that will be targeted are spread across the proposed Guidance and Service super groups.

https://trello.com/c/z9wtoGTV