### PR TITLE
Makes sure the description a govspeak output

### DIFF
--- a/examples/service_sign_in/frontend/service_sign_in.json
+++ b/examples/service_sign_in/frontend/service_sign_in.json
@@ -30,7 +30,7 @@
     "choose_sign_in": {
       "title": "Prove your identity to continue",
       "slug": "choose-sign-in",
-      "description": "You can't file online until you've activated Government Gateway account using your Unique Taxpayer Reference(UTR).",
+      "description": "<p>You can't file online until you've activated Government Gateway account using your Unique Taxpayer Reference(UTR).</p>",
       "options": [
         {
           "text": "Use Government Gateway",


### PR DESCRIPTION
Since these descriptions are expected to be govspeak, a single line like this
would be given a wrapper paragraph.

This updates to add this wrapper, so that when it's passed to the [govspeak](http://govuk-static.herokuapp.com/component-guide/govspeak)
component, proper spacing and styling is applied