### PR TITLE
Add content_purpose_document_supertype

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -195,7 +199,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -267,7 +271,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -202,7 +206,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -278,7 +282,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -189,7 +193,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -255,7 +259,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -180,7 +184,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -218,7 +222,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -196,7 +200,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -268,7 +272,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -197,7 +201,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -271,7 +275,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -201,7 +205,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -280,7 +284,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -191,7 +195,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -263,7 +267,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -188,7 +192,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -253,7 +257,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -336,7 +340,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -399,7 +403,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -336,7 +340,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -399,7 +403,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "type": "null"
     },
@@ -144,7 +148,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/gone/notification/schema.json
+++ b/dist/formats/gone/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "type": "null"
     },
@@ -165,7 +169,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -153,7 +157,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -182,7 +186,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -183,7 +187,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -243,7 +247,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -164,7 +168,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -205,7 +209,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -153,7 +157,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -187,7 +191,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -187,7 +191,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -255,7 +259,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -212,7 +216,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -298,7 +302,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -339,7 +343,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -406,7 +410,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -201,7 +205,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -283,7 +287,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -224,7 +228,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -306,7 +310,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "type": "null"
     },
@@ -147,7 +151,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/redirect/notification/schema.json
+++ b/dist/formats/redirect/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "type": "null"
     },
@@ -168,7 +172,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -194,7 +198,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -265,7 +269,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -190,7 +194,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -257,7 +261,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -198,7 +202,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -273,7 +277,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -339,7 +343,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -402,7 +406,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -208,7 +212,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -277,7 +281,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -214,7 +218,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -302,7 +306,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -189,7 +193,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -251,7 +255,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -194,7 +198,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -265,7 +269,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -190,7 +194,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -257,7 +261,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -189,7 +193,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -255,7 +259,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -189,7 +193,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -255,7 +259,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/vanish/notification/schema.json
+++ b/dist/formats/vanish/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "type": "null"
     },
@@ -168,7 +172,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -190,7 +194,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -257,7 +261,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -195,7 +199,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -267,7 +271,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/formats/shared/default_properties/publishing_api_out.jsonnet
+++ b/formats/shared/default_properties/publishing_api_out.jsonnet
@@ -27,7 +27,11 @@
   },
   user_need_document_supertype: {
     type: "string",
-    description: "Document supertype grouping documents by user need",
+    description: "DEPRECATED. Use `content_purpose_document_supertype`.",
+  },
+  content_purpose_document_supertype: {
+    type: "string",
+    description: "Document supertype grouping documents by purpose",
   },
   withdrawn_notice: {
     "$ref": "#/definitions/withdrawn_notice",


### PR DESCRIPTION
This has replaced the `user_need_document_supertype` (https://github.com/alphagov/govuk_document_types/pull/33).

https://trello.com/c/PBPo5tmL