### PR TITLE
Allow redirects

### DIFF
--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -130,6 +130,9 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "redirects": {
+      "$ref": "#/definitions/redirects"
+    },
     "rendering_app": {
       "type": "null"
     },
@@ -163,6 +166,11 @@
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
     "absolute_path": {
       "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
@@ -250,6 +258,11 @@
           }
         }
       }
+    },
+    "govuk_subdomain_url": {
+      "description": "A URL under the gov.uk domain with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
     },
     "guid": {
       "type": "string",
@@ -370,6 +383,51 @@
           "type": "null"
         }
       ]
+    },
+    "redirect_route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "destination": {
+          "type": "string",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/absolute_fullpath"
+            },
+            {
+              "$ref": "#/definitions/govuk_subdomain_url"
+            }
+          ]
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      },
+      "minItems": 1
     },
     "withdrawn_notice": {
       "type": "object",

--- a/examples/redirect/frontend/redirect.json
+++ b/examples/redirect/frontend/redirect.json
@@ -23,5 +23,18 @@
   "publishing_request_id": null,
   "links": {},
   "description": null,
-  "details": {}
+  "details": {},
+  "redirects": [
+    {
+      "path": "/406beacon",
+      "type": "exact",
+      "destination": "/maritime-safety-weather-and-navigation/register-406-mhz-beacons?query=answer#fragment"
+    },
+    {
+      "path": "/406beacon/prefix",
+      "type": "prefix",
+      "destination": "/new-406-beacons-destination",
+      "segments_mode": "preserve"
+    }
+  ]
 }

--- a/lib/schema_generator/frontend_schema_generator.rb
+++ b/lib/schema_generator/frontend_schema_generator.rb
@@ -67,7 +67,7 @@ module SchemaGenerator
     end
 
     def derived_properties
-      properties = {
+      {
         "content_id" => format.content_id(frontend: true).definition,
         "document_type" => format.document_type.definition,
         "description" => format.description.definition,
@@ -76,7 +76,9 @@ module SchemaGenerator
         "rendering_app" => format.rendering_app.definition,
         "schema_name" => format.schema_name_definition,
         "title" => format.title.definition,
-      }
+      }.tap do |p|
+        p["redirects"] = format.redirects.definition if format.schema_name == "redirect"
+      end
     end
 
     def change_multiple_content_types(definitions)


### PR DESCRIPTION
See: https://github.com/alphagov/gds-api-adapters/pull/805 for context

Currently it's possible to have a redirect make its way to a frontend
application (for example when a route is in the process of changing to a
redirect at the time of a request). Frontend apps don't have any means
to deal with these redirects as they are not provided with the content
item.

Since this field is only useful on redirects it's only enabled on
documents with that schema name. It is also an optional field as any
existing published redirects won't have it.