### PR TITLE
Add scheduled publishing time to the frontend schemas

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -491,6 +501,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -461,6 +471,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -190,6 +190,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -608,6 +618,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -464,6 +474,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -500,6 +510,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -197,6 +197,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -666,6 +676,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -184,6 +184,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -677,6 +687,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -175,6 +175,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -547,6 +557,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -191,6 +191,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -617,6 +627,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -192,6 +192,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -560,6 +570,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -525,6 +535,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -196,6 +196,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -500,6 +510,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -186,6 +186,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -661,6 +671,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -183,6 +183,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -553,6 +563,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -330,6 +330,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -603,6 +613,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -330,6 +330,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -629,6 +639,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -139,6 +139,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "type": "null"
     },
@@ -422,6 +432,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "withdrawn_notice": {
       "type": "object",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -516,6 +526,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -491,6 +501,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -576,6 +586,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -580,6 +590,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -144,6 +144,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -416,6 +426,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -178,6 +178,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -486,6 +496,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -510,6 +520,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -534,6 +544,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -159,6 +159,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -455,6 +465,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -148,6 +148,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -536,6 +546,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -182,6 +182,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -553,6 +563,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -521,6 +531,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -207,6 +207,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -642,6 +652,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -500,6 +510,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -334,6 +334,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -725,6 +735,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -196,6 +196,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -679,6 +689,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -219,6 +219,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -678,6 +688,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -142,6 +142,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "redirects": {
       "$ref": "#/definitions/redirects"
     },
@@ -395,6 +405,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "redirect_route": {
       "type": "object",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -189,6 +189,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -512,6 +522,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -454,6 +464,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -185,6 +185,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -470,6 +480,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -503,6 +513,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -193,6 +193,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -483,6 +493,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -536,6 +546,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -553,6 +563,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -333,6 +333,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app_optional"
     },
@@ -576,6 +586,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -203,6 +203,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -1654,6 +1664,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "raib_report_metadata": {
       "type": "object",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -209,6 +209,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -659,6 +669,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -521,6 +531,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -184,6 +184,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -493,6 +503,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -147,6 +147,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -470,6 +480,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -494,6 +504,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -193,6 +193,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -477,6 +487,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -185,6 +185,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -471,6 +481,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -468,6 +478,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -529,6 +539,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -184,6 +184,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -600,6 +610,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -184,6 +184,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -478,6 +488,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -477,6 +487,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -181,6 +181,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -464,6 +474,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -185,6 +185,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -500,6 +510,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -190,6 +190,16 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
@@ -615,6 +625,11 @@
           "type": "null"
         }
       ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/examples/publication/frontend/scheduled_publication.json
+++ b/examples/publication/frontend/scheduled_publication.json
@@ -1,0 +1,25 @@
+{
+  "base_path": "/government/publications/a-scheduled-publication",
+  "content_id": "9802be23-bbdc-4e85-bb6a-a03b8954747e",
+  "title": "Title of a scheduled publication",
+  "description": "Description of a scheduled publication",
+  "locale": "en",
+  "updated_at": "2016-05-03T14:11:53.023Z",
+  "public_updated_at": "2016-05-03T14:11:50.000+00:00",
+  "publishing_scheduled_at": "2016-05-03T14:10:00.000+00:00",
+  "government_document_supertype": "notices",
+  "details": {
+    "body": "Body text",
+    "documents": [],
+    "first_public_at": "2012-11-01T00:00:00.000+00:00",
+    "government": {
+      "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+      "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+      "current": false
+    },
+    "political": false
+  },
+  "links": {},
+  "schema_name": "publication",
+  "document_type": "notice"
+}

--- a/formats/shared/default_properties/frontend.jsonnet
+++ b/formats/shared/default_properties/frontend.jsonnet
@@ -26,4 +26,14 @@
     type: "string",
     format: "date-time",
   },
+  publishing_scheduled_at: {
+    anyOf: [
+      {
+        "$ref": "#/definitions/publishing_scheduled_at",
+      },
+      {
+        type: "null",
+      },
+    ],
+  },
 }

--- a/formats/shared/definitions/publishing_api_base.jsonnet
+++ b/formats/shared/definitions/publishing_api_base.jsonnet
@@ -144,6 +144,11 @@
     type: "string",
     format: "date-time",
   },
+  publishing_scheduled_at: {
+    description: "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+    type: "string",
+    format: "date-time",
+  },
   publishing_request_id: {
     description: "A unique identifier used to track publishing requests to rendered content",
     oneOf: [


### PR DESCRIPTION
Add optional `publishing_scheduled_at` field to the frontend schemas. This field will be added by the content store to let publishers compare the scheduled publishing time with the actual publishing time.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting