### PR TITLE
Remove business_support_finder as an allowed document_type

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -43,7 +43,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -58,7 +58,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -43,7 +43,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -58,7 +58,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -43,7 +43,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -58,7 +58,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -61,7 +61,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -46,7 +46,6 @@
         "asylum_support_decision",
         "authored_article",
         "business_finance_support_scheme",
-        "business_support_finder",
         "calculator",
         "calendar",
         "campaign",

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -7,7 +7,6 @@
 - asylum_support_decision
 - authored_article
 - business_finance_support_scheme
-- business_support_finder
 - calculator
 - calendar
 - campaign


### PR DESCRIPTION
For: https://trello.com/c/ufw2S0ZX/265-create-publishing-api-redirect-for-business-finance-support-finder

We've unpublished the old custom finder that lived at
/business-finance-support-finder with a redirect to the new standard
finder that lives at /business-finance-support.  No other documents use
this document_type so we are safe to remove it.