### PR TITLE
Add some more document_type attributes to frontend examples

### DIFF
--- a/examples/case_study/frontend/archived.json
+++ b/examples/case_study/frontend/archived.json
@@ -53,7 +53,8 @@
         "base_path": "/government/organisations/department-for-work-pensions",
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-work-pensions",
         "web_url": "https://www.gov.uk/government/organisations/department-for-work-pensions",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "organisation"
       }
     ],
     "related_policies": [
@@ -64,7 +65,8 @@
         "base_path": "/government/policies/helping-people-to-find-and-stay-in-work",
         "api_url": "https://www.gov.uk/api/content/government/policies/helping-people-to-find-and-stay-in-work",
         "web_url": "https://www.gov.uk/government/policies/helping-people-to-find-and-stay-in-work",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ],
     "world_locations": [
@@ -92,7 +94,8 @@
         "base_path": "/government/collections/work-programme-real-life-stories",
         "api_url": "https://www.gov.uk/api/content/government/collections/work-programme-real-life-stories",
         "web_url": "https://www.gov.uk/government/collections/work-programme-real-life-stories",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "document_collection"
       }
     ]
   },

--- a/examples/case_study/frontend/case_study.json
+++ b/examples/case_study/frontend/case_study.json
@@ -36,7 +36,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-international-development",
         "web_url": "https://www.gov.uk/government/organisations/department-for-international-development",
         "locale": "en",
-        "analytics_identifier": "L2"
+        "analytics_identifier": "L2",
+        "document_type": "organisation"
       }
     ],
     "related_policies": [
@@ -91,7 +92,8 @@
         "base_path": "/government/collections/work-programme-real-life-stories",
         "api_url": "https://www.gov.uk/api/content/government/collections/work-programme-real-life-stories",
         "web_url": "https://www.gov.uk/government/collections/work-programme-real-life-stories",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "document_collection"
       }
     ]
   },

--- a/examples/case_study/frontend/translated.json
+++ b/examples/case_study/frontend/translated.json
@@ -70,7 +70,8 @@
         "base_path": "/government/organisations/uk-trade-investment",
         "locale": "en",
         "title": "UK Trade & Investment",
-        "web_url": "https://www.gov.uk/government/organisations/uk-trade-investment"
+        "web_url": "https://www.gov.uk/government/organisations/uk-trade-investment",
+        "document_type": "organisation"
       }
     ],
     "world_locations": [

--- a/examples/news_article/frontend/news_article.json
+++ b/examples/news_article/frontend/news_article.json
@@ -18,7 +18,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
         "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
         "locale": "en",
-        "analytics_identifier": "OT532"
+        "analytics_identifier": "OT532",
+        "document_type": "organisation"
       }
     ],
     "ministers": [
@@ -29,7 +30,8 @@
         "base_path": "/government/people/theresa-may",
         "api_url": "https://www.gov.uk/api/content/government/people/theresa-may",
         "web_url": "https://www.gov.uk/government/people/theresa-may",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ],
     "available_translations": [

--- a/examples/news_article/frontend/news_article_government_response.json
+++ b/examples/news_article/frontend/news_article_government_response.json
@@ -18,7 +18,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/marine-management-organisation",
         "web_url": "https://www.gov.uk/government/organisations/marine-management-organisation",
         "locale": "en",
-        "analytics_identifier": "PB57"
+        "analytics_identifier": "PB57",
+        "document_type": "organisation"
       }
     ],
     "related_policies": [
@@ -29,7 +30,8 @@
         "base_path": "/government/policies/marine-environment",
         "api_url": "https://www.gov.uk/api/content/government/policies/marine-environment",
         "web_url": "https://www.gov.uk/government/policies/marine-environment",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ]
   },

--- a/examples/news_article/frontend/news_article_history_mode.json
+++ b/examples/news_article/frontend/news_article_history_mode.json
@@ -18,7 +18,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-of-health",
         "web_url": "https://www.gov.uk/government/organisations/department-of-health",
         "locale": "en",
-        "analytics_identifier": "D12"
+        "analytics_identifier": "D12",
+        "document_type": "organisation"
       }
     ],
     "related_policies": [
@@ -29,7 +30,8 @@
         "base_path": "/government/policies/health-and-social-care-integration",
         "api_url": "https://www.gov.uk/api/content/government/policies/health-and-social-care-integration",
         "web_url": "https://www.gov.uk/government/policies/health-and-social-care-integration",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       },
       {
         "content_id": "5d635d59-7631-11e4-a3cb-005056011aef",
@@ -38,7 +40,8 @@
         "base_path": "/government/policies/choice-in-health-and-social-care",
         "api_url": "https://www.gov.uk/api/content/government/policies/choice-in-health-and-social-care",
         "web_url": "https://www.gov.uk/government/policies/choice-in-health-and-social-care",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ]
   },

--- a/examples/news_article/frontend/news_article_news_story_translated_arabic.json
+++ b/examples/news_article/frontend/news_article_news_story_translated_arabic.json
@@ -18,7 +18,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
         "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
         "locale": "en",
