### PR TITLE
Update add a new schema docs

### DIFF
--- a/docs/adding-a-new-schema.md
+++ b/docs/adding-a-new-schema.md
@@ -12,8 +12,9 @@ With the following contents:
 You can then use the contents of the `formats/_example.jsonnet` as the basis
 of what to put into the file.
 
-Once you have completed these file, you can generate the corresponding schemas
-with the [`rake` task](../README.md#Rakefile).
+Once you have completed these file add the new format to `allowed_document_types.yml`.
+You can generate the corresponding schemas with the
+[`rake` task](../README.md#Rakefile).
 
 ## Examples
 
@@ -21,4 +22,3 @@ Any new schema should also ship with a set of curated examples. These examples
 will be validated against the schema and can also be used by the corresponding
 frontend applications to verify that it can render examples of the schema. These
 examples should be added to the `examples/FORMAT_NAME/frontend` folder.
-


### PR DESCRIPTION
We add a missing step to the "Adding a new schema" docs, which is to remember to
add the new format to `allowed_document_types.yml`.