### PR TITLE
Add search-admin to downstream builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ def dependentApplications = [
   ['publisher', true],
   ['publishing-api', true],
   ['rummager', true],
+  ['search-admin', true],
   ['service-manual-publisher', true],
   ['short-url-manager', true],
   ['smartanswers', true],


### PR DESCRIPTION
The search-admin app now publishes external content ("recommended links") to the publishing API and depends on the content schemas.

https://trello.com/c/rDurYmt8/525-send-external-links-from-search-admin-to-the-publishing-api