-        "analytics_identifier": "OT532"
+        "analytics_identifier": "OT532",
+        "document_type": "organisation"
       }
     ],
     "ministers": [
@@ -29,7 +30,8 @@
         "base_path": "/government/people/theresa-may",
         "api_url": "https://www.gov.uk/api/content/government/people/theresa-may",
         "web_url": "https://www.gov.uk/government/people/theresa-may",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ],
     "available_translations": [

--- a/examples/news_article/frontend/news_article_press_release.json
+++ b/examples/news_article/frontend/news_article_press_release.json
@@ -18,7 +18,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/public-health-england",
         "web_url": "https://www.gov.uk/government/organisations/public-health-england",
         "locale": "en",
-        "analytics_identifier": "OT532"
+        "analytics_identifier": "OT532",
+        "document_type": "organisation"
       }
     ]
   },

--- a/examples/news_article/frontend/world_news_story_news_article.json
+++ b/examples/news_article/frontend/world_news_story_news_article.json
@@ -17,7 +17,8 @@
         "base_path": "/government/people/theresa-may",
         "api_url": "https://www.gov.uk/api/content/government/people/theresa-may",
         "web_url": "https://www.gov.uk/government/people/theresa-may",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ],
     "available_translations": [

--- a/examples/speech/frontend/speech-authored-article.json
+++ b/examples/speech/frontend/speech-authored-article.json
@@ -51,7 +51,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
         "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
         "locale": "en",
-        "analytics_identifier": "OT532"
+        "analytics_identifier": "OT532",
+        "document_type": "organisation"
       }
     ],
     "speaker": [
@@ -62,7 +63,8 @@
         "base_path": "/government/people/david-cameron",
         "api_url": "https://www.gov.uk/api/content/government/people/david-cameron",
         "web_url": "https://www.gov.uk/government/people/david-cameron",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ],
     "topical_events": [
@@ -84,7 +86,8 @@
         "base_path": "/government/policies/european-single-market",
         "api_url": "https://www.gov.uk/api/content/government/policies/european-single-market",
         "web_url": "https://www.gov.uk/government/policies/european-single-market",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ]
   }

--- a/examples/speech/frontend/speech-oral-statement-parliament.json
+++ b/examples/speech/frontend/speech-oral-statement-parliament.json
@@ -51,7 +51,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/ministry-of-justice",
         "web_url": "https://www.gov.uk/government/organisations/ministry-of-justice",
         "locale": "en",
-        "analytics_identifier": "D18"
+        "analytics_identifier": "D18",
+        "document_type": "organisation"
       }
     ],
     "speaker": [
@@ -62,7 +63,8 @@
         "base_path": "/government/people/elizabeth-truss",
         "api_url": "https://www.gov.uk/api/content/government/people/elizabeth-truss",
         "web_url": "https://www.gov.uk/government/people/elizabeth-truss",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ]
   }

--- a/examples/speech/frontend/speech-speaker-without-profile.json
+++ b/examples/speech/frontend/speech-speaker-without-profile.json
@@ -50,7 +50,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
         "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
         "locale": "en",
-        "analytics_identifier": "OT532"
+        "analytics_identifier": "OT532",
+        "document_type": "organisation"
       },
       {
         "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
@@ -60,7 +61,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/cabinet-office",
         "web_url": "https://www.gov.uk/government/organisations/cabinet-office",
         "locale": "en",
-        "analytics_identifier": "D2"
+        "analytics_identifier": "D2",
+        "document_type": "organisation"
       }
     ],
     "topical_events": [
@@ -82,7 +84,8 @@
         "base_path": "/government/policies/government-transparency-and-accountability",
         "api_url": "https://www.gov.uk/api/content/government/policies/government-transparency-and-accountability",
         "web_url": "https://www.gov.uk/government/policies/government-transparency-and-accountability",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ]
   }

--- a/examples/speech/frontend/speech-speaking-notes.json
+++ b/examples/speech/frontend/speech-speaking-notes.json
@@ -52,7 +52,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/home-office",
         "web_url": "https://www.gov.uk/government/organisations/home-office",
         "locale": "en",
-        "analytics_identifier": "D16"
+        "analytics_identifier": "D16",
+        "document_type": "organisation"
       }
     ],
     "speaker": [
@@ -63,7 +64,8 @@
         "base_path": "/government/people/theresa-may",
         "api_url": "https://www.gov.uk/api/content/government/people/theresa-may",
         "web_url": "https://www.gov.uk/government/people/theresa-may",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ],
     "related_policies": [
@@ -74,7 +76,8 @@
         "base_path": "/government/policies/policing",
         "api_url": "https://www.gov.uk/api/content/government/policies/policing",
         "web_url": "https://www.gov.uk/government/policies/policing",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ]
   }

