### PR TITLE
Remove root taxons link type

### DIFF
--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -91,10 +91,6 @@
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "root_taxons": {
-          "description": "Defines a set of Taxonomy trees rooted in this node. (Deprecated - use level_one_taxons instead)",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -92,10 +92,6 @@
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "root_taxons": {
-          "description": "Defines a set of Taxonomy trees rooted in this node. (Deprecated - use level_one_taxons instead)",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -115,10 +111,6 @@
       "properties": {
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "root_taxons": {
-          "description": "Defines a set of Taxonomy trees rooted in this node. (Deprecated - use level_one_taxons instead)",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -7,10 +7,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "root_taxons": {
-          "description": "Defines a set of Taxonomy trees rooted in this node. (Deprecated - use level_one_taxons instead)",
-          "$ref": "#/definitions/guid_list"
-        }
       }
     },
     "previous_version": {
@@ -18,16 +14,5 @@
     }
   },
   "definitions": {
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      },
-      "uniqueItems": true
-    }
   }
 }

--- a/formats/homepage.jsonnet
+++ b/formats/homepage.jsonnet
@@ -6,9 +6,5 @@
       properties: {},
     },
   },
-  links: {
-    root_taxons: {
-      description: "Defines a set of Taxonomy trees rooted in this node. (Deprecated - use level_one_taxons instead)",
-    },
-  },
+  links: {},
 }


### PR DESCRIPTION
Trello: https://trello.com/c/g41T515W/314-clean-up-use-of-the-roottaxons-link-on-the-homepage-content-item

This has been replaced by a reversible link type introduced in [1].
Consumers that were using the 'root_taxons' links have been updated and
are now using the 'level_one_taxons' link type.

[1] https://github.com/alphagov/govuk-content-schemas/commit/ce97b51b6d61d72eef49e54ae79c2546c1494f04
