### PR TITLE
Fix generated schema for calendar

### DIFF
--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -25,6 +25,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -186,7 +190,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -40,6 +40,10 @@
     "content_id": {
       "$ref": "#/definitions/guid"
     },
+    "content_purpose_document_supertype": {
+      "description": "Document supertype grouping documents by purpose",
+      "type": "string"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -249,7 +253,7 @@
       "type": "string"
     },
     "user_need_document_supertype": {
-      "description": "Document supertype grouping documents by user need",
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
       "type": "string"
     },
     "withdrawn_notice": {


### PR DESCRIPTION
https://github.com/alphagov/govuk-content-schemas/pull/677 and https://github.com/alphagov/govuk-content-schemas/pull/678 were merged around the same time, so the calendars schema didn't have all the changes. This is causing subsequent PRs like https://github.com/alphagov/govuk-content-schemas/pull/680 to fail.

This situation can be prevented by requiring branches to be up to date before merging (there's a GitHub setting for that), but it's so rare that I don't think it's worth the hassle.