### PR TITLE
Remove Vehicle Recalls and Faults Alerts schema

### DIFF
--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -177,7 +177,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -192,7 +192,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -180,7 +180,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -177,7 +177,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -192,7 +192,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -180,7 +180,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -177,7 +177,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -192,7 +192,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -180,7 +180,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -180,7 +180,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -195,7 +195,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -180,7 +180,6 @@
         "unpublishing",
         "utaac_decision",
         "vanish",
-        "vehicle_recalls_and_faults_alert",
         "welsh_language_scheme",
         "working_group",
         "world_location",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -50,7 +50,6 @@
         "raib_report",
         "drug_safety_update",
         "business_finance_support_scheme",
-        "vehicle_recalls_and_faults_alert",
         "asylum_support_decision"
       ]
     },
@@ -336,9 +335,6 @@
         },
         {
           "$ref": "#/definitions/utaac_decision_metadata"
-        },
-        {
-          "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata"
         }
       ]
     },
@@ -1766,70 +1762,6 @@
           "items": {
             "type": "string"
           }
-        }
-      }
-    },
-    "vehicle_recalls_and_faults_alert_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "alert_issue_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_end_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_start_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "bulk_published": {
-          "type": "boolean"
-        },
-        "fault_type": {
-          "type": "string",
-          "enum": [
-            "recall",
-            "non_urgent_fault"
-          ]
-        },
-        "faulty_item_model": {
-          "type": "string"
-        },
-        "faulty_item_type": {
-          "type": "string",
-          "enum": [
-            "vehicle",
-            "baby-seat",
-            "tyres",
-            "parts",
-            "agricultural-equipment",
-            "other-accessories"
-          ]
-        },
-        "manufacturer": {
-          "type": "string",
-          "enum": [
-            "alfa-romeo",
-            "audi",
-            "balco",
-            "bmw",
-            "bridgestone",
-            "britax",
-            "citroen",
-            "ferrari",
-            "mccormick-tractors-ltd",
-            "michelin",
-            "mitas-tyres-ltd",
-            "mothercare",
-            "nim-engineering-ltd",
-            "other-manufacturer"
-          ]
-        },
-        "serial_number": {
-          "type": "string"
         }
       }
     },

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -65,7 +65,6 @@
         "raib_report",
         "drug_safety_update",
         "business_finance_support_scheme",
-        "vehicle_recalls_and_faults_alert",
         "asylum_support_decision"
       ]
     },
@@ -405,9 +404,6 @@
         },
         {
           "$ref": "#/definitions/utaac_decision_metadata"
-        },
-        {
-          "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata"
         }
       ]
     },
@@ -1904,70 +1900,6 @@
           "items": {
             "type": "string"
           }
-        }
-      }
-    },
-    "vehicle_recalls_and_faults_alert_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "alert_issue_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_end_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_start_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "bulk_published": {
-          "type": "boolean"
-        },
-        "fault_type": {
-          "type": "string",
-          "enum": [
-            "recall",
-            "non_urgent_fault"
-          ]
-        },
-        "faulty_item_model": {
-          "type": "string"
-        },
-        "faulty_item_type": {
-          "type": "string",
-          "enum": [
-            "vehicle",
-            "baby-seat",
-            "tyres",
-            "parts",
-            "agricultural-equipment",
-            "other-accessories"
-          ]
-        },
-        "manufacturer": {
-          "type": "string",
-          "enum": [
-            "alfa-romeo",
-            "audi",
-            "balco",
-            "bmw",
-            "bridgestone",
-            "britax",
-            "citroen",
-            "ferrari",
-            "mccormick-tractors-ltd",
-            "michelin",
-            "mitas-tyres-ltd",
-            "mothercare",
-            "nim-engineering-ltd",
-            "other-manufacturer"
-          ]
-        },
-        "serial_number": {
-          "type": "string"
         }
       }
     },

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -53,7 +53,6 @@
         "raib_report",
         "drug_safety_update",
         "business_finance_support_scheme",
-        "vehicle_recalls_and_faults_alert",
         "asylum_support_decision"
       ]
     },
@@ -269,9 +268,6 @@
         },
         {
           "$ref": "#/definitions/utaac_decision_metadata"
-        },
-        {
-          "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata"
         }
       ]
     },
