### PR TITLE
Add search keywords field

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -170,6 +170,9 @@
         "answer"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -498,6 +501,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -234,6 +234,9 @@
         "answer"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -623,6 +626,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "answer"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -381,6 +384,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -179,6 +179,9 @@
         "case_study"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -615,6 +618,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -252,6 +252,9 @@
         "case_study"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -730,6 +733,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "case_study"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -428,6 +431,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -170,6 +170,9 @@
         "coming_soon"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -471,6 +474,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -234,6 +234,9 @@
         "coming_soon"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -577,6 +580,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "coming_soon"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -335,6 +338,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -170,6 +170,9 @@
         "completed_transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -507,6 +510,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -234,6 +234,9 @@
         "completed_transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -613,6 +616,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "completed_transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -371,6 +374,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -186,6 +186,9 @@
         "consultation"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -673,6 +676,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -263,6 +263,9 @@
         "consultation"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -792,6 +795,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -137,6 +137,9 @@
         "consultation"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -579,6 +582,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -173,6 +173,9 @@
         "contact"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -684,6 +687,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -240,6 +240,9 @@
         "contact"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -783,6 +786,10 @@
       "items": {
         "ref": "#/definitions/route"
       }
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -101,6 +101,9 @@
         "contact"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -533,6 +536,10 @@
       "items": {
         "ref": "#/definitions/route"
       }
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -164,6 +164,9 @@
         "corporate_information_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -554,6 +557,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -203,6 +203,9 @@
         "corporate_information_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -635,6 +638,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -135,6 +135,9 @@
         "corporate_information_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -456,6 +459,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -180,6 +180,9 @@
         "detailed_guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -624,6 +627,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -253,6 +253,9 @@
         "detailed_guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -739,6 +742,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -104,6 +104,9 @@
         "detailed_guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -503,6 +506,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -181,6 +181,9 @@
         "document_collection"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -567,6 +570,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -256,6 +256,9 @@
         "document_collection"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -684,6 +687,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -126,6 +126,9 @@
         "document_collection"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -467,6 +470,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -170,6 +170,9 @@
         "email_alert_signup"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -532,6 +535,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -234,6 +234,9 @@
         "email_alert_signup"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -638,6 +641,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "email_alert_signup"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -396,6 +399,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -185,6 +185,9 @@
         "fatality_notice"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -507,6 +510,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -265,6 +265,9 @@
         "fatality_notice"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -629,6 +632,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -128,6 +128,9 @@
         "fatality_notice"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -405,6 +408,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -175,6 +175,9 @@
         "finder"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -668,6 +671,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -248,6 +248,9 @@
         "finder"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -783,6 +786,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "finder"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -527,6 +530,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -172,6 +172,9 @@
         "finder_email_signup"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -560,6 +563,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -238,6 +238,9 @@
         "finder_email_signup"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -668,6 +671,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "finder_email_signup"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -422,6 +425,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -320,6 +320,9 @@
         "generic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -611,6 +614,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -384,6 +384,9 @@
         "generic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -717,6 +720,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -253,6 +253,9 @@
         "generic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -475,6 +478,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -320,6 +320,9 @@
         "generic_with_external_related_links"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -637,6 +640,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -384,6 +384,9 @@
         "generic_with_external_related_links"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -743,6 +746,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -253,6 +253,9 @@
         "generic_with_external_related_links"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -501,6 +504,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -128,6 +128,9 @@
         "gone"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -391,6 +394,10 @@
           "type": "null"
         }
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "withdrawn_notice": {
       "type": "object",

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -150,6 +150,9 @@
         "gone"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -448,6 +451,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "update_type": {
       "enum": [

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -96,6 +96,9 @@
         "gone"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "type": "null"
     },
@@ -290,6 +293,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "update_type": {
       "enum": [

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -170,6 +170,9 @@
         "guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -523,6 +526,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -234,6 +234,9 @@
         "guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -648,6 +651,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -406,6 +409,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -170,6 +170,9 @@
         "help_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -498,6 +501,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -234,6 +234,9 @@
         "help_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -623,6 +626,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "help_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -381,6 +384,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -170,6 +170,9 @@
         "hmrc_manual"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -583,6 +586,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -234,6 +234,9 @@
         "hmrc_manual"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -689,6 +692,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "hmrc_manual"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -447,6 +450,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -170,6 +170,9 @@
         "hmrc_manual_section"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -587,6 +590,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -234,6 +234,9 @@
         "hmrc_manual_section"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -693,6 +696,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "hmrc_manual_section"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -451,6 +454,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -137,6 +137,9 @@
         "homepage"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -427,6 +430,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -167,6 +167,9 @@
         "homepage"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -499,6 +502,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -104,6 +104,9 @@
         "homepage"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -325,6 +328,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -167,6 +167,9 @@
         "html_publication"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -493,6 +496,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -228,6 +228,9 @@
         "html_publication"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -596,6 +599,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -114,6 +114,9 @@
         "html_publication"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -371,6 +374,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -170,6 +170,9 @@
         "licence"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -517,6 +520,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -234,6 +234,9 @@
         "licence"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -642,6 +645,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "licence"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -400,6 +403,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -170,6 +170,9 @@
         "local_transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -541,6 +544,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -234,6 +234,9 @@
         "local_transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -666,6 +669,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "local_transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -424,6 +427,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -148,6 +148,9 @@
         "mainstream_browse_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -462,6 +465,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -190,6 +190,9 @@
         "mainstream_browse_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -539,6 +542,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "mainstream_browse_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -341,6 +344,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -137,6 +137,9 @@
         "manual"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -543,6 +546,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -172,6 +172,9 @@
         "manual"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -639,6 +642,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "manual"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -459,6 +462,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -171,6 +171,9 @@
         "manual_section"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -560,6 +563,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -240,6 +240,9 @@
         "manual_section"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -690,6 +693,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "manual_section"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -442,6 +445,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -170,6 +170,9 @@
         "need"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -528,6 +531,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -234,6 +234,9 @@
         "need"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -634,6 +637,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "need"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -392,6 +395,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -196,6 +196,9 @@
         "news_article"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -649,6 +652,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -283,6 +283,9 @@
         "news_article"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -778,6 +781,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -106,6 +106,9 @@
         "news_article"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -448,6 +451,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -170,6 +170,9 @@
         "place"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -507,6 +510,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -234,6 +234,9 @@
         "place"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -632,6 +635,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "place"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -390,6 +393,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -323,6 +323,9 @@
       "type": "string",
       "pattern": "^(placeholder|placeholder_.+)$"
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -732,6 +735,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -391,6 +391,9 @@
       "type": "string",
       "pattern": "^(placeholder|placeholder_.+)$"
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -842,6 +845,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -256,6 +256,9 @@
       "type": "string",
       "pattern": "^(placeholder|placeholder_.+)$"
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -596,6 +599,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -185,6 +185,9 @@
         "policy"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -686,6 +689,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -268,6 +268,9 @@
         "policy"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -811,6 +814,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "policy"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -535,6 +538,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -208,6 +208,9 @@
         "publication"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -685,6 +688,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -291,6 +291,9 @@
         "publication"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -810,6 +813,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -159,6 +159,9 @@
         "publication"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -525,6 +528,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -131,6 +131,9 @@
         "redirect"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -351,6 +354,10 @@
           "type": "null"
         }
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "withdrawn_notice": {
       "type": "object",

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -153,6 +153,9 @@
         "redirect"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -437,6 +440,10 @@
         "$ref": "#/definitions/redirect_route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "update_type": {
       "enum": [

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -99,6 +99,9 @@
         "redirect"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "type": "null"
     },
@@ -303,6 +306,10 @@
         "$ref": "#/definitions/redirect_route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "update_type": {
       "enum": [

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -178,6 +178,9 @@
         "service_manual_guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -519,6 +522,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -250,6 +250,9 @@
         "service_manual_guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -633,6 +636,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "service_manual_guide"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -399,6 +402,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -170,6 +170,9 @@
         "service_manual_homepage"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -461,6 +464,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -234,6 +234,9 @@
         "service_manual_homepage"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -567,6 +570,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "service_manual_homepage"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -325,6 +328,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -174,6 +174,9 @@
         "service_manual_service_standard"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -477,6 +480,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -242,6 +242,9 @@
         "service_manual_service_standard"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -587,6 +590,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "service_manual_service_standard"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -337,6 +340,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -170,6 +170,9 @@
         "service_manual_service_toolkit"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -510,6 +513,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -234,6 +234,9 @@
         "service_manual_service_toolkit"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -616,6 +619,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "service_manual_service_toolkit"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -374,6 +377,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -182,6 +182,9 @@
         "service_manual_topic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -490,6 +493,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "service_manual_topic_groups": {
       "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -258,6 +258,9 @@
         "service_manual_topic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -601,6 +604,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "service_manual_topic_groups": {
       "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "service_manual_topic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -335,6 +338,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "service_manual_topic_groups": {
       "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -170,6 +170,9 @@
         "service_sign_in"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -544,6 +547,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -234,6 +234,9 @@
         "service_sign_in"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -669,6 +672,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "service_sign_in"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -427,6 +430,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -170,6 +170,9 @@
         "simple_smart_answer"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -560,6 +563,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -234,6 +234,9 @@
         "simple_smart_answer"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -685,6 +688,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "simple_smart_answer"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -443,6 +446,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -323,6 +323,9 @@
         "special_route"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -594,6 +597,10 @@
           "type": "null"
         }
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title_optional": {
       "type": "string"

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -387,6 +387,9 @@
         "special_route"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -700,6 +703,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title_optional": {
       "type": "string"

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -253,6 +253,9 @@
         "special_route"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title_optional"
     },
@@ -479,6 +482,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title_optional": {
       "type": "string"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -192,6 +192,9 @@
         "specialist_document"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -1691,6 +1694,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "service_standard_report_metadata": {
       "type": "object",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -262,6 +262,9 @@
         "specialist_document"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -1822,6 +1825,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "service_standard_report_metadata": {
       "type": "object",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -125,6 +125,9 @@
         "specialist_document"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -1598,6 +1601,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "service_standard_report_metadata": {
       "type": "object",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -198,6 +198,9 @@
         "speech"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -666,6 +669,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -287,6 +287,9 @@
         "speech"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -797,6 +800,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -106,6 +106,9 @@
         "speech"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -463,6 +466,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -170,6 +170,9 @@
         "statistical_data_set"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -528,6 +531,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -234,6 +234,9 @@
         "statistical_data_set"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -634,6 +637,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "statistical_data_set"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -416,6 +419,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -173,6 +173,9 @@
         "statistics_announcement"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -500,6 +503,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -236,6 +236,9 @@
         "statistics_announcement"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -605,6 +608,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -107,6 +107,9 @@
         "statistics_announcement"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -365,6 +368,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -170,6 +170,9 @@
         "take_part"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -501,6 +504,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -234,6 +234,9 @@
         "take_part"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -607,6 +610,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "take_part"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -365,6 +368,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -178,6 +178,9 @@
         "taxon"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -480,6 +483,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -250,6 +250,9 @@
         "taxon"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -594,6 +597,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -111,6 +111,9 @@
         "taxon"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -344,6 +347,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -174,6 +174,9 @@
         "topic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -478,6 +481,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -242,6 +242,9 @@
         "topic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -581,6 +584,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "topic"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -331,6 +334,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -170,6 +170,9 @@
         "topical_event_about_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -475,6 +478,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -234,6 +234,9 @@
         "topical_event_about_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -581,6 +584,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "topical_event_about_page"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -339,6 +342,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -170,6 +170,9 @@
         "transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -526,6 +529,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -234,6 +234,9 @@
         "transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -651,6 +654,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "transaction"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -409,6 +412,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -173,6 +173,9 @@
         "travel_advice"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -607,6 +610,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -240,6 +240,9 @@
         "travel_advice"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -735,6 +738,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "travel_advice"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -498,6 +501,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -173,6 +173,9 @@
         "travel_advice_index"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -485,6 +488,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -240,6 +240,9 @@
         "travel_advice_index"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -594,6 +597,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "travel_advice_index"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -357,6 +360,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -170,6 +170,9 @@
         "unpublishing"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -484,6 +487,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -234,6 +234,9 @@
         "unpublishing"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -590,6 +593,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "unpublishing"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -348,6 +351,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -153,6 +153,9 @@
         "vanish"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -408,6 +411,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "update_type": {
       "enum": [

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -170,6 +170,9 @@
         "working_group"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -471,6 +474,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -234,6 +234,9 @@
         "working_group"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -577,6 +580,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "working_group"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -335,6 +338,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -174,6 +174,9 @@
         "world_location"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -507,6 +510,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -242,6 +242,9 @@
         "world_location"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -607,6 +610,10 @@
       "items": {
         "ref": "#/definitions/route"
       }
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -105,6 +105,9 @@
         "world_location"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -359,6 +362,10 @@
       "items": {
         "ref": "#/definitions/route"
       }
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -179,6 +179,9 @@
         "world_location_news_article"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -622,6 +625,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -252,6 +252,9 @@
         "world_location_news_article"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "search_user_need_document_supertype": {
       "description": "Document supertype grouping core and government documents",
       "type": "string"
@@ -737,6 +740,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -103,6 +103,9 @@
         "world_location_news_article"
       ]
     },
+    "search_keywords": {
+      "$ref": "#/definitions/search_keywords"
+    },
     "title": {
       "$ref": "#/definitions/title"
     },
@@ -435,6 +438,10 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "search_keywords": {
+      "description": "Used by Rummager for indexable content in Elasticsearch",
+      "type": "string"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/formats/shared/default_properties/publisher.jsonnet
+++ b/formats/shared/default_properties/publisher.jsonnet
@@ -22,6 +22,9 @@
   public_updated_at: {
     "$ref": "#/definitions/public_updated_at",
   },
+  search_keywords: {
+   "$ref": "#/definitions/search_keywords",
+  },
   update_type: {
     "$ref": "#/definitions/update_type",
   },

--- a/formats/shared/default_properties/publishing_api_out.jsonnet
+++ b/formats/shared/default_properties/publishing_api_out.jsonnet
@@ -17,6 +17,9 @@
   publishing_request_id: {
     "$ref": "#/definitions/publishing_request_id",
   },
+  search_keywords: {
+   "$ref": "#/definitions/search_keywords",
+  },
   search_user_need_document_supertype: {
     type: "string",
     description: "Document supertype grouping core and government documents",

--- a/formats/shared/definitions/search_keywords.jsonnet
+++ b/formats/shared/definitions/search_keywords.jsonnet
@@ -1,0 +1,6 @@
+{
+  search_keywords: {
+    type: "string",
+    description: "Used by Rummager for indexable content in Elasticsearch",
+  },
+}


### PR DESCRIPTION
Formats such as Finders in Whitehall and Calendars send separate indexable content to Rummager as a top level field. This should be an optional field for any document that wishes to send any keywords for Rummager to pass as indexable content into Elasticsearch.

https://trello.com/c/ut9cWxrT