### PR TITLE
Add document_type to detailed guide examples

### DIFF
--- a/examples/detailed_guide/frontend/detailed_guide.json
+++ b/examples/detailed_guide/frontend/detailed_guide.json
@@ -56,7 +56,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/hm-revenue-customs",
         "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
         "locale": "en",
-        "analytics_identifier": "D25"
+        "analytics_identifier": "D25",
+        "document_type": "organisation"
       }
     ],
     "policy_areas": [
@@ -67,7 +68,8 @@
         "base_path": "/government/topics/tax-and-revenue",
         "api_url": "https://www.gov.uk/api/content/government/world/topics/tax-and-revenue",
         "web_url": "https://www.gov.uk/government/world/topics/tax-and-revenue",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "policy_area"
       }
     ],
     "parent": [
@@ -79,6 +81,7 @@
         "api_url": "https://www.gov.uk/api/content/topic/business-tax/paye",
         "web_url": "https://www.gov.uk/topic/business-tax/paye",
         "locale": "en",
+        "document_type": "topic",
         "links": {
           "parent": [
             {
@@ -88,7 +91,8 @@
               "api_path": "/api/content/topic/business-tax",
               "api_url": "https://www.gov.uk/api/content/topic/business-tax",
               "web_url": "https://www.gov.uk/topic/business-tax",
-              "locale": "en"
+              "locale": "en",
+              "document_type": "topic"
             }
           ]
         }
@@ -102,7 +106,8 @@
         "api_path": "/api/content/topic/business-tax/paye",
         "api_url": "https://www.gov.uk/api/content/topic/business-tax/paye",
         "web_url": "https://www.gov.uk/topic/business-tax/paye",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "topic"
       },
       {
         "content_id": "a481832e-5f10-4d3b-8131-a064b36730ae",
@@ -111,7 +116,8 @@
         "api_path": "/api/content/topic/business-tax",
         "api_url": "https://www.gov.uk/api/content/topic/business-tax",
         "web_url": "https://www.gov.uk/topic/business-tax",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "topic"
       }
     ]
   }

--- a/examples/detailed_guide/frontend/national_applicability_detailed_guide.json
+++ b/examples/detailed_guide/frontend/national_applicability_detailed_guide.json
@@ -65,7 +65,8 @@
         "api_url": "https://www.gov.uk/api/conent/government/organisations/department-for-communities-and-local-government",
         "web_url": "https://www.gov.uk/government/organisations/department-for-communities-and-local-government",
         "locale": "en",
-        "analytics_identifier": "D4"
+        "analytics_identifier": "D4",
+        "document_type": "organisation"
       }
     ],
     "parent": [

--- a/examples/detailed_guide/frontend/political_detailed_guide.json
+++ b/examples/detailed_guide/frontend/political_detailed_guide.json
@@ -42,7 +42,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/department-of-energy-climate-change",
         "web_url": "https://www.gov.uk/government/organisations/department-of-energy-climate-change",
         "locale": "en",
-        "analytics_identifier": "D11"
+        "analytics_identifier": "D11",
+        "document_type": "organisation"
       }
     ],
     "parent": [
@@ -54,6 +55,7 @@
         "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy/low-carbon-energy",
         "web_url": "https://www.gov.uk/topic/climate-change-energy/low-carbon-energy",
         "locale": "en",
+        "document_type": "topic",
         "links": {
           "parent": [
             {
@@ -63,7 +65,8 @@
               "base_path": "/topic/climate-change-energy",
               "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy",
               "web_url": "https://www.gov.uk/topic/climate-change-energy",
-              "locale": "en"
+              "locale": "en",
+              "document_type": "topic"
             }
           ]
         }
@@ -77,7 +80,8 @@
         "base_path": "/guidance/offshore-wind-part-of-the-uks-energy-mix",
         "api_url": "https://www.gov.uk/api/content/guidance/offshore-wind-part-of-the-uks-energy-mix",
         "web_url": "https://www.gov.uk/guidance/offshore-wind-part-of-the-uks-energy-mix",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "detailed_guide"
       }
     ],
     "topics": [
@@ -88,7 +92,8 @@
         "base_path": "/topic/climate-change-energy/low-carbon-energy",
         "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy/low-carbon-energy",
         "web_url": "https://www.gov.uk/topic/climate-change-energy/low-carbon-energy",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "topic"
       },
       {
         "content_id": "57c6699d-ceda-4168-9d23-3fed774ca776",
@@ -97,7 +102,8 @@
         "base_path": "/topic/climate-change-energy",
         "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy",
         "web_url": "https://www.gov.uk/topic/climate-change-energy",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "topic"
       }
     ]
   }

--- a/examples/detailed_guide/frontend/related_mainstream_detailed_guide.json
+++ b/examples/detailed_guide/frontend/related_mainstream_detailed_guide.json
@@ -55,7 +55,8 @@
         "base_path": "/government/collections/overseas-living-in-guides",
         "api_url": "https://www.gov.uk/api/content/government/collections/overseas-living-in-guides",
         "web_url": "https://www.gov.uk/government/collections/overseas-living-in-guides",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "document_collection"
       }
     ],
     "related_guides": [
@@ -66,7 +67,8 @@
         "base_path": "/guidance/living-in-fiji",
         "api_url": "https://www.gov.uk/api/content/guidance/living-in-fiji",
         "web_url": "https://www.gov.uk/guidance/living-in-fiji",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "detailed_guide"
       }
     ],
     "organisations": [
@@ -78,7 +80,8 @@
         "api_url": "https://www.gov.uk/api/content/government/organisations/foreign-commonwealth-office",
         "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
         "locale": "en",
-        "analytics_identifier": "D13"
+        "analytics_identifier": "D13",
+        "document_type": "organisation"
       }
     ],
     "related_mainstream_content": [
@@ -89,7 +92,8 @@
         "base_path": "/overseas-passports",
         "api_url": "https://www.gov.uk/api/content/overseas-passports",
         "web_url": "https://www.gov.uk/overseas-passports",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "answer"
       },
       {
         "content_id": "f02fc2c9-f5ff-4ea2-acc4-730bbda957bb",
@@ -98,7 +102,8 @@
         "base_path": "/report-a-lost-or-stolen-passport",
         "api_url": "https://www.gov.uk/api/content/report-a-lost-or-stolen-passport",
         "web_url": "https://www.gov.uk/report-a-lost-or-stolen-passport",
-        "locale": "en"
+        "locale": "en",
+        "document_type": "transaction"
       }
     ]
   }


### PR DESCRIPTION
Part of https://trello.com/c/uScvU8q2/189-add-detailedguide-to-universal-layout

Required by https://github.com/alphagov/government-frontend/pull/706