@@ -1680,70 +1676,6 @@
           "items": {
             "type": "string"
           }
-        }
-      }
-    },
-    "vehicle_recalls_and_faults_alert_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "alert_issue_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_end_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_start_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "bulk_published": {
-          "type": "boolean"
-        },
-        "fault_type": {
-          "type": "string",
-          "enum": [
-            "recall",
-            "non_urgent_fault"
-          ]
-        },
-        "faulty_item_model": {
-          "type": "string"
-        },
-        "faulty_item_type": {
-          "type": "string",
-          "enum": [
-            "vehicle",
-            "baby-seat",
-            "tyres",
-            "parts",
-            "agricultural-equipment",
-            "other-accessories"
-          ]
-        },
-        "manufacturer": {
-          "type": "string",
-          "enum": [
-            "alfa-romeo",
-            "audi",
-            "balco",
-            "bmw",
-            "bridgestone",
-            "britax",
-            "citroen",
-            "ferrari",
-            "mccormick-tractors-ltd",
-            "michelin",
-            "mitas-tyres-ltd",
-            "mothercare",
-            "nim-engineering-ltd",
-            "other-manufacturer"
-          ]
-        },
-        "serial_number": {
-          "type": "string"
         }
       }
     }

--- a/formats/shared/definitions/_specialist_document.jsonnet
+++ b/formats/shared/definitions/_specialist_document.jsonnet
@@ -53,9 +53,6 @@
       {
         "$ref": "#/definitions/utaac_decision_metadata",
       },
-      {
-        "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata",
-      },
     ],
   },
   nested_headers: {
@@ -1207,70 +1204,6 @@
       },
       hidden_indexable_content: {
         type: "string",
-      },
-    },
-  },
-  vehicle_recalls_and_faults_alert_metadata: {
-    type: "object",
-    additionalProperties: false,
-    properties: {
-      bulk_published: {
-        type: "boolean",
-      },
-      fault_type: {
-        type: "string",
-        enum: [
-          "recall",
-          "non_urgent_fault",
-        ],
-      },
-      faulty_item_type: {
-        type: "string",
-        enum: [
-          "vehicle",
-          "baby-seat",
-          "tyres",
-          "parts",
-          "agricultural-equipment",
-          "other-accessories",
-        ],
-      },
-      manufacturer: {
-        type: "string",
-        enum: [
-          "alfa-romeo",
-          "audi",
-          "balco",
-          "bmw",
-          "bridgestone",
-          "britax",
-          "citroen",
-          "ferrari",
-          "mccormick-tractors-ltd",
-          "michelin",
-          "mitas-tyres-ltd",
-          "mothercare",
-          "nim-engineering-ltd",
-          "other-manufacturer",
-        ],
-      },
-      faulty_item_model: {
-        type: "string",
-      },
-      serial_number: {
-        type: "string",
-      },
-      alert_issue_date: {
-        type: "string",
-        pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
-      },
-      build_start_date: {
-        type: "string",
-        pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
-      },
-      build_end_date: {
-        type: "string",
-        pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
       },
     },
   },

--- a/formats/specialist_document.jsonnet
+++ b/formats/specialist_document.jsonnet
@@ -16,7 +16,6 @@
     "raib_report",
     "drug_safety_update",
     "business_finance_support_scheme",
-    "vehicle_recalls_and_faults_alert",
     "asylum_support_decision",
   ],
   definitions: (import "shared/definitions/_specialist_document.jsonnet") + {

--- a/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/lib/govuk_content_schemas/allowed_document_types.yml
@@ -141,7 +141,6 @@
 - unpublishing
 - utaac_decision
 - vanish # Not in the content store
-- vehicle_recalls_and_faults_alert
 - welsh_language_scheme
 - working_group
 - world_location


### PR DESCRIPTION
This specialist document type was added in https://github.com/alphagov/manuals-publisher/pull/480 as an MVP. Unfortunately no documents were ever published.

It's unused, so it's probably best to remove it to avoid unnecessary maintenance and avoid confusion.

The code was removed from specialist publisher in https://github.com/alphagov/specialist-publisher/pull/1072.

https://trello.com/c/Jm6K9Tpx