### PR TITLE
Integrate dummy content store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,13 @@ ruby File.read(".ruby-version").strip
 gem 'json-schema'
 gem 'rake'
 gem 'rspec'
-gem 'govuk-dummy_content_store', '0.0.5'
-gem 'foreman', '0.78.0'
 gem 'jsonnet', '~> 0.2'
+
+# Preview app for examples
+gem 'foreman', '~> 0.84.0'
+gem 'sinatra', '~> 2.0'
+gem 'govuk_schemas', '~> 3.0.1'
+gem 'rack-test', '~> 0.8.2'
 
 group :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,18 +5,17 @@ GEM
     byebug (9.0.6)
     coderay (1.1.1)
     diff-lcs (1.2.5)
-    foreman (0.78.0)
+    foreman (0.84.0)
       thor (~> 0.19.1)
-    git-version-bump (0.15.1)
-    govuk-dummy_content_store (0.0.5)
-      rack
-      rack-contrib
+    govuk_schemas (3.0.1)
+      json-schema (~> 2.5.0)
     json-schema (2.5.0)
       addressable (~> 2.3)
     jsonnet (0.2.0)
       mini_portile2 (~> 2.2.0)
     method_source (0.8.2)
     mini_portile2 (2.2.0)
+    mustermann (1.0.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -24,10 +23,11 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rack (1.6.4)
-    rack-contrib (1.4.0)
-      git-version-bump (~> 0.15)
-      rack (~> 1.4)
+    rack (2.0.3)
+    rack-protection (2.0.0)
+      rack
+    rack-test (0.8.2)
+      rack (>= 1.0, < 3)
     rake (10.4.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -41,20 +41,28 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
     slop (3.6.0)
-    thor (0.19.1)
+    thor (0.19.4)
+    tilt (2.0.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  foreman (= 0.78.0)
-  govuk-dummy_content_store (= 0.0.5)
+  foreman (~> 0.84.0)
+  govuk_schemas (~> 3.0.1)
   json-schema
   jsonnet (~> 0.2)
   pry-byebug
+  rack-test (~> 0.8.2)
   rake
   rspec
+  sinatra (~> 2.0)
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec dummy_content_store
+web: bundle exec ruby app.rb

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For each schema, there are three possible representations:
 * [Adding contract tests to your app](docs/contract-testing-howto.md)
 * [Suggested workflows](docs/suggested-workflows.md)
 * [Why do contract testing?](docs/why-contract-testing.md)
-* [Running your frontend against the examples (content-store not needed)](docs/running-frontend-against-examples.md)
+* [Running your frontend against the examples and random content (content-store not needed)](docs/running-frontend-against-examples.md)
 * [Deployment](docs/deployment.md)
 
 ## Background

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,46 @@
+require "sinatra"
+require "govuk_schemas"
+
+set :views, "preview_app"
+
+get "/" do
+  schema_examples = {}
+  
+  Dir.glob("examples/**/frontend/*.json").each do |filename|
+    _, schema_name, _, example_file = filename.split("/")
+    
+    schema_examples[schema_name] ||= []
+    
+    schema_examples[schema_name] << {
+      example_name: example_file.gsub(".json", ""),
+      content_item: JSON.parse(File.read(filename))
+    }
+  end
+
+  erb :index, locals: { schema_examples: schema_examples }
+end
+
+get "/api/content/examples/:schema_name/random" do |schema_name|
+  content_type :json
+
+  content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: schema_name)
+  content_item["base_path"] = "/examples/#{schema_name}/random" 
+  content_item.to_json
+end
+
+get "/api/content/examples/:schema_name/:example_name" do |schema_name, example_name|
+  content_type :json
+  
+  begin
+    content_item = GovukSchemas::Example.find(schema_name, example_name: example_name)
+    content_item["base_path"] = "/examples/#{schema_name}/#{example_name}" 
+    content_item.to_json
+  rescue Errno::ENOENT
+    status 404
+    "Page not found. Perhaps you've mistyped the example name?"
+  end
+end
+
+get "/api/content/*" do
+  redirect "https://www.gov.uk/api/content/#{params[:splat].join("/")}"
+end

--- a/docs/running-frontend-against-examples.md
+++ b/docs/running-frontend-against-examples.md
@@ -1,8 +1,8 @@
 # Running your frontend against the examples
 
-The [dummy content store](https://github.com/alphagov/govuk-dummy_content_store) allows you to run an instance of content store, serving the examples in this repo, without having to the run the [content-store](https://github.com/alphagov/content-store) application itself.
+This repo contains a Sinatra app that allows you to run an instance of content store, serving the examples in this repo, without having to the run the [content-store](https://github.com/alphagov/content-store) application itself.
 
-It has the same API as the real [content-store](https://github.com/alphagov/content-store.) and can be used interchangably in your app. The only difference will be the content items available.
+It has the same API as the real [content-store](https://github.com/alphagov/content-store) and can be used interchangably in your app. The only difference will be the content items available.
 
 Note: The dummy content store also has an index page which lists all the example content items available, you can find this at the root path: `/`.
 

--- a/preview_app/index.erb
+++ b/preview_app/index.erb
@@ -1,0 +1,59 @@
+<!doctype html>
+<html class="no-js" lang="en">
+  <head>
+      <meta charset="utf-8">
+      <meta http-equiv="x-ua-compatible" content="ie=edge">
+      <title>Content schema examples</title>
+      <meta name="description" content="">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style media="screen">
+        body {
+          margin: 0 auto;
+          padding: 0 1em 3em;
+          max-width: 80em;
+          color: #111;
+          background: #fff;
+          font: medium 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        }
+
+        table {
+          border-collapse: collapse;
+        }
+
+        table th,
+        table td {
+          padding: .75em 1.2em;
+          border-bottom: 1px solid #ddd;
+        }
+
+        table th {
+          text-align: left;
+          border-bottom: 2px solid #ddd;
+        }
+
+        table tbody tr:nth-child(odd) {
+          background-color: #fafafa;
+        }
+      </style>
+  </head>
+  <body>
+    <h1>Content schema examples</h1>
+    
+    <table>
+    <% schema_examples.each do |schema_name, examples| %>
+      <h2><%= schema_name %> (<a href="https://docs.publishing.service.gov.uk/content-schemas/<%= schema_name %>.html">docs)</a></h2>
+      
+      <ul>
+        <li>
+          <a href='/api/content/examples/<%= schema_name %>/random'><strong>randomly generated example</strong></a>
+        </li>
+
+        <% examples.each do |example| %>
+          <li>
+            <a href='/api/content/examples/<%= schema_name %>/<%= example[:example_name] %>'><%= example[:example_name] %></a>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </body>
+</html>

--- a/spec/integration/preview_app_spec.rb
+++ b/spec/integration/preview_app_spec.rb
@@ -1,0 +1,36 @@
+ENV["GOVUK_CONTENT_SCHEMAS_PATH"] = "."
+
+require 'rack/test'
+require_relative '../../app'
+
+RSpec.describe "Dummy content store rack application" do
+  include Rack::Test::Methods
+
+  it "serves the list of examples" do
+    get "/"
+
+    expect(last_response).to be_ok
+  end
+
+  it "serves random examples" do
+    get "/api/content/examples/guide/random"
+
+    expect(last_response).to be_ok
+  end
+
+  it "serves handwritten examples" do
+    get "/api/content/examples/guide/guide"
+
+    expect(last_response).to be_ok
+  end
+
+  it "redirects to the real content store for everything else" do
+    get "/api/content/some/thing/else"
+
+    expect(last_response.location).to eql "https://www.gov.uk/api/content/some/thing/else"
+  end
+
+  def app
+    Sinatra::Application
+  end
+end

--- a/startup.sh
+++ b/startup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bundle exec dummy_content_store
+bundle exec ruby app.rb


### PR DESCRIPTION
This integrates the dummy content store (https://github.com/alphagov/govuk-dummy_content_store).

Differences between this and the gem:

- It's no longer a gem so we don't have to release a new version for each change and bump the version. This makes it easier for the app on Heroku to keep up to date (the app is deployed from this repo to make sure that the schemas used by the app are always up to date).
- By using Sinatra we can drop a lot of the code needed to render responses and render the ERB template. This version is hundreds of lines smaller.
- Instead of proxying the content store, this app redirects to the live content store. This removes complexity and is more robust.
- Makes sure that items returned have the correct base_path. Applications like government-frontend sometimes look at the base_path to determine if they should redirect to a more canonical URL.

Tested by running `./startup.sh` in this repo and then this for government-frontend:

```
PLEK_SERVICE_CONTENT_STORE_URI=http://localhost:4567/api ./startup.sh --live
```

After this is merged govuk-dummy_content_store can be archived.

https://trello.com/c/IoHKyhoX