### PR TITLE
Allow prefixed routes to work in examples

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -41,6 +41,10 @@ get "/api/content/examples/:schema_name/:example_name" do |schema_name, example_
   end
 end
 
+get "/api/content/examples/:schema_name/:example_name/:suffix" do |schema_name, example_name, suffix|
+  redirect "/api/content/examples/#{schema_name}/#{example_name}"
+end
+
 get "/api/content/*" do
   redirect "https://www.gov.uk/api/content/#{params[:splat].join("/")}"
 end

--- a/spec/integration/preview_app_spec.rb
+++ b/spec/integration/preview_app_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe "Dummy content store rack application" do
     expect(last_response).to be_ok
   end
 
+  it "serves handwritten examples with prefix routes" do
+    get "/api/content/examples/guide/guide/key-stage-1-and-2"
+
+    expect(last_response.location).to eql "http://example.org/api/content/examples/guide/guide"
+  end
+
   it "redirects to the real content store for everything else" do
     get "/api/content/some/thing/else"
 


### PR DESCRIPTION
If a content example is given a suffix, then we assume it's a prefixed route.
This allows pages like 'examples/guide/guide/key-stage-1-and-2' to succeed.

Unblocks https://trello.com/c/zsPE3IXV/248-3-pull-data-into-the-choose-sign-in-options-page