### PR TITLE
Add more government_document_supertypes to examples

### DIFF
--- a/examples/consultation/frontend/closed_consultation.json
+++ b/examples/consultation/frontend/closed_consultation.json
@@ -7,6 +7,7 @@
   "updated_at": "2016-09-05T15:00:00Z",
   "schema_name": "consultation",
   "document_type": "closed_consultation",
+  "government_document_supertype": "consultations",
   "locale": "en",
   "details": {
     "body": "<div class=\"govspeak\"><p>The Museums Review will consider how museums and galleries across England can thrive and become even more inclusive. The Review will look at how the sector operates, the challenges it faces and the role of government-sponsored museums.</p>\n\n<p>To help inform this review, DCMS would welcome your feedback through our online Calls for Evidence (see links in attached document).</p>\n\n<p>The Calls for Evidence are open until 31 October 2016.</p>\n\n<p>The full Terms of Reference for the review can be found in the above document.</p>\n\n<p>If you have any queries about the review, please contact DCMS at museums.review@culture.gov.uk</p>\n</div>",

--- a/examples/consultation/frontend/consultation_outcome.json
+++ b/examples/consultation/frontend/consultation_outcome.json
@@ -7,6 +7,7 @@
   "updated_at": "2016-10-18T09:30:00Z",
   "schema_name": "consultation",
   "document_type": "consultation_outcome",
+  "government_document_supertype": "consultations",
   "locale": "en",
   "details": {
     "body": "<div class=\"govspeak\"><p>A NIC election is the means of legally transferring to the employee the Employer’s Class 1 NIC obligation on the occasion of chargeable events in connection with employment-related securities options, and with restricted or convertible employment-related securities. This consultation is designed to gather views and evidence from companies with nontax-advantaged share schemes about whether there is a need for the continued availability of a NIC election. NIC agreements will continue to be available.</p>\n\n<p>The consultation is particularly relevant for accounting and legal advisers of companies which offer non tax-advantaged share schemes, particularly multinational companies with UK employees.</p>\n</div>",

--- a/examples/consultation/frontend/consultation_outcome_with_feedback.json
+++ b/examples/consultation/frontend/consultation_outcome_with_feedback.json
@@ -7,6 +7,7 @@
   "updated_at": "2016-09-08T10:38:10.000+01:00",
   "schema_name": "consultation",
   "document_type": "consultation_outcome",
+  "government_document_supertype": "consultations",
   "locale": "en",
   "details": {
     "body": "<div class=\"govspeak\"><p>We are seeking views on our proposals for setting grade standards for new GCSEs. This consultation follows on from our earlier consultation on <a rel=\"external\" href=\"http://webarchive.nationalarchives.gov.uk/20141110161323/http:/comment.ofqual.gov.uk/setting-the-grade-standards-of-new-gcses-april-2014/\">‘Setting the grade standards of new GCSEs in England’</a>.</p><p>In September 2014 we announced our decisions about the awarding of new GCSEs in English language, English literature and mathematics which will be first awarded in summer 2017.</p><p>We are now consulting on the approach to be taken in all other subjects. We are also consulting on a change to our previous decisions for English language, English literature and mathematics, about how grades 8 and 9 are set.</p><p>Our proposals are designed to protect students taking the new qualifications, particularly in the first year when teachers will be less familiar with the new content and how it is assessed. We want to minimise unexpected or unfair outcomes for students in the transition to the new GCSEs.</p></div>",

--- a/examples/consultation/frontend/open_consultation_with_participation.json
+++ b/examples/consultation/frontend/open_consultation_with_participation.json
@@ -7,6 +7,7 @@
   "updated_at": "2016-11-08T12:52:46.734Z",
   "schema_name": "consultation",
   "document_type": "open_consultation",
+  "government_document_supertype": "consultations",
   "locale": "en",
   "details": {
     "body": "<div class=\"govspeak\"><p>Government provides funding to maintain a national network of post office branches that is accessible to everyone. We want you to tell us what you expect from the post office network.</p>\n\n<p>Your responses will be used to help determine the funding provided to the post office after the existing agreement with Post Office Limited ends in 2018.</p>\n\n<p>We are not proposing any changes to the network through this consultation.</p>\n</div>",

--- a/examples/consultation/frontend/unopened_consultation.json
+++ b/examples/consultation/frontend/unopened_consultation.json
@@ -7,6 +7,7 @@
   "updated_at": "2016-11-16T15:33:24.545Z",
   "schema_name": "consultation",
   "document_type": "consultation",
+  "government_document_supertype": "consultations",
   "locale": "en",
   "details": {
     "body": "<div class=\"govspeak\"><p>The Environment Agency is proposing to consult with stakeholders on the generic design assessment (GDA) of Hitachi-GE Nuclear Energy Ltd’s (Hitachi-GE) UK Advanced Boiling Water Reactor (ABWR).</p><p>The consultation will be open from 12 December 2016 until 3 March 2017.</p></div>",


### PR DESCRIPTION
These consultations examples will be used by integration tests in government-frontend.

See https://github.com/alphagov/government-frontend/pull/720