### PR TITLE
Add document type attribute for consultations

### DIFF
--- a/examples/consultation/frontend/closed_consultation.json
+++ b/examples/consultation/frontend/closed_consultation.json
@@ -47,6 +47,7 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-culture-media-sport",
         "web_url": "https://www.gov.uk/government/organisations/department-for-culture-media-sport",
         "locale": "en",
+        "document_type": "organisation",
         "analytics_identifier": "D5"
       }
     ],

--- a/examples/consultation/frontend/consultation_outcome.json
+++ b/examples/consultation/frontend/consultation_outcome.json
@@ -58,6 +58,7 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs",
         "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
         "locale": "en",
+        "document_type": "organisation",
         "analytics_identifier": "D25"
       }
     ],

--- a/examples/consultation/frontend/consultation_outcome_with_feedback.json
+++ b/examples/consultation/frontend/consultation_outcome_with_feedback.json
@@ -86,6 +86,7 @@
         "web_url": "https://www.gov.uk/government/organisations/ofqual",
         "locale": "en",
         "analytics_identifier": "D109",
+        "document_type": "organisation",
         "title": "Ofqual"
       }
     ]

--- a/examples/consultation/frontend/open_consultation.json
+++ b/examples/consultation/frontend/open_consultation.json
@@ -51,6 +51,7 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
         "web_url": "https://www.gov.uk/government/organisations/department-for-education",
         "locale": "en",
+        "document_type": "organisation",
         "analytics_identifier": "D25"
       }
     ],
@@ -73,7 +74,8 @@
         "api_path": "/api/content/topic/higher-education/administration",
         "api_url": "https://www.gov.uk/api/content/topic/higher-education/administration",
         "web_url": "https://www.gov.uk/topic/higher-education/administration",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "topic"
       }
     ]
   }

--- a/examples/consultation/frontend/open_consultation_with_participation.json
+++ b/examples/consultation/frontend/open_consultation_with_participation.json
@@ -56,6 +56,7 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
         "web_url": "https://www.gov.uk/government/organisations/department-for-education",
         "locale": "en",
+        "document_type": "organisation",
         "analytics_identifier": "D25"
       },
       {
@@ -66,6 +67,7 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-business-energy-and-industrial-strategy",
         "web_url": "https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy",
         "locale": "en",
+        "document_type": "organisation",
         "analytics_identifier": "D1198"
       }
     ]

--- a/examples/consultation/frontend/unopened_consultation.json
+++ b/examples/consultation/frontend/unopened_consultation.json
@@ -44,6 +44,7 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/environment-agency",
         "web_url": "https://www.gov.uk/government/organisations/environment-agency",
         "locale": "en",
+        "document_type": "organisation",
         "analytics_identifier": "EA199"
       }
     ],
@@ -55,7 +56,8 @@
         "api_path": "/api/content/government/policies/radioactive-and-nuclear-substances-and-waste",
         "api_url": "https://www.gov.uk/api/content/government/policies/radioactive-and-nuclear-substances-and-waste",
         "web_url": "https://www.gov.uk/government/policies/radioactive-and-nuclear-substances-and-waste",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy"
       }
     ],
     "document_collections": [
@@ -66,7 +68,8 @@
         "base_path": "/government/collections/assessing-new-nuclear-power-station-designs",
         "api_url": "https://www.gov.uk/api/content/government/collections/assessing-new-nuclear-power-station-designs",
         "web_url": "https://www.gov.uk/government/collections/assessing-new-nuclear-power-station-designs",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "document_collection"
       }
     ],
     "topics": [
@@ -77,7 +80,8 @@
         "base_path": "/topic/environmental-management/nuclear-regulation",
         "api_url": "https://www.gov.uk/api/content/topic/environmental-management/nuclear-regulation",
         "web_url": "https://www.gov.uk/topic/environmental-management/nuclear-regulation",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "topic"
       }
     ]
   }


### PR DESCRIPTION
Moving 'Part Of' links to the related navigation sidebar means some integration tests will require the sidebar to render.
The logic behind the sidebar relies on the presence of the document_type attribute, so we need to add this to our examples.