### PR TITLE
Add email-alert-frontend to publishing apps

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -432,6 +432,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -531,6 +531,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -304,6 +304,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -549,6 +549,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -638,6 +638,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -351,6 +351,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -405,6 +405,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -485,6 +485,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -258,6 +258,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -441,6 +441,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -521,6 +521,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -294,6 +294,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -607,6 +607,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -700,6 +700,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -502,6 +502,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -618,6 +618,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -711,6 +711,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -476,6 +476,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -488,6 +488,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -543,6 +543,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -379,6 +379,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -558,6 +558,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -647,6 +647,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -426,6 +426,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -501,6 +501,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -592,6 +592,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -390,6 +390,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -466,6 +466,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -546,6 +546,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -319,6 +319,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -441,6 +441,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -537,6 +537,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -328,6 +328,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -602,6 +602,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -691,6 +691,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -450,6 +450,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -494,6 +494,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -576,6 +576,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -345,6 +345,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -554,6 +554,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -634,6 +634,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -407,6 +407,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -580,6 +580,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -660,6 +660,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -433,6 +433,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -353,6 +353,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -384,6 +384,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -241,6 +241,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -457,6 +457,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -556,6 +556,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -329,6 +329,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -432,6 +432,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -531,6 +531,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -304,6 +304,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -517,6 +517,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -597,6 +597,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -370,6 +370,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -521,6 +521,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -601,6 +601,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -374,6 +374,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -361,6 +361,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -407,6 +407,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -248,6 +248,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -427,6 +427,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -504,6 +504,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -294,6 +294,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -451,6 +451,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -550,6 +550,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -323,6 +323,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -475,6 +475,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -574,6 +574,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -347,6 +347,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -396,6 +396,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -447,6 +447,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -264,6 +264,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -477,6 +477,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -547,6 +547,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -382,6 +382,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -494,6 +494,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -598,6 +598,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -365,6 +365,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -462,6 +462,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -542,6 +542,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -315,6 +315,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -584,6 +584,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -687,6 +687,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -372,6 +372,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -441,6 +441,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -540,6 +540,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -313,6 +313,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -675,6 +675,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -759,6 +759,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -528,6 +528,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -620,6 +620,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -719,6 +719,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -458,6 +458,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -620,6 +620,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -719,6 +719,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -449,6 +449,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -313,6 +313,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -354,6 +354,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -235,6 +235,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -453,6 +453,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -541,6 +541,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -322,6 +322,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -395,6 +395,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -475,6 +475,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -248,6 +248,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -411,6 +411,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -495,6 +495,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -260,6 +260,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -444,6 +444,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -524,6 +524,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -297,6 +297,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -424,6 +424,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -509,6 +509,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -258,6 +258,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -494,6 +494,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -593,6 +593,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -366,6 +366,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -527,6 +527,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -607,6 +607,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -401,6 +401,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1591,6 +1591,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -1696,6 +1696,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1487,6 +1487,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -600,6 +600,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -705,6 +705,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -386,6 +386,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -462,6 +462,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -542,6 +542,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -339,6 +339,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -434,6 +434,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -513,6 +513,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -288,6 +288,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -435,6 +435,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -515,6 +515,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -288,6 +288,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -414,6 +414,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -502,6 +502,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -267,6 +267,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -412,6 +412,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -489,6 +489,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -254,6 +254,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -409,6 +409,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -489,6 +489,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -262,6 +262,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -460,6 +460,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -559,6 +559,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -332,6 +332,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -541,6 +541,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -643,6 +643,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -410,6 +410,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -419,6 +419,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -502,6 +502,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -269,6 +269,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -418,6 +418,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -498,6 +498,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -271,6 +271,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -344,6 +344,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -405,6 +405,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -485,6 +485,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -258,6 +258,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -441,6 +441,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -535,6 +535,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -302,6 +302,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -556,6 +556,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -645,6 +645,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -358,6 +358,7 @@
         "contacts",
         "content-tagger",
         "design-principles",
+        "email-alert-frontend",
         "external-link-tracker",
         "feedback",
         "frontend",

--- a/formats/shared/definitions/publishing_app.jsonnet
+++ b/formats/shared/definitions/publishing_app.jsonnet
@@ -9,6 +9,7 @@
       "contacts",
       "content-tagger",
       "design-principles",
+      "email-alert-frontend",
       "external-link-tracker",
       "feedback",
       "frontend",


### PR DESCRIPTION
Email Alert Frontend needs to be able to publish to the Publishing Api so that we can publish our prefix route for unsubscribing from emails from the rake task in Email Alert Frontend.

[Trello](https://trello.com/c/M0ODsZHV/398-add-prefix-route-to-router-to-point-email-to-email-alert-frontend)

Related PR in [Email Alert Frontend](https://github.com/alphagov/email-alert-frontend/pull/56)