--- a/examples/speech/frontend/speech-transcript.json
+++ b/examples/speech/frontend/speech-transcript.json
@@ -53,7 +53,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/prime-ministers-office-10-downing-street",
         "web_url": "https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street",
         "locale": "en",
-        "analytics_identifier": "OT532"
+        "analytics_identifier": "OT532",
+        "document_type": "organisation"
       },
       {
         "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
@@ -63,7 +64,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/cabinet-office",
         "web_url": "https://www.gov.uk/government/organisations/cabinet-office",
         "locale": "en",
-        "analytics_identifier": "D2"
+        "analytics_identifier": "D2",
+        "document_type": "organisation"
       }
     ],
     "speaker": [
@@ -74,7 +76,8 @@
         "base_path": "/government/people/david-cameron",
         "api_url": "https://www.gov.uk/api/content/government/people/david-cameron",
         "web_url": "https://www.gov.uk/government/people/david-cameron",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ],
     "topical_events": [
@@ -96,7 +99,8 @@
         "base_path": "/government/policies/government-transparency-and-accountability",
         "api_url": "https://www.gov.uk/api/content/government/policies/government-transparency-and-accountability",
         "web_url": "https://www.gov.uk/government/policies/government-transparency-and-accountability",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       },
       {
         "content_id": "5d3bf736-7631-11e4-a3cb-005056011aef",
@@ -105,7 +109,8 @@
         "base_path": "/government/policies/tax-evasion-and-avoidance",
         "api_url": "https://www.gov.uk/api/content/government/policies/tax-evasion-and-avoidance",
         "web_url": "https://www.gov.uk/government/policies/tax-evasion-and-avoidance",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ]
   }

--- a/examples/speech/frontend/speech-translated.json
+++ b/examples/speech/frontend/speech-translated.json
@@ -53,7 +53,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/foreign-commonwealth-office",
         "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
         "locale": "en",
-        "analytics_identifier": "D13"
+        "analytics_identifier": "D13",
+        "document_type": "organisation"
       }
     ],
     "speaker": [
@@ -64,7 +65,8 @@
         "base_path": "/government/people/boris-johnson",
         "api_url": "https://www.gov.uk/api/content/government/people/boris-johnson",
         "web_url": "https://www.gov.uk/government/people/boris-johnson",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ],
     "world_locations": [

--- a/examples/speech/frontend/speech-written-statement-parliament.json
+++ b/examples/speech/frontend/speech-written-statement-parliament.json
@@ -52,7 +52,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
         "web_url": "https://www.gov.uk/government/organisations/department-for-education",
         "locale": "en",
-        "analytics_identifier": "D6"
+        "analytics_identifier": "D6",
+        "document_type": "organisation"
       },
       {
         "content_id": "b9fc8528-81d1-419b-8748-6c00be71044b",
@@ -62,7 +63,9 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/education-funding-agency",
         "web_url": "https://www.gov.uk/government/organisations/education-funding-agency",
         "locale": "en",
-        "analytics_identifier": "EA242"
+        "analytics_identifier": "EA242",
+        "document_type": "organisation"
+
       }
     ],
     "speaker": [
@@ -73,7 +76,8 @@
         "base_path": "/government/people/nick-gibb",
         "api_url": "https://www.gov.uk/api/content/government/people/nick-gibb",
         "web_url": "https://www.gov.uk/government/people/nick-gibb",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ],
     "related_policies": [
@@ -84,7 +88,8 @@
         "base_path": "/government/policies/school-and-college-funding",
         "api_url": "https://www.gov.uk/api/content/government/policies/school-and-college-funding",
         "web_url": "https://www.gov.uk/government/policies/school-and-college-funding",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ]
   }

--- a/examples/speech/frontend/speech.json
+++ b/examples/speech/frontend/speech.json
@@ -53,7 +53,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-of-energy-climate-change",
         "web_url": "https://www.gov.uk/government/organisations/department-of-energy-climate-change",
         "locale": "en",
-        "analytics_identifier": "D11"
+        "analytics_identifier": "D11",
+        "document_type": "organisation"
       }
     ],
     "speaker": [
@@ -64,7 +65,8 @@
         "base_path": "/government/people/andrea-leadsom",
         "api_url": "https://www.gov.uk/api/content/government/people/andrea-leadsom",
         "web_url": "https://www.gov.uk/government/people/andrea-leadsom",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "person"
       }
     ]
   }


### PR DESCRIPTION
https://trello.com/c/q0PNOZkj/117-move-formats-with-images-to-universal-layout

Moving 'Part of' links to the navigation sidebar means [some
integration tests on government-frontend will require the sidebar
to render](https://github.com/alphagov/government-frontend/pull/580/commits/bff4b8c805ae3f5eb376bd70cd7d4e9b45eff9b5), so add the `document_type` to the relevant
schema examples used in the first batch of redesigned formats as
the [related navigation relies on this attribute to include the links](https://github.com/alphagov/govuk_navigation_helpers/blob/master/lib/govuk_navigation_helpers/content_item.rb#L161).

More to follow as we redesign more formats.