### PR TITLE
Add fields to step by step navigation

### DIFF
--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -183,6 +183,14 @@
         }
       ]
     },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -482,12 +490,18 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "introduction": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
         "steps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/individual_step"
           },
           "minItems": 1
+        },
+        "title": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -208,6 +208,14 @@
         }
       ]
     },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -434,6 +442,25 @@
         "zh-tw"
       ]
     },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",
       "type": "integer"
@@ -550,12 +577,18 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "introduction": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
         "steps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/individual_step"
           },
           "minItems": 1
+        },
+        "title": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -146,6 +146,14 @@
         }
       ]
     },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
     "description_optional": {
       "anyOf": [
         {
@@ -275,6 +283,25 @@
         "zh-tw"
       ]
     },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
@@ -376,12 +403,18 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "introduction": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
         "steps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/individual_step"
           },
           "minItems": 1
+        },
+        "title": {
+          "type": "string"
         }
       }
     },

--- a/examples/step_by_step_nav/frontend/learn_to_drive_a_car.json
+++ b/examples/step_by_step_nav/frontend/learn_to_drive_a_car.json
@@ -14,6 +14,8 @@
   },
   "details": {
     "step_by_step_nav": {
+      "title": "Learn to drive a car: step by step",
+      "introduction": "<p>Check what you need to do to learn to drive.</p>",
       "steps": [
         {
           "title": "Check you're allowed to drive",

--- a/examples/step_by_step_nav/publisher_v2/learn_to_drive_a_car.json
+++ b/examples/step_by_step_nav/publisher_v2/learn_to_drive_a_car.json
@@ -22,6 +22,13 @@
   },
   "details": {
     "step_by_step_nav": {
+      "title": "Learn to drive a car: step by step",
+      "introduction": [
+        {
+          "content_type": "text/govspeak",
+          "content": "Check what you need to do to learn to drive."
+        }
+      ],
       "steps": [
         {
           "title": "Check you're allowed to drive",

--- a/formats/shared/definitions/_step_by_step_nav.jsonnet
+++ b/formats/shared/definitions/_step_by_step_nav.jsonnet
@@ -6,6 +6,12 @@
       "steps",
     ],
     properties: {
+      title: {
+        type: "string"
+      },
+      introduction: {
+        "$ref": "#/definitions/body_html_and_govspeak",
+      },
       steps: {
         type: "array",
         minItems: 1,


### PR DESCRIPTION
We need to be able to display a title and introduction to a step by step navigation.  These may be different to the page title and the description (which is used as the meta description and in search).  

The introduction may also be in markdown as we've already identified that this will need to have
several paragraphs for future step by step navigation journeys.

We'll make this `required` in a future PR

https://trello.com/c/3pQPJDmj/440-allow-collections-to-render-task-lists-from-the-publishing-api