### PR TITLE
Update service sign in examples

### DIFF
--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -324,8 +324,7 @@
     "details": {
       "type": "object",
       "required": [
-        "choose_sign_in",
-        "create_new_account"
+        "choose_sign_in"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -387,8 +387,7 @@
     "details": {
       "type": "object",
       "required": [
-        "choose_sign_in",
-        "create_new_account"
+        "choose_sign_in"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -232,8 +232,7 @@
     "details": {
       "type": "object",
       "required": [
-        "choose_sign_in",
-        "create_new_account"
+        "choose_sign_in"
       ],
       "additionalProperties": false,
       "properties": {

--- a/examples/service_sign_in/frontend/service_sign_in.json
+++ b/examples/service_sign_in/frontend/service_sign_in.json
@@ -35,23 +35,23 @@
         {
           "text": "Use Government Gateway",
           "url": "https://www.tax.service.gov.uk/account",
-          "hint_text": "You'll have a user ID if you've registered to file your Self Assessment tax return online before."
+          "hint_text": "You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online."
         },
         {
           "text": "Use GOV.UK Verify",
-          "hint_text": "You'll have an account if you've proved your identity with a certified company, such as the Post Office.",
+          "hint_text": "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.",
           "url": "https://www.tax.service.gov.uk/ida/sa/login"
         },
         {
           "text": "Create an account",
-          "url": "/log-in-file-self-assessment-tax-return/sign-in/create-new-account"
+          "url": "/examples/service_sign_in/service_sign_in/create-new-account"
         }
       ]
     },
     "create_new_account": {
       "title": "Create an account",
       "slug": "create-new-account",
-      "body": "<p>To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.</p><p>Once you have an account, you can use it to access other government services online. </p><h2>Choose a way to prove your identity</h2><h3>Government Gateway</h3><p>Registering with Government Gateway usually takes about 10 minutes. It works best if you have:</p><ul><li>your National Insurance number</li><li>a recent payslip or a P60 or valid UK passport</li></ul><a href='#'>Create a Government Gateway account</a>"
+      "body": "<p>To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.</p><p>Once you have an account, you can use it to access other government services online.</p><h2 id='choose-a-way-to-prove-your-identity'>Choose a way to prove your identity</h2><h3 id='government-gateway'>Government Gateway</h3><p>Registering with Government Gateway usually takes about 10 minutes. It works best if you have:</p><ul><li>your National Insurance number</li><li>a recent payslip or P60 or a valid UK passport</li></ul><p><a rel='external' href='https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.114080007.145612230.1512381177-373904926.1473694521'>Create a Government Gateway account.</a></p><h3 id='govuk-verify'>GOV.UK Verify</h3><p>Registering with GOV.UK Verify usually takes about 15 minutes. It works best if you have:</p><ul><li>a UK address</li><li>a valid passport or photocard driving licence</li></ul><p><a rel='external' href='https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521'>Create a GOV.UK Verify account.</a></p><p>A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.</p><h2 id='personal-tax-account'>Personal tax account</h2><p>Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.</p>"
     }
   }
 }

--- a/examples/service_sign_in/frontend/view_driving_licence.json
+++ b/examples/service_sign_in/frontend/view_driving_licence.json
@@ -1,0 +1,47 @@
+{
+  "base_path": "/view-driving-licence/sign-in",
+  "content_id": "514754a3-3cac-4335-a676-f8987e3478fe",
+  "document_type": "service_sign_in",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2015-05-28T15:46:51.000+00:00",
+  "publishing_app": "publisher",
+  "rendering_app": "government-frontend",
+  "schema_name": "service_sign_in",
+  "title": "View Driving Licence",
+  "description": "Sign-in pages for view driving licence",
+  "updated_at": "2017-02-09T14:34:06.890Z",
+  "links": {
+    "parent": [
+      {
+        "content_id": "bee455d5-5a4f-440a-88be-eb65ae8fde7d",
+        "base_path": "/view-driving-licence",
+        "schema_name": "transaction",
+        "description": "Find out what information DVLA holds about your driving licence or create a check code to share your driving record, for example to hire a car",
+        "document_type": "transaction",
+        "locale": "en",
+        "public_updated_at": "2015-01-15T16:17:28.000+00:00",
+        "title": "View or share your driving licence information"
+      }
+    ]
+  },
+  "details": {
+    "choose_sign_in": {
+      "title": "Prove your identity to continue",
+      "slug": "choose-sign-in",
+      "options": [
+        {
+          "text": "Use your driving licence and National Insurance number",
+          "url": "https://www.viewdrivingrecord.service.gov.uk/driving-record/licence-number",
+          "hint_text": "Your driving licence must have been issued in England, Scotland or Wales."
+        },
+        {
+          "text": "Use GOV.UK Verify",
+          "hint_text": "You can use an existing identity account or create a new one. It usually takes about 5 minutes to create an account.",
+          "url": "https://www.viewdrivingrecord.service.gov.uk/verify/start"
+        }
+      ]
+    }
+  }
+}

--- a/examples/service_sign_in/frontend/welsh.json
+++ b/examples/service_sign_in/frontend/welsh.json
@@ -1,0 +1,57 @@
+{
+  "base_path": "/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad/mewngofnodi",
+  "content_id": "e8a05f06-60b5-484d-8e28-d3e3fa225152",
+  "document_type": "service_sign_in",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "locale": "cy",
+  "phase": "live",
+  "public_updated_at": "2015-05-28T15:46:51.000+00:00",
+  "publishing_app": "publisher",
+  "rendering_app": "government-frontend",
+  "schema_name": "service_sign_in",
+  "title": "Self Assessment",
+  "description": "Sign-in pages for Self Assessment",
+  "updated_at": "2017-02-09T14:34:06.890Z",
+  "links": {
+    "parent": [
+      {
+        "content_id": "c2add6c6-be21-4acc-9165-9755a2cdeda5",
+        "base_path": "/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad",
+        "schema_name": "guide",
+        "description": "Bydd angen i chi brofi pwy ydych chi gan ddefnyddio Porth y Llywodraeth neu GOV.UK Verify.",
+        "document_type": "guide",
+        "locale": "cy",
+        "public_updated_at": "2015-01-15T16:17:28.000+00:00",
+        "title": "Cyflwynwch eich Ffurflen Dreth ar-lein"
+      }
+    ]
+  },
+  "details": {
+    "choose_sign_in": {
+      "title": "Profwch pwy ydych chi i fwrw ymlaen",
+      "slug": "dewiswch-lofnodi",
+      "description": "<p>Os ydych chi’n ffeilio ar-lein am y tro cyntaf, bydd angen i chi gofrestru ar gyfer Hunanasesiad yn gyntaf.</p>",
+      "options": [
+        {
+          "text": "Defnyddio Porth y Llywodraeth",
+          "url": "https://www.tax.service.gov.uk/account",
+          "hint_text": "Bydd gennych chi ID defnyddiwr os ydych chi wedi cofrestru ar gyfer Hunanasesiad neu wedi ffeilio ffurflen dreth ar-lein yn y gorffennol."
+        },
+        {
+          "text": "Defnyddio GOV.UK Verify ",
+          "hint_text": "Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.",
+          "url": "https://www.tax.service.gov.uk/ida/sa/login"
+        },
+        {
+          "text": "Cofrestru ar gyfer Hunanasesiad",
+          "url": "/examples/service_sign_in/welsh/cofrestru-ar-gyfer-hunanasesiad"
+        }
+      ]
+    },
+    "create_new_account": {
+      "title": "Cofrestru ar gyfer Hunanasesiad",
+      "slug": "cofrestru-ar-gyfer-hunanasesiad",
+      "body": "<p>Mae ffyrdd gwahanol o gofrestru os ydych chi:</p><ul><li><a href='/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad/cofrestru-os-ydych-yn-hunangyflogedig'>yn hunangyflogedig neu’n unig fasnachwr</a></li><li><a href='/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad/cofrestru-os-nad-ydych-yn-hunangyflogedig'>ddim yn hunangyflogedig</a></li><li><a href='/mewngofnodi-chyflwynoch-ffurflen-dreth-huanasesiad/cofrestru-os-ydych-yn-bartner-neun-bartneriaeth'>yn cofrestru partner neu bartneriaeth</a></li></ul><p>Rhowch ddigon o amser i chi gwblhau’r broses gofrestru er mwyn i chi ddychwelyd eich ffurflen erbyn y <a href='/ffurflenni-treth-hunanasesiad/dyddiadau-cau'>dyddiad cau</a>.</p><h2 id='os-ydych-chi-wedi-cofrestrun-barod'>Os ydych chi wedi cofrestru’n barod</h2><p>Unwaith y byddwch chi wedi cofrestru, bydd angen i chi roi eich cyfrif Porth y Llywodraeth ar waith drwy ei gysylltu â’ch Cyfeirnod Trethdalwr Unigryw (UTR).  Fe gewch chi lythyr a fydd yn dweud wrthych chi sut mae gwneud hyn.</p><p>Gallwch <a rel='external' href='https://www.tax.service.gov.uk/government-gateway-registration-frontend/route?continue=%2Faccount&amp;origin=unknown'>greu cyfrif Porth y Llywodraeth</a> os nad oes gennych chi un.</p><div role='note' aria-label='Information' class='application-notice info-notice'><p>Peidiwch â chreu cyfrif newydd os ydych chi wedi rhoi un ar waith yn barod. Gallwch gysylltu eich UTR ag un cyfrif Porth y Llywodraeth yn unig.</p></div>"
+    }
+  }
+}

--- a/formats/service_sign_in.jsonnet
+++ b/formats/service_sign_in.jsonnet
@@ -6,7 +6,6 @@
       additionalProperties: false,
       required: [
         "choose_sign_in",
-        "create_new_account",
       ],
       properties: {
         choose_sign_in: {


### PR DESCRIPTION
- Adds in a VDL example so we can test examples that do not need the :or option
- Adds a welsh version so we can test i18n and our routing works with different slugs
- Updates default example to be more complete
- Makes `create_new_account` an optional field, as there are services such as VDL that don't require it ([Trello card](https://trello.com/c/ydt46bDm/276-make-the-create-new-account-page-optional-in-the-schema))

Tested against government-frontend with

- http://government-frontend.dev.gov.uk/examples/service_sign_in/service_sign_in/choose-sign-in
- http://government-frontend.dev.gov.uk/examples/service_sign_in/welsh/dewiswch-lofnodi
- http://government-frontend.dev.gov.uk/examples/service_sign_in/view_driving_licence/choose-sign-in