### PR TITLE
Add JSON Schema documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For each schema, there are three possible representations:
 
 * [How to change a schema](docs/changing-a-schema.md)
 * [How to add a new content schema](docs/adding-a-new-schema.md)
+* [Working with JSON Schema keywords](docs/working-with-json-schema-keywords.md)
 * [Adding contract tests to your app](docs/contract-testing-howto.md)
 * [Suggested workflows](docs/suggested-workflows.md)
 * [Why do contract testing?](docs/why-contract-testing.md)

--- a/docs/working-with-json-schema-keywords.md
+++ b/docs/working-with-json-schema-keywords.md
@@ -1,0 +1,22 @@
+# Working with JSON Schema keywords
+
+There are various keywords available to use in your content schema. Some of the keywords listed below have been used in our more complex schemas.
+
+| Keyword                                               |  Explanation                                                                                    |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [`type`][data-types]                                  | The data type of a schema                                                                       |
+| [`required`][required]                                | Specify object-level properties that must exist - by default all object properties are optional |
+| [`enum`][enum]                                        | To specify values a request parameter or model property can accept                              |
+| [`oneOf`][oneof], [`anyOf`][anyof], [`allOf`][allof]  | These allow you to validate the use of other subschemas in your schema                          |
+| [`$ref`][ref]                                         | To include a subschema within your schema. It can be either a relative or absolute URI          |
+| [`additionalProperties`][additional-properties]       | Controls whether properties that are not already specified can be accepted. By default any additional properties are allowed     |
+
+
+[data-types]: https://swagger.io/docs/specification/data-models/data-types/
+[required]: https://spacetelescope.github.io/understanding-json-schema/reference/object.html?highlight=required#required
+[enum]: https://spacetelescope.github.io/understanding-json-schema/reference/object.html?highlight=required#required
+[oneof]: https://spacetelescope.github.io/understanding-json-schema/reference/combining.html?highlight=oneof#oneof
+[anyof]: https://spacetelescope.github.io/understanding-json-schema/reference/combining.html?highlight=anyof#anyof
+[allof]: https://spacetelescope.github.io/understanding-json-schema/reference/combining.html?highlight=allof#allof
+[ref]: https://spacetelescope.github.io/understanding-json-schema/structuring.html?highlight=$ref
+[additional-properties]: https://spacetelescope.github.io/understanding-json-schema/reference/object.html?highlight=additionalproperties#properties


### PR DESCRIPTION
The Modelling Services team have been working on the content schema for `step by step navigation` (previously called `task lists`).

We had to do a bit of research to find out how to represent certain properties of our task list, and thought it would be good to add to our documentation.

Please feel free to add to this.