### PR TITLE
Add reversable level_one_taxons link to the homepage

### DIFF
--- a/formats/homepage.jsonnet
+++ b/formats/homepage.jsonnet
@@ -7,6 +7,13 @@
     },
   },
   links: {
-    root_taxons: "Defines a set of Taxonomy trees rooted in this node.",
+    root_taxons: {
+      "$ref": "#/definitions/guid_list",
+      description: "Defines a set of Taxonomy trees rooted in this node. (Deprecated - use level_one_taxons instead)",
+    },
+    level_one_taxons: {
+      "$ref": "#/definitions/guid_list",
+      description: "Defines a set of Taxonomy branches rooted in this node.",
+    },
   },
 }

--- a/formats/taxon.jsonnet
+++ b/formats/taxon.jsonnet
@@ -24,6 +24,13 @@
     associated_taxons: "A list of associated taxons whose children should be included as children of this taxon",
   },
   links: (import "shared/base_links.jsonnet") + {
-    parent_taxons: "The list of taxon parents (DEPRECATED: use the edition links instead)",
+    parent_taxons: {
+      "$ref": "#/definitions/guid_list",
+      description: "The list of taxon parents (DEPRECATED: use the edition links instead)",
+    },
+    root_taxon: {
+      "$ref": "#/definitions/guid",
+      description: "Set to the root taxon (homepage) if this is a level one taxon.",
+    },
   },
 }


### PR DESCRIPTION
- Add level_one_taxons links to the homepage
- Deprecate root_taxons link on the homepage
- Add root_taxon to taxons which acts as the reverse of the
level_one_taxons

Adding a parent of a parentless taxon previously required an additional call to the publishing api to ensure it is not a level one taxon (i.e. getting the homepage to see if there is a 'root_taxons' link to the taxon). With this change a reverse link is introduced making these types of update easier.