### PR TITLE
Service Manual Frontend & Whitehall now use the standard buildProject

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,7 @@ def dependentApplications = [
   ['smartanswers', true],
   ['specialist-publisher', true],
   ['static', true],
-
-  ['whitehall', false],
+  ['whitehall', true],
 ]
 
 node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,13 +29,13 @@ def dependentApplications = [
   ['publishing-api', true],
   ['rummager', true],
   ['search-admin', true],
+  ['service-manual-frontend', true],
   ['service-manual-publisher', true],
   ['short-url-manager', true],
   ['smartanswers', true],
   ['specialist-publisher', true],
   ['static', true],
 
-  ['service-manual-frontend', false],
   ['whitehall', false],
 ]
 


### PR DESCRIPTION
For: https://trello.com/c/QtpGwa2A/288-improve-feedback-on-github-for-changes-to-govuk-content-schemas

This means both these apps can report to github themselves and we don't have to wait for them
explicitly in our Jenkinsfile anymore.

These are the last two, but I've left the wait version of the `dependentApplications` loop just in case we need to add some apps that don't use the standard jenkinsfile and don't talk to github themselves.  But I could be convinced to delete this if pressed as I don't really think we want to encourage it.

See: alphagov/service-manual-frontend#127, alphagov/whitehall#3640 and previous work in #661 