### PR TITLE
Add examples of documents with step nav links

### DIFF
--- a/examples/answer/frontend/answer-with-step-navs.json
+++ b/examples/answer/frontend/answer-with-step-navs.json
@@ -1,0 +1,320 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/gwasanaethau-ar-lein-cymraeg-cthem",
+  "content_id": "bcf3e1c5-b1f9-4813-a712-e9c9dd75c1f4",
+  "document_type": "answer",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "locale": "cy",
+  "need_ids": [
+
+  ],
+  "phase": "live",
+  "public_updated_at": "2015-05-28T15:46:51.000+00:00",
+  "publishing_app": "publisher",
+  "rendering_app": "frontend",
+  "schema_name": "answer",
+  "title": "Gwasanaethau ar-lein Cyllid a Thollau EM yn y Gymraeg",
+  "updated_at": "2017-02-09T14:34:06.890Z",
+  "withdrawn_notice": {
+  },
+  "links": {
+    "part_of_step_navs": [
+      {
+        "api_path": "/api/content/learn-to-drive-a-car",
+        "base_path": "/learn-to-drive-a-car",
+        "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+        "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+        "document_type": "step_by_step_nav",
+        "locale": "en",
+        "public_updated_at": "2018-03-02T11:53:13Z",
+        "schema_name": "step_by_step_nav",
+        "title": "Learn to drive a car: step by step",
+        "withdrawn": false,
+        "details": {
+          "step_by_step_nav": {
+            "title": "Learn to drive a car: step by step",
+            "introduction": [
+              {
+                "content_type": "text/govspeak",
+                "content": "Check what you need to do to learn to drive."
+              }
+            ],
+            "steps": [
+              {
+                "title": "Check you're allowed to drive",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "Most people can start learning to drive when they’re 17."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/vehicles-can-drive",
+                        "text": "Check what age you can drive"
+                      },
+                      {
+                        "href": "/legal-obligations-drivers-riders",
+                        "text": "Requirements for driving legally"
+                      },
+                      {
+                        "href": "/driving-eyesight-rules",
+                        "text": "Driving eyesight rules"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Get a provisional driving licence",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/apply-first-provisional-driving-licence",
+                        "text": "Apply for your first provisional driving licence",
+                        "context": "£34 - £43"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Driving lessons and practice",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to take lessons or practice."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/guidance/the-highway-code",
+                        "text": "The Highway Code"
+                      },
+                      {
+                        "href": "/driving-lessons-learning-to-drive",
+                        "text": "Taking driving lessons"
+                      },
+                      {
+                        "href": "/find-driving-schools-and-lessons",
+                        "text": "Find driving schools, lessons and instructors"
+                      },
+                      {
+                        "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                        "text": "Practise vehicle safety questions"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Prepare for your theory test",
+                "logic": "and",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/theory-test/revision-and-practice",
+                        "text": "Theory test revision and practice"
+                      },
+                      {
+                        "href": "/take-practice-theory-test",
+                        "text": "Take a practice theory test"
+                      },
+                      {
+                        "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                        "text": "Theory and hazard perception test app"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your theory test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to book your theory test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-theory-test",
+                        "text": "Book your theory test",
+                        "context": "£23"
+                      },
+                      {
+                        "href": "/theory-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-theory-test",
+                        "text": "Change your theory test appointment"
+                      },
+                      {
+                        "href": "/check-theory-test",
+                        "text": "Check your theory test appointment details"
+                      },
+                      {
+                        "href": "/cancel-theory-test",
+                        "text": "Cancel your theory test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your driving test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You must pass your theory test before you can book your driving test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-driving-test",
+                        "text": "Book your driving test",
+                        "context": "£62"
+                      },
+                      {
+                        "href": "/driving-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-driving-test",
+                        "text": "Change your driving test appointment"
+                      },
+                      {
+                        "href": "/check-driving-test",
+                        "text": "Check your driving test appointment details"
+                      },
+                      {
+                        "href": "/cancel-driving-test",
+                        "text": "Cancel your driving test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "When you pass",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You can start driving as soon as you pass your driving test."
+                  },
+                  {
+                    "type": "paragraph",
+                    "text": "You must have an insurance policy that allows you to drive without supervision."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/pass-plus",
+                        "text": "Find out about Pass Plus training courses"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "links": {
+          "pages_part_of_step_nav": [
+            {
+              "api_path": "/api/content/theory-test",
+              "base_path": "/theory-test",
+              "content_id": "b5d8c773-3a31-45f2-838d-255afef5511a",
+              "description": "When to book your car theory test, what to take with you, how the multiple-choice questions and hazard perception test work, and the pass mark",
+              "document_type": "guide",
+              "locale": "en",
+              "public_updated_at": "2016-12-20T13:49:20Z",
+              "schema_name": "guide",
+              "title": "Theory test: cars",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.gov.uk/api/content/theory-test",
+              "web_url": "https://www.gov.uk/theory-test"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/learn-to-drive-a-car",
+        "web_url": "https://www.gov.uk/learn-to-drive-a-car"
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "D25",
+        "api_path": "/api/content/government/organisations/hm-revenue-customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2015-05-13T10:09:06Z",
+        "schema_name": "placeholder",
+        "title": "HM Revenue & Customs",
+        "withdrawn": false,
+        "details": {
+          "brand": "hm-revenue-customs",
+          "logo": {
+            "formatted_title": "HM Revenue<br/>&amp; Customs",
+            "crest": "hmrc"
+          }
+        },
+        "links": {
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/government/organisations/hm-revenue-customs",
+        "web_url": "http://www.dev.gov.uk/government/organisations/hm-revenue-customs"
+      }
+    ],
+    "available_translations": [
+      {
+        "analytics_identifier": null,
+        "base_path": "/gwasanaethau-ar-lein-cymraeg-cthem",
+        "content_id": "bcf3e1c5-b1f9-4813-a712-e9c9dd75c1f4",
+        "description": "Gallwch ddefnyddio’r gwasanaethau canlynol gan Gyllid a Thollau Ei Mawrhydi (CThEM) ar-lein yn y Gymraeg - Hunanasesu, TAW, Treth Gorfforaeth, Talu Wrth Ennill Ar-lein i gyflogwyr, Elusennau Ar-lein, Toll Peiriannau Hapchwarae",
+        "document_type": "answer",
+        "locale": "en",
+        "public_updated_at": "2015-05-28T15:46:51Z",
+        "schema_name": "answer",
+        "title": "Gwasanaethau ar-lein Cyllid a Thollau EM yn y Gymraeg",
+        "api_path": "/api/content/gwasanaethau-ar-lein-cymraeg-cthem",
+        "withdrawn": false,
+        "api_url": "http://www.dev.gov.uk/api/content/gwasanaethau-ar-lein-cymraeg-cthem",
+        "web_url": "http://www.dev.gov.uk/gwasanaethau-ar-lein-cymraeg-cthem",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "Gallwch ddefnyddio’r gwasanaethau canlynol gan Gyllid a Thollau Ei Mawrhydi (CThEM) ar-lein yn y Gymraeg - Hunanasesu, TAW, Treth Gorfforaeth, Talu Wrth Ennill Ar-lein i gyflogwyr, Elusennau Ar-lein, Toll Peiriannau Hapchwarae",
+  "details": {
+    "body": "<p>Gallwch ddefnyddio’r gwasanaethau canlynol gan Gyllid a Thollau Ei Mawrhydi (<abbr title=\"Gyllid a Thollau Ei Mawrhydi\">CThEM</abbr>) ar-lein yn y Gymraeg:</p>\n\n<ul>\n  <li>Hunanasesiad</li>\n  <li>TAW</li>\n  <li>Treth Gorfforaeth</li>\n  <li>Talu Wrth Ennill Ar-lein i gyflogwyr</li>\n  <li>Elusennau Ar-lein</li>\n  <li>Toll Peiriannau Hapchwarae</li>\n  <li>Y Crynodeb Treth Blynyddol</li>\n  <li>Gwasanaeth Car Cwmni TWE</li>\n  <li>Gwneud Cais am Lwfans Priodasol</li>\n  <li>Gwasanaeth Talu</li>\n  <li>Gwasanaeth Cynorthwywyr y Gellir Ymddiried Ynddynt</li>\n  <li>Gwasanaeth Buddiannau drwy’r Gyflogres</li>\n  <li>Cael cyfriflen Pensiwn y Wladwriaeth</li>\n</ul>\n\n<h2 id=\"cofrestru-ar-gyfer-trethi\">Cofrestru ar gyfer trethi</h2>\n\n<p>Rhaid i chi <a rel=\"external\" href=\"https://online.hmrc.gov.uk/registration/newbusiness/introduction?lang=cym\">gofrestru ar gyfer trethi</a> cyn i chi gofrestru ar gyfer:</p>\n\n<ul>\n  <li>Treth Gorfforaeth</li>\n  <li>Hunanasesiad</li>\n  <li>TAW</li>\n  <li>Talu Wrth Ennill Ar-lein i gyflogwyr</li>\n</ul>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>Peidiwch â defnyddio acenion ar lafariaid pan fyddwch yn llenwi’r ffurflenni ar-lein.</p>\n</div>\n\n<p>Bydd <abbr title=\"Gyllid a Thollau Ei Mawrhydi\">CThEM</abbr> yn anfon y canlynol atoch:</p>\n\n<ul>\n  <li>Eich Cyfeirnod Unigryw y Trethdalwr ar gyfer Hunanasesiad neu Dreth Gorfforaeth</li>\n  <li>Rhif cofrestru ar gyfer TAW</li>\n</ul>\n\n<p>Bydd angen y rhain arnoch pan fyddwch yn cofrestru i ddefnyddio gwasanaethau ar-lein.</p>\n\n<h2 id=\"cofrestru-ar-gyfer-y-gwasanaeth\">Cofrestru ar gyfer y gwasanaeth</h2>\n\n<p>Byd angen ID Defnyddiwr a chyfrinair arnoch cyn y byddwch yn gallu mewngofnodi a defnyddio’r gwasanaeth.</p>\n\n<ol class=\"steps\">\n<li>\n<p>Ewch i <a rel=\"external\" href=\"https://online.hmrc.gov.uk/login?lang=cym\">wasanaethau ar-lein <abbr title=\"Gyllid a Thollau Ei Mawrhydi\">CThEM</abbr></a> a chlicio ‘Cofrestru’.</p>\n</li>\n<li>\n<p>Dilynwch y camau i gofrestru ar gyfer y gwasanaeth sydd ei angen arnoch.</p>\n</li>\n<li>\n<p>Byddwch yn cael ID Defnyddiwr a bydd yn rhaid i chi ddewis cyfrinair.</p>\n</li>\n</ol>\n\n<h2 id=\"dechrau-defnyddior-gwasanaeth\">Dechrau defnyddio’r gwasanaeth</h2>\n\n<p>Bydd angen cod cychwyn arnoch i ddechrau defnyddio’r holl wasanaethau hyn, ac eithrio TAW. Anfonir hwn atoch cyn pen saith diwrnod gwaith ar ôl i chi gofrestru. Os ydych chi’n byw dramor, gall gymryd hyd at 21 diwrnod i gyrraedd.</p>\n\n<p>Rhowch eich cyfrif ar waith drwy <a rel=\"external\" href=\"https://online.hmrc.gov.uk/login?lang=cym\">fewngofnodi</a> cyn pen 28 diwrnod i’r dyddiad a nodir ar y llythyr. Os na fyddwch yn gwneud hyn, bydd y cod yn dod i ben a bydd yn rhaid i chi ofyn am un newydd.</p>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>Cysylltwch â <a href=\"/government/organisations/hm-revenue-customs/contact?search%5Bname%5D=&amp;search%5Bcontact_group_id%5D=37\">llinellau cymorth Cymraeg <abbr title=\"Gyllid a Thollau Ei Mawrhydi\">CThEM</abbr></a> os oes angen help arnoch i ddefnyddio unrhyw un o’r gwasanaethau.</p>\n</div>\n\n<h2 id=\"talu-wrth-ennill-ar-lein\">Talu Wrth Ennill Ar-lein</h2>\n\n<p>Os ydych chi’n gyflogwr newydd, bydd angen i chi ddefnyddio <a href=\"/basic-paye-tools\">Offer TWE Sylfaenol</a> neu <a href=\"/payroll-software\">feddalwedd cyflogres</a> arall i gyflwyno gwybodaeth am y gyflogres i <abbr title=\"Gyllid a Thollau Ei Mawrhydi\">CThEM</abbr>.</p>\n\n<h2 id=\"negeseuon-e-bost-gwe-rwydo-a-sgamiau-treth\">Negeseuon e-bost gwe-rwydo a sgamiau treth</h2>\n\n<p>Ni fydd <abbr title=\"Gyllid a Thollau Ei Mawrhydi\">CThEM</abbr> byth yn defnyddio negeseuon testun na negeseuon e-bost i wneud y canlynol:</p>\n\n<ul>\n  <li>rhoi gwybod i chi am ddirwy neu ad-daliad treth</li>\n  <li>gofyn am wybodaeth am daliadau personol</li>\n</ul>\n\n<p>Anfonwch unrhyw negeseuon e-bost amheus at <a href=\"mailto:gwasanaeth.cymraeg@hmrc.gsi.gov.uk\">gwasanaeth.cymraeg@hmrc.gsi.gov.uk</a> neu tarwch olwg ar <a href=\"/government/publications/genuine-hmrc-contact-and-recognising-phishing-emails.cy\">arweiniad ar adnabod sgamiau</a> <abbr title=\"Gyllid a Thollau Ei Mawrhydi\">CThEM</abbr> os nad ydych chi’n siŵr.</p>\n\n",
+    "external_related_links": [
+      {
+        "url": "https://online.hmrc.gov.uk/login?lang=cym",
+        "title": "Gwasanaethau ar-lein"
+      }
+    ]
+  },
+  "publishing_request_id": "2546-1460985144476-19268198-3242"
+}

--- a/examples/guide/frontend/guide-with-step-navs.json
+++ b/examples/guide/frontend/guide-with-step-navs.json
@@ -1,0 +1,910 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/national-curriculum",
+  "content_id": "be9f6021-f60a-47d2-a184-d1c31bc6eba0",
+  "document_type": "guide",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "locale": "en",
+  "need_ids": [],
+  "phase": "live",
+  "public_updated_at": "2014-12-02T10:28:58.000+00:00",
+  "publishing_app": "publisher",
+  "rendering_app": "frontend",
+  "schema_name": "guide",
+  "title": "The national curriculum",
+  "updated_at": "2017-02-20T16:54:09.397Z",
+  "withdrawn_notice": {},
+  "links": {
+    "part_of_step_navs": [
+      {
+        "api_path": "/api/content/learn-to-drive-a-car",
+        "base_path": "/learn-to-drive-a-car",
+        "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+        "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+        "document_type": "step_by_step_nav",
+        "locale": "en",
+        "public_updated_at": "2018-03-02T11:53:13Z",
+        "schema_name": "step_by_step_nav",
+        "title": "Learn to drive a car: step by step",
+        "withdrawn": false,
+        "details": {
+          "step_by_step_nav": {
+            "title": "Learn to drive a car: step by step",
+            "introduction": [
+              {
+                "content_type": "text/govspeak",
+                "content": "Check what you need to do to learn to drive."
+              }
+            ],
+            "steps": [
+              {
+                "title": "Check you're allowed to drive",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "Most people can start learning to drive when they’re 17."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/vehicles-can-drive",
+                        "text": "Check what age you can drive"
+                      },
+                      {
+                        "href": "/legal-obligations-drivers-riders",
+                        "text": "Requirements for driving legally"
+                      },
+                      {
+                        "href": "/driving-eyesight-rules",
+                        "text": "Driving eyesight rules"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Get a provisional driving licence",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/apply-first-provisional-driving-licence",
+                        "text": "Apply for your first provisional driving licence",
+                        "context": "£34 - £43"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Driving lessons and practice",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to take lessons or practice."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/guidance/the-highway-code",
+                        "text": "The Highway Code"
+                      },
+                      {
+                        "href": "/driving-lessons-learning-to-drive",
+                        "text": "Taking driving lessons"
+                      },
+                      {
+                        "href": "/find-driving-schools-and-lessons",
+                        "text": "Find driving schools, lessons and instructors"
+                      },
+                      {
+                        "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                        "text": "Practise vehicle safety questions"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Prepare for your theory test",
+                "logic": "and",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/theory-test/revision-and-practice",
+                        "text": "Theory test revision and practice"
+                      },
+                      {
+                        "href": "/take-practice-theory-test",
+                        "text": "Take a practice theory test"
+                      },
+                      {
+                        "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                        "text": "Theory and hazard perception test app"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your theory test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to book your theory test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-theory-test",
+                        "text": "Book your theory test",
+                        "context": "£23"
+                      },
+                      {
+                        "href": "/theory-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-theory-test",
+                        "text": "Change your theory test appointment"
+                      },
+                      {
+                        "href": "/check-theory-test",
+                        "text": "Check your theory test appointment details"
+                      },
+                      {
+                        "href": "/cancel-theory-test",
+                        "text": "Cancel your theory test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your driving test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You must pass your theory test before you can book your driving test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-driving-test",
+                        "text": "Book your driving test",
+                        "context": "£62"
+                      },
+                      {
+                        "href": "/driving-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-driving-test",
+                        "text": "Change your driving test appointment"
+                      },
+                      {
+                        "href": "/check-driving-test",
+                        "text": "Check your driving test appointment details"
+                      },
+                      {
+                        "href": "/cancel-driving-test",
+                        "text": "Cancel your driving test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "When you pass",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You can start driving as soon as you pass your driving test."
+                  },
+                  {
+                    "type": "paragraph",
+                    "text": "You must have an insurance policy that allows you to drive without supervision."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/pass-plus",
+                        "text": "Find out about Pass Plus training courses"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "links": {
+          "pages_part_of_step_nav": [
+            {
+              "api_path": "/api/content/theory-test",
+              "base_path": "/theory-test",
+              "content_id": "b5d8c773-3a31-45f2-838d-255afef5511a",
+              "description": "When to book your car theory test, what to take with you, how the multiple-choice questions and hazard perception test work, and the pass mark",
+              "document_type": "guide",
+              "locale": "en",
+              "public_updated_at": "2016-12-20T13:49:20Z",
+              "schema_name": "guide",
+              "title": "Theory test: cars",
+              "withdrawn": false,
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/theory-test",
+              "web_url": "https://www.gov.uk/theory-test"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/learn-to-drive-a-car",
+        "web_url": "https://www.gov.uk/learn-to-drive-a-car"
+      }
+    ],
+    "mainstream_browse_pages": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/childcare-parenting/schools-education",
+        "base_path": "/browse/childcare-parenting/schools-education",
+        "content_id": "6e3014fa-5bd1-48b9-9aab-f7b1241afdb6",
+        "description": "Sending a child to school, financial support, dealing with the school",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-08-11T14:45:03Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Schools and education",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting/schools-education",
+        "web_url": "http://www.dev.gov.uk/browse/childcare-parenting/schools-education"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/education/school-life",
+        "base_path": "/browse/education/school-life",
+        "content_id": "99e2b248-baa4-4bf2-8a96-646fedd4d308",
+        "description": "Help with school costs, the curriculum and school attendance",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-06-24T13:56:50Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Schools and curriculum",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "http://www.dev.gov.uk/api/content/browse/education/school-life",
+        "web_url": "http://www.dev.gov.uk/browse/education/school-life"
+      }
+    ],
+    "ordered_related_items": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/apply-for-primary-school-place",
+        "base_path": "/apply-for-primary-school-place",
+        "content_id": "5867f01b-97c5-4513-84d4-aa892aab9a0f",
+        "description": "Apply for a state primary school place through your local council ",
+        "document_type": "local_transaction",
+        "locale": "en",
+        "public_updated_at": "2012-05-02T16:27:18Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Apply for a primary school place",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/education/school-admissions-transport",
+              "base_path": "/browse/education/school-admissions-transport",
+              "content_id": "61778a6b-d0e8-4b75-85a9-8ec2e333581a",
+              "description": "Applying for a school place, home schooling and travel costs",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:41Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "School admissions and transport to school",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/education",
+                    "base_path": "/browse/education",
+                    "content_id": "4ba04d39-1f8c-4117-89f5-73ec4f1b48e8",
+                    "description": "Get help if you’re at school, planning to go on to further or higher education, looking for training or interested in a student or career development loan.",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Education and learning",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/education",
+                    "web_url": "http://www.dev.gov.uk/browse/education"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/education/school-admissions-transport",
+              "web_url": "http://www.dev.gov.uk/browse/education/school-admissions-transport"
+            },
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/childcare-parenting/schools-education",
+              "base_path": "/browse/childcare-parenting/schools-education",
+              "content_id": "6e3014fa-5bd1-48b9-9aab-f7b1241afdb6",
+              "description": "Sending a child to school, financial support, dealing with the school",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-11T14:45:03Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Schools and education",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "http://www.dev.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting/schools-education",
+              "web_url": "http://www.dev.gov.uk/browse/childcare-parenting/schools-education"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/apply-for-primary-school-place",
+        "web_url": "http://www.dev.gov.uk/apply-for-primary-school-place"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/apply-for-secondary-school-place",
+        "base_path": "/apply-for-secondary-school-place",
+        "content_id": "2245ac28-2464-489f-ae20-195696fabd0c",
+        "description": "Apply for a state secondary school place through your local council",
+        "document_type": "local_transaction",
+        "locale": "en",
+        "public_updated_at": "2012-05-02T16:27:18Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Apply for a secondary school place",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/education/school-admissions-transport",
+              "base_path": "/browse/education/school-admissions-transport",
+              "content_id": "61778a6b-d0e8-4b75-85a9-8ec2e333581a",
+              "description": "Applying for a school place, home schooling and travel costs",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:41Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "School admissions and transport to school",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/education",
+                    "base_path": "/browse/education",
+                    "content_id": "4ba04d39-1f8c-4117-89f5-73ec4f1b48e8",
+                    "description": "Get help if you’re at school, planning to go on to further or higher education, looking for training or interested in a student or career development loan.",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Education and learning",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/education",
+                    "web_url": "http://www.dev.gov.uk/browse/education"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/education/school-admissions-transport",
+              "web_url": "http://www.dev.gov.uk/browse/education/school-admissions-transport"
+            },
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/childcare-parenting/schools-education",
+              "base_path": "/browse/childcare-parenting/schools-education",
+              "content_id": "6e3014fa-5bd1-48b9-9aab-f7b1241afdb6",
+              "description": "Sending a child to school, financial support, dealing with the school",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-11T14:45:03Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Schools and education",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "http://www.dev.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting/schools-education",
+              "web_url": "http://www.dev.gov.uk/browse/childcare-parenting/schools-education"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/apply-for-secondary-school-place",
+        "web_url": "http://www.dev.gov.uk/apply-for-secondary-school-place"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/home-schooling-information-council",
+        "base_path": "/home-schooling-information-council",
+        "content_id": "3ab90258-f0c5-4ea7-b3c9-09cab7619f37",
+        "description": "Your responsibilities with your local council if you want to educate your child at home - sometimes called home schooling",
+        "document_type": "local_transaction",
+        "locale": "en",
+        "public_updated_at": "2012-05-18T14:08:42Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Home education: get information from your council",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/childcare-parenting/schools-education",
+              "base_path": "/browse/childcare-parenting/schools-education",
+              "content_id": "6e3014fa-5bd1-48b9-9aab-f7b1241afdb6",
+              "description": "Sending a child to school, financial support, dealing with the school",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-11T14:45:03Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Schools and education",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "http://www.dev.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting/schools-education",
+              "web_url": "http://www.dev.gov.uk/browse/childcare-parenting/schools-education"
+            },
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/education/school-admissions-transport",
+              "base_path": "/browse/education/school-admissions-transport",
+              "content_id": "61778a6b-d0e8-4b75-85a9-8ec2e333581a",
+              "description": "Applying for a school place, home schooling and travel costs",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:41Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "School admissions and transport to school",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/education",
+                    "base_path": "/browse/education",
+                    "content_id": "4ba04d39-1f8c-4117-89f5-73ec4f1b48e8",
+                    "description": "Get help if you’re at school, planning to go on to further or higher education, looking for training or interested in a student or career development loan.",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Education and learning",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/education",
+                    "web_url": "http://www.dev.gov.uk/browse/education"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/education/school-admissions-transport",
+              "web_url": "http://www.dev.gov.uk/browse/education/school-admissions-transport"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/home-schooling-information-council",
+        "web_url": "http://www.dev.gov.uk/home-schooling-information-council"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/school-term-holiday-dates",
+        "base_path": "/school-term-holiday-dates",
+        "content_id": "8f3caf52-238a-478a-b2fd-36c43057d589",
+        "description": "Find your child's school term, half term and holiday dates on your local council's website",
+        "document_type": "local_transaction",
+        "locale": "en",
+        "public_updated_at": "2015-10-02T15:13:44Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "School term and holiday dates",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/childcare-parenting/schools-education",
+              "base_path": "/browse/childcare-parenting/schools-education",
+              "content_id": "6e3014fa-5bd1-48b9-9aab-f7b1241afdb6",
+              "description": "Sending a child to school, financial support, dealing with the school",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-11T14:45:03Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Schools and education",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "http://www.dev.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting/schools-education",
+              "web_url": "http://www.dev.gov.uk/browse/childcare-parenting/schools-education"
+            },
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/education/school-life",
+              "base_path": "/browse/education/school-life",
+              "content_id": "99e2b248-baa4-4bf2-8a96-646fedd4d308",
+              "description": "Help with school costs, the curriculum and school attendance",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:50Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Schools and curriculum",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/education",
+                    "base_path": "/browse/education",
+                    "content_id": "4ba04d39-1f8c-4117-89f5-73ec4f1b48e8",
+                    "description": "Get help if you’re at school, planning to go on to further or higher education, looking for training or interested in a student or career development loan.",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Education and learning",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/education",
+                    "web_url": "http://www.dev.gov.uk/browse/education"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/education/school-life",
+              "web_url": "http://www.dev.gov.uk/browse/education/school-life"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/school-term-holiday-dates",
+        "web_url": "http://www.dev.gov.uk/school-term-holiday-dates"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/types-of-school",
+        "base_path": "/types-of-school",
+        "content_id": "4c029b5a-7c1c-4e6b-a893-d056be112756",
+        "description": "Types of school and how they're run - community schools, academies, free schools, faith schools, state boarding schools",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2016-01-05T17:24:38Z",
+        "schema_name": "guide",
+        "title": "Types of school",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/education/school-admissions-transport",
+              "base_path": "/browse/education/school-admissions-transport",
+              "content_id": "61778a6b-d0e8-4b75-85a9-8ec2e333581a",
+              "description": "Applying for a school place, home schooling and travel costs",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:41Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "School admissions and transport to school",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/education",
+                    "base_path": "/browse/education",
+                    "content_id": "4ba04d39-1f8c-4117-89f5-73ec4f1b48e8",
+                    "description": "Get help if you’re at school, planning to go on to further or higher education, looking for training or interested in a student or career development loan.",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Education and learning",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/education",
+                    "web_url": "http://www.dev.gov.uk/browse/education"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/education/school-admissions-transport",
+              "web_url": "http://www.dev.gov.uk/browse/education/school-admissions-transport"
+            },
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/childcare-parenting/schools-education",
+              "base_path": "/browse/childcare-parenting/schools-education",
+              "content_id": "6e3014fa-5bd1-48b9-9aab-f7b1241afdb6",
+              "description": "Sending a child to school, financial support, dealing with the school",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-11T14:45:03Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Schools and education",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/childcare-parenting",
+                    "base_path": "/browse/childcare-parenting",
+                    "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+                    "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-07-15T11:40:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Childcare and parenting",
+                    "withdrawn": false,
+                    "links": {},
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting",
+                    "web_url": "http://www.dev.gov.uk/browse/childcare-parenting"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting/schools-education",
+              "web_url": "http://www.dev.gov.uk/browse/childcare-parenting/schools-education"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/types-of-school",
+        "web_url": "http://www.dev.gov.uk/types-of-school"
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "D6",
+        "api_path": "/api/content/government/organisations/department-for-education",
+        "base_path": "/government/organisations/department-for-education",
+        "content_id": "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2016-09-23T09:06:42Z",
+        "schema_name": "placeholder",
+        "title": "Department for Education",
+        "withdrawn": false,
+        "details": {
+          "brand": "department-for-education",
+          "logo": {
+            "formatted_title": "Department <br/>for Education",
+            "crest": "single-identity"
+          }
+        },
+        "links": {},
+        "api_url": "http://www.dev.gov.uk/api/content/government/organisations/department-for-education",
+        "web_url": "http://www.dev.gov.uk/government/organisations/department-for-education"
+      }
+    ],
+    "parent": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/childcare-parenting/schools-education",
+        "base_path": "/browse/childcare-parenting/schools-education",
+        "content_id": "6e3014fa-5bd1-48b9-9aab-f7b1241afdb6",
+        "description": "Sending a child to school, financial support, dealing with the school",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-08-11T14:45:03Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Schools and education",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/childcare-parenting",
+              "base_path": "/browse/childcare-parenting",
+              "content_id": "451c8029-6fe3-41cf-80e8-717debd317bd",
+              "description": "Includes giving birth, fostering, adopting, benefits for children, childcare and schools",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-07-15T11:40:43Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Childcare and parenting",
+              "withdrawn": false,
+              "links": {},
+              "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting",
+              "web_url": "http://www.dev.gov.uk/browse/childcare-parenting"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/browse/childcare-parenting/schools-education",
+        "web_url": "http://www.dev.gov.uk/browse/childcare-parenting/schools-education"
+      }
+    ],
+    "taxons": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/education/school-curriculum",
+        "base_path": "/education/school-curriculum",
+        "content_id": "7c75c541-403f-4cb1-9b34-4ddde816a80d",
+        "description": "Early years, key stages 1 to 5, GCSE and AS and A level reforms, tests, exams and assessments, PSHE and SMSC.",
+        "document_type": "taxon",
+        "locale": "en",
+        "public_updated_at": "2017-01-30T15:40:26Z",
+        "schema_name": "taxon",
+        "title": "School curriculum",
+        "withdrawn": false,
+        "details": {
+          "internal_name": "School curriculum",
+          "notes_for_editors": ""
+        },
+        "links": {
+          "parent_taxons": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/education",
+              "base_path": "/education",
+              "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+              "description": "Early years learning, schools and academies, further and higher education, skills and vocational training, student funding.",
+              "document_type": "taxon",
+              "locale": "en",
+              "public_updated_at": "2017-01-30T15:40:09Z",
+              "schema_name": "taxon",
+              "title": "Education, training and skills",
+              "withdrawn": false,
+              "details": {
+                "internal_name": "education, training and skills",
+                "notes_for_editors": ""
+              },
+              "links": {},
+              "api_url": "http://www.dev.gov.uk/api/content/education",
+              "web_url": "http://www.dev.gov.uk/education"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/education/school-curriculum",
+        "web_url": "http://www.dev.gov.uk/education/school-curriculum"
+      }
+    ],
+    "topics": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
+        "base_path": "/topic/schools-colleges-childrens-services/curriculum-qualifications",
+        "content_id": "28e39d16-c279-46c6-a7cd-b0a807686928",
+        "description": "List of information about Curriculum and qualifications.",
+        "document_type": "topic",
+        "locale": "en",
+        "public_updated_at": "2016-12-15T16:08:00Z",
+        "schema_name": "topic",
+        "title": "Curriculum and qualifications",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "http://www.dev.gov.uk/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
+        "web_url": "http://www.dev.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "The national curriculum",
+        "public_updated_at": "2014-12-02T10:28:58Z",
+        "analytics_identifier": null,
+        "document_type": "guide",
+        "schema_name": "guide",
+        "base_path": "/national-curriculum",
+        "description": "The English national curriculum means children in different schools (at primary and secondary level) study the same subjects to similar standards - it's split into key stages with tests",
+        "api_path": "/api/content/national-curriculum",
+        "withdrawn": false,
+        "content_id": "be9f6021-f60a-47d2-a184-d1c31bc6eba0",
+        "locale": "en",
+        "api_url": "http://www.dev.gov.uk/api/content/national-curriculum",
+        "web_url": "http://www.dev.gov.uk/national-curriculum",
+        "links": {}
+      }
+    ]
+  },
+  "description": "The English national curriculum means children in different schools (at primary and secondary level) study the same subjects to similar standards - it's split into key stages with tests",
+  "details": {
+    "parts": [
+      {
+        "title": "Overview",
+        "slug": "overview",
+        "body": "<p>The ‘basic’ school curriculum includes the <a href=\"/government/collections/national-curriculum\">‘national curriculum’</a>, as well as <a href=\"/national-curriculum/other-compulsory-subjects\">religious education and sex education</a>.</p>\n\n<p>The national curriculum is a set of subjects and standards used by <a href=\"/types-of-school\">primary and secondary schools</a> so children learn the same things. It covers what subjects are taught and the standards children should reach in each subject.</p>\n\n<p>Other <a href=\"/types-of-school\">types of school</a> like <a href=\"/types-of-school/academies\">academies</a> and <a href=\"/types-of-school/private-schools\">private schools</a> don’t have to follow the national curriculum. Academies must teach a broad and balanced curriculum including English, maths and science. They must also teach religious education.</p>\n\n<h2 id=\"key-stages\">Key stages</h2>\n\n<p>The national curriculum is organised into blocks of years called ‘key stages’ (KS). At the end of each key stage, the teacher will formally assess your child’s performance.</p>\n\n<table>\n  <thead>\n    <tr>\n      <th>Age</th>\n      <th>Year</th>\n      <th>Key stage</th>\n      <th>Assessment</th>\n      <th> </th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>3 to 4</td>\n      <td> </td>\n      <td><a href=\"/early-years-foundation-stage\">Early years</a></td>\n      <td> </td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>4 to 5</td>\n      <td>Reception</td>\n      <td><a href=\"/early-years-foundation-stage\">Early years</a></td>\n      <td>Teacher assessments (there’s also an optional assessment at the start of the year)</td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>5 to 6</td>\n      <td>Year 1</td>\n      <td>KS1</td>\n      <td>Phonics screening check</td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>6 to 7</td>\n      <td>Year 2</td>\n      <td>KS1</td>\n      <td>National tests and teacher assessments in English, maths and science</td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>7 to 8</td>\n      <td>Year 3</td>\n      <td>KS2</td>\n      <td> </td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>8 to 9</td>\n      <td>Year 4</td>\n      <td>KS2</td>\n      <td> </td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>9 to 10</td>\n      <td>Year 5</td>\n      <td>KS2</td>\n      <td> </td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>10 to 11</td>\n      <td>Year 6</td>\n      <td>KS2</td>\n      <td>National tests and teacher assessments in English and maths, and teacher assessments in science</td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>11 to 12</td>\n      <td>Year 7</td>\n      <td>KS3</td>\n      <td> </td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>12 to 13</td>\n      <td>Year 8</td>\n      <td>KS3</td>\n      <td> </td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>13 to 14</td>\n      <td>Year 9</td>\n      <td>KS3</td>\n      <td> </td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>14 to 15</td>\n      <td>Year 10</td>\n      <td>KS4</td>\n      <td>Some children take GCSEs</td>\n      <td> </td>\n    </tr>\n    <tr>\n      <td>15 to 16</td>\n      <td>Year 11</td>\n      <td>KS4</td>\n      <td>Most children take GCSEs or other national qualifications</td>\n      <td> </td>\n    </tr>\n  </tbody>\n</table>\n\n<h3 id=\"assessments\">Assessments</h3>\n\n<p>By the end of each summer term the school must write a report on your child’s progress and talk it through with you.</p>\n\n<p>Children who are in years 2 and 6 at the moment will take the <a href=\"/guidance/scaled-scores\">new national primary curriculum tests</a> in 2016.</p>\n"
+      },
+      {
+        "title": "Key stage 1 and 2",
+        "slug": "key-stage-1-and-2",
+        "body": "<p>Compulsory national curriculum subjects at primary school are:</p>\n\n<ul>\n  <li>English</li>\n  <li>maths</li>\n  <li>science</li>\n  <li>design and technology</li>\n  <li>history</li>\n  <li>geography</li>\n  <li>art and design</li>\n  <li>music</li>\n  <li>physical education (PE), including swimming</li>\n  <li>computing</li>\n  <li>ancient and modern foreign languages (at key stage 2)</li>\n</ul>\n\n<p>Schools must provide <a href=\"/national-curriculum/other-compulsory-subjects\">religious education (RE)</a> but parents can ask for their children to be taken out of the whole lesson or part of it.</p>\n\n<p>Schools often also teach:</p>\n\n<ul>\n  <li>personal, social and health education (PSHE)</li>\n  <li>citizenship</li>\n  <li>modern foreign languages (at key stage 1)</li>\n</ul>\n\n<h2 id=\"tests-and-assessments\">Tests and assessments</h2>\n\n<h3 id=\"year-1-phonics-screening-check\">Year 1 phonics screening check</h3>\n\n<p>The check will take place in June when your child will read 40 words out loud to a teacher. You’ll find out how your child did, and their teacher will assess whether he or she needs extra help with reading. If your child doesn’t do well enough in the check they’ll have to do it again in Year 2.</p>\n\n<h3 id=\"key-stage-1\">Key stage 1</h3>\n\n<p>Key stage 1 tests cover:</p>\n\n<ul>\n  <li>English reading</li>\n  <li>English grammar, punctuation and spelling</li>\n  <li>maths</li>\n</ul>\n\n<p>Your child will take the tests in May. You can ask the school for the test results.</p>\n\n<p>You’ll be sent the results of your child’s teacher assessments automatically.</p>\n\n<h3 id=\"key-stage-2\">Key stage 2</h3>\n\n<p>Your child will take national tests in May when they reach the end of key stage 2. These test your child’s skills in:</p>\n\n<ul>\n  <li>English reading</li>\n  <li>English grammar, punctuation and spelling</li>\n  <li>maths</li>\n</ul>\n\n<p>The tests last less than 4 hours. You’ll get the results in July.</p>\n\n<p>The school will send you the results of your child’s tests and teacher assessments.</p>\n"
+      },
+      {
+        "title": "Key stage 3 and 4",
+        "slug": "key-stage-3-and-4",
+        "body": "<h2 id=\"key-stage-3\">Key stage 3</h2>\n\n<p>Compulsory national curriculum subjects are:</p>\n\n<ul>\n  <li>English</li>\n  <li>maths</li>\n  <li>science</li>\n  <li>history</li>\n  <li>geography</li>\n  <li>modern foreign languages</li>\n  <li>design and technology</li>\n  <li>art and design</li>\n  <li>music</li>\n  <li>physical education</li>\n  <li>citizenship</li>\n  <li>computing</li>\n</ul>\n\n<p>Schools must provide <a href=\"/national-curriculum/other-compulsory-subjects\">religious education (<abbr title=\"religious education\">RE</abbr>) and sex education</a> from key stage 3 but parents can ask for their children to be taken out of the whole lesson or part of it.</p>\n\n<h2 id=\"key-stage-4\">Key stage 4</h2>\n\n<p>During key stage 4 most pupils work towards national qualifications - usually GCSEs.</p>\n\n<p>The compulsory national curriculum subjects are the ‘core’ and ‘foundation’ subjects.</p>\n\n<p>Core subjects are:</p>\n\n<ul>\n  <li>English</li>\n  <li>maths</li>\n  <li>science</li>\n</ul>\n\n<p>Foundation subjects are:</p>\n\n<ul>\n  <li>computing</li>\n  <li>physical education</li>\n  <li>citizenship</li>\n</ul>\n\n<p>Schools must also offer at least one subject from each of these areas:</p>\n\n<ul>\n  <li>arts</li>\n  <li>design and technology</li>\n  <li>humanities</li>\n  <li>modern foreign languages</li>\n</ul>\n\n<p>They must also provide <a href=\"/national-curriculum/other-compulsory-subjects\">religious education (<abbr title=\"religious education\">RE</abbr>) and sex education</a> at key stage 4.</p>\n\n<h3 id=\"english-baccalaureate-ebacc\">English Baccalaureate (<abbr title=\"English Baccalaureate\">EBacc</abbr>)</h3>\n\n<p>In performance tables, the <abbr title=\"English Baccalaureate\">EBacc</abbr> shows how many students got a GCSE grade C or above in English, maths, 2 sciences, a language, and history or geography.</p>\n\n"
+      },
+      {
+        "title": "Other compulsory subjects",
+        "slug": "other-compulsory-subjects",
+        "body": "<p>Children must also study:</p>\n\n<ul>\n  <li>sex and relationships education (year 7 onwards)</li>\n  <li>religious education (<abbr title=\"religious education\">RE</abbr>)</li>\n</ul>\n\n<p>They may not have to take exams in these subjects.</p>\n\n<h2 id=\"sex-and-relationship-education\">Sex and relationship education</h2>\n\n<p>Sex and relationship education (<abbr title=\"Sex and relationship education\">SRE</abbr>) is compulsory from age 11 onwards. It involves teaching children about reproduction, sexuality and sexual health. It doesn’t promote early sexual activity or any particular sexual orientation.</p>\n\n<p>Some parts of sex and relationship education are compulsory - these are part of the national curriculum for science. Parents can withdraw their children from all other parts of sex and relationship education if they want.</p>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>All schools must have a written policy on sex education, which they must make available to parents for free.</p>\n</div>\n\n<h2 id=\"religious-education\">Religious education</h2>\n\n<p>Schools have to teach <abbr title=\"religious education\">RE</abbr> but parents can withdraw their children for all or part of the lessons. Pupils can choose to withdraw themselves once they’re 18.</p>\n\n<p>Local councils are responsible for deciding the <abbr title=\"religious education\">RE</abbr> syllabus, but <a href=\"/types-of-school/faith-schools\">faith schools</a> and <a href=\"/types-of-school/academies\">academies</a> can set their own.</p>\n\n"
+      }
+    ],
+    "external_related_links": []
+  }
+}

--- a/examples/manual/frontend/manual-with-step-navs.json
+++ b/examples/manual/frontend/manual-with-step-navs.json
@@ -1,0 +1,327 @@
+{
+  "content_id": "9b2e22e1-a222-4cda-9799-de7ce56088b0",
+  "base_path": "/guidance/content-design",
+  "title": "Content design: planning, writing and managing content",
+  "description": "Planning and managing digital content to meet the needs the public has of government.",
+  "need_ids": [
+
+  ],
+  "locale": "en",
+  "updated_at": "2015-04-27T12:54:38.685Z",
+  "public_updated_at": "2015-04-27T12:54:27.000+00:00",
+  "details": {
+    "body": "<p>Vis nostro intellegebat at. Impedit pericula duo ne, pri nonumes ullamcorper in. Oratio invidunt et his, ele, at principes similique nam. No eam eleifend euripidis intellegat, sensibus theophrastus consectetuer.\nSumo solum quaestio has cu. Eu oblique euismod deleniti eum, congue necessitatibus ne sit.\nNo eum mutat soleat definiebas, ut argumentum efficiantur delicatissimi ius. At feugait adversarium vel. At cum mutat numquam graecis. Sit appareat adolescens constituto eu, te eleifend postulant theophrastus eam\nIf you would like to receive email updates for daily ice cream flavours, send us a hand written note.\nVel ut iudico dolore. Vix ne diam iuvaret referrentur, eam nisl accusamus temporibus ne.If you like yoga <a href=\"/lloydsfactsheet\">click here</a>.</p>\n",
+    "child_section_groups": [
+      {
+        "title": "Contents",
+        "child_sections": [
+          {
+            "title": "What is content design?",
+            "description": "Introduction to content design.",
+            "base_path": "/guidance/content-design/what-is-content-design"
+          },
+          {
+            "title": "User needs",
+            "description": "How to write and record a user need for GOV.UK.",
+            "base_path": "/guidance/content-design/user-needs"
+          },
+          {
+            "title": "Planning content",
+            "description": "Find out how to decide if something is suitable for GOV.UK, what the content lifecycle is and why accessibility must be planned for.",
+            "base_path": "/guidance/content-design/planning-content"
+          }
+        ]
+      }
+    ],
+    "change_notes": [
+      {
+        "base_path": "/guidance/content-design/what-is-content-design",
+        "title": "What is content design?",
+        "change_note": "New section added.",
+        "published_at": "2014-10-06T19:49:25Z"
+      },
+      {
+        "base_path": "/guidance/content-design/user-needs",
+        "title": "User needs",
+        "change_note": "New section added.",
+        "published_at": "2014-10-06T19:49:25Z"
+      },
+      {
+        "base_path": "/guidance/content-design/planning-content",
+        "title": "Planning content",
+        "change_note": "New section added.",
+        "published_at": "2014-10-06T19:49:25Z"
+      },
+      {
+        "base_path": "/guidance/content-design/content-types",
+        "title": "Content types",
+        "change_note": "New section added.",
+        "published_at": "2014-10-06T19:49:25Z"
+      }
+    ],
+    "organisations": [
+      {
+        "title": "Government Digital Service",
+        "abbreviation": "GDS",
+        "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
+      }
+    ]
+  },
+  "links": {
+    "part_of_step_navs": [
+      {
+        "api_path": "/api/content/learn-to-drive-a-car",
+        "base_path": "/learn-to-drive-a-car",
+        "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+        "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+        "document_type": "step_by_step_nav",
+        "locale": "en",
+        "public_updated_at": "2018-03-02T11:53:13Z",
+        "schema_name": "step_by_step_nav",
+        "title": "Learn to drive a car: step by step",
+        "withdrawn": false,
+        "details": {
+          "step_by_step_nav": {
+            "title": "Learn to drive a car: step by step",
+            "introduction": [
+              {
+                "content_type": "text/govspeak",
+                "content": "Check what you need to do to learn to drive."
+              }
+            ],
+            "steps": [
+              {
+                "title": "Check you're allowed to drive",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "Most people can start learning to drive when they’re 17."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/vehicles-can-drive",
+                        "text": "Check what age you can drive"
+                      },
+                      {
+                        "href": "/legal-obligations-drivers-riders",
+                        "text": "Requirements for driving legally"
+                      },
+                      {
+                        "href": "/driving-eyesight-rules",
+                        "text": "Driving eyesight rules"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Get a provisional driving licence",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/apply-first-provisional-driving-licence",
+                        "text": "Apply for your first provisional driving licence",
+                        "context": "£34 - £43"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Driving lessons and practice",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to take lessons or practice."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/guidance/the-highway-code",
+                        "text": "The Highway Code"
+                      },
+                      {
+                        "href": "/driving-lessons-learning-to-drive",
+                        "text": "Taking driving lessons"
+                      },
+                      {
+                        "href": "/find-driving-schools-and-lessons",
+                        "text": "Find driving schools, lessons and instructors"
+                      },
+                      {
+                        "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                        "text": "Practise vehicle safety questions"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Prepare for your theory test",
+                "logic": "and",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/theory-test/revision-and-practice",
+                        "text": "Theory test revision and practice"
+                      },
+                      {
+                        "href": "/take-practice-theory-test",
+                        "text": "Take a practice theory test"
+                      },
+                      {
+                        "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                        "text": "Theory and hazard perception test app"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your theory test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to book your theory test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-theory-test",
+                        "text": "Book your theory test",
+                        "context": "£23"
+                      },
+                      {
+                        "href": "/theory-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-theory-test",
+                        "text": "Change your theory test appointment"
+                      },
+                      {
+                        "href": "/check-theory-test",
+                        "text": "Check your theory test appointment details"
+                      },
+                      {
+                        "href": "/cancel-theory-test",
+                        "text": "Cancel your theory test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your driving test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You must pass your theory test before you can book your driving test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-driving-test",
+                        "text": "Book your driving test",
+                        "context": "£62"
+                      },
+                      {
+                        "href": "/driving-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-driving-test",
+                        "text": "Change your driving test appointment"
+                      },
+                      {
+                        "href": "/check-driving-test",
+                        "text": "Check your driving test appointment details"
+                      },
+                      {
+                        "href": "/cancel-driving-test",
+                        "text": "Cancel your driving test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "When you pass",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You can start driving as soon as you pass your driving test."
+                  },
+                  {
+                    "type": "paragraph",
+                    "text": "You must have an insurance policy that allows you to drive without supervision."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/pass-plus",
+                        "text": "Find out about Pass Plus training courses"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "links": {
+          "pages_part_of_step_nav": [
+            {
+              "api_path": "/api/content/theory-test",
+              "base_path": "/theory-test",
+              "content_id": "b5d8c773-3a31-45f2-838d-255afef5511a",
+              "description": "When to book your car theory test, what to take with you, how the multiple-choice questions and hazard perception test work, and the pass mark",
+              "document_type": "guide",
+              "locale": "en",
+              "public_updated_at": "2016-12-20T13:49:20Z",
+              "schema_name": "guide",
+              "title": "Theory test: cars",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.gov.uk/api/content/theory-test",
+              "web_url": "https://www.gov.uk/theory-test"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/learn-to-drive-a-car",
+        "web_url": "https://www.gov.uk/learn-to-drive-a-car"
+      }
+    ],
+    "available_translations": [
+      {
+        "content_id": "9b2e22e1-a222-4cda-9799-de7ce56088b0",
+        "title": "Content design: planning, writing and managing content",
+        "api_path": "/api/content/guidance/content-design",
+        "base_path": "/guidance/content-design",
+        "api_url": "https://www.gov.uk/api/content/guidance/content-design",
+        "web_url": "https://www.gov.uk/guidance/content-design",
+        "locale": "en"
+      }
+    ]
+  },
+  "schema_name": "manual",
+  "document_type": "manual"
+}

--- a/examples/simple_smart_answer/frontend/simple-smart-answer-with-step-navs.json
+++ b/examples/simple_smart_answer/frontend/simple-smart-answer-with-step-navs.json
@@ -1,0 +1,684 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/become-a-driving-instructor",
+  "content_id": "bc1c2f06-8601-452b-8f18-37520ba7d1f8",
+  "document_type": "simple_smart_answer",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "locale": "en",
+  "need_ids": [
+
+  ],
+  "phase": "live",
+  "public_updated_at": "2017-02-22T13:50:49.000+00:00",
+  "publishing_app": "publisher",
+  "rendering_app": "frontend",
+  "schema_name": "simple_smart_answer",
+  "title": "Become a driving instructor",
+  "updated_at": "2017-02-23T10:35:08.669Z",
+  "withdrawn_notice": {
+  },
+  "links": {
+    "part_of_step_navs": [
+      {
+        "api_path": "/api/content/learn-to-drive-a-car",
+        "base_path": "/learn-to-drive-a-car",
+        "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+        "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+        "document_type": "step_by_step_nav",
+        "locale": "en",
+        "public_updated_at": "2018-03-02T11:53:13Z",
+        "schema_name": "step_by_step_nav",
+        "title": "Learn to drive a car: step by step",
+        "withdrawn": false,
+        "details": {
+          "step_by_step_nav": {
+            "title": "Learn to drive a car: step by step",
+            "introduction": [
+              {
+                "content_type": "text/govspeak",
+                "content": "Check what you need to do to learn to drive."
+              }
+            ],
+            "steps": [
+              {
+                "title": "Check you're allowed to drive",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "Most people can start learning to drive when they’re 17."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/vehicles-can-drive",
+                        "text": "Check what age you can drive"
+                      },
+                      {
+                        "href": "/legal-obligations-drivers-riders",
+                        "text": "Requirements for driving legally"
+                      },
+                      {
+                        "href": "/driving-eyesight-rules",
+                        "text": "Driving eyesight rules"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Get a provisional driving licence",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/apply-first-provisional-driving-licence",
+                        "text": "Apply for your first provisional driving licence",
+                        "context": "£34 - £43"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Driving lessons and practice",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to take lessons or practice."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/guidance/the-highway-code",
+                        "text": "The Highway Code"
+                      },
+                      {
+                        "href": "/driving-lessons-learning-to-drive",
+                        "text": "Taking driving lessons"
+                      },
+                      {
+                        "href": "/find-driving-schools-and-lessons",
+                        "text": "Find driving schools, lessons and instructors"
+                      },
+                      {
+                        "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                        "text": "Practise vehicle safety questions"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Prepare for your theory test",
+                "logic": "and",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/theory-test/revision-and-practice",
+                        "text": "Theory test revision and practice"
+                      },
+                      {
+                        "href": "/take-practice-theory-test",
+                        "text": "Take a practice theory test"
+                      },
+                      {
+                        "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                        "text": "Theory and hazard perception test app"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your theory test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to book your theory test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-theory-test",
+                        "text": "Book your theory test",
+                        "context": "£23"
+                      },
+                      {
+                        "href": "/theory-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-theory-test",
+                        "text": "Change your theory test appointment"
+                      },
+                      {
+                        "href": "/check-theory-test",
+                        "text": "Check your theory test appointment details"
+                      },
+                      {
+                        "href": "/cancel-theory-test",
+                        "text": "Cancel your theory test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your driving test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You must pass your theory test before you can book your driving test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-driving-test",
+                        "text": "Book your driving test",
+                        "context": "£62"
+                      },
+                      {
+                        "href": "/driving-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-driving-test",
+                        "text": "Change your driving test appointment"
+                      },
+                      {
+                        "href": "/check-driving-test",
+                        "text": "Check your driving test appointment details"
+                      },
+                      {
+                        "href": "/cancel-driving-test",
+                        "text": "Cancel your driving test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "When you pass",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You can start driving as soon as you pass your driving test."
+                  },
+                  {
+                    "type": "paragraph",
+                    "text": "You must have an insurance policy that allows you to drive without supervision."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/pass-plus",
+                        "text": "Find out about Pass Plus training courses"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "links": {
+          "pages_part_of_step_nav": [
+            {
+              "api_path": "/api/content/theory-test",
+              "base_path": "/theory-test",
+              "content_id": "b5d8c773-3a31-45f2-838d-255afef5511a",
+              "description": "When to book your car theory test, what to take with you, how the multiple-choice questions and hazard perception test work, and the pass mark",
+              "document_type": "guide",
+              "locale": "en",
+              "public_updated_at": "2016-12-20T13:49:20Z",
+              "schema_name": "guide",
+              "title": "Theory test: cars",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.gov.uk/api/content/theory-test",
+              "web_url": "https://www.gov.uk/theory-test"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/learn-to-drive-a-car",
+        "web_url": "https://www.gov.uk/learn-to-drive-a-car"
+      }
+    ],
+    "mainstream_browse_pages": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/driving/teaching-people-to-drive",
+        "base_path": "/browse/driving/teaching-people-to-drive",
+        "content_id": "ae54d8dc-0d05-4b30-8d56-30b5d65b43d6",
+        "description": "",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2016-12-21T23:58:27Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Teaching people to drive",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/browse/driving/teaching-people-to-drive",
+        "web_url": "http://www.dev.gov.uk/browse/driving/teaching-people-to-drive"
+      }
+    ],
+    "ordered_related_items": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/apply-to-become-a-driving-instructor",
+        "base_path": "/apply-to-become-a-driving-instructor",
+        "content_id": "ae837bea-d848-4e84-86a3-6122457b7b1d",
+        "description": "Apply to start qualifying as an approved driving instructor (ADI) with the Driver and Vehicle Standards Agency (DVSA)",
+        "document_type": "transaction",
+        "locale": "en",
+        "public_updated_at": "2014-11-26T12:54:52Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Apply to become a driving instructor",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/driving/teaching-people-to-drive",
+              "base_path": "/browse/driving/teaching-people-to-drive",
+              "content_id": "ae54d8dc-0d05-4b30-8d56-30b5d65b43d6",
+              "description": "",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2016-12-21T23:58:27Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Teaching people to drive",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/driving",
+                    "base_path": "/browse/driving",
+                    "content_id": "03531ffd-314b-4fed-9361-fa9816005c31",
+                    "description": "Apply for a driving licence, tax your vehicle, book your driving test, and find out the legal requirements for buying, owning, importing or scrapping a car or motorcycle, and read about your rights and responsibilities as a driver",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2016-10-07T22:18:32Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Driving and transport",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/driving",
+                    "web_url": "http://www.dev.gov.uk/browse/driving"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/driving/teaching-people-to-drive",
+              "web_url": "http://www.dev.gov.uk/browse/driving/teaching-people-to-drive"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/apply-to-become-a-driving-instructor",
+        "web_url": "http://www.dev.gov.uk/apply-to-become-a-driving-instructor"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/approved-driving-instructor-adi-fees",
+        "base_path": "/approved-driving-instructor-adi-fees",
+        "content_id": "12774fd5-4984-4c4e-8588-74505de040ea",
+        "description": "Fees for taking the approved driving instructor (ADI) qualifying tests, and registering as an ADI with the Driver and Vehicle Standards Agency (DVSA)",
+        "document_type": "answer",
+        "locale": "en",
+        "public_updated_at": "2014-11-26T12:53:30Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Approved driving instructor (ADI) fees",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/driving/teaching-people-to-drive",
+              "base_path": "/browse/driving/teaching-people-to-drive",
+              "content_id": "ae54d8dc-0d05-4b30-8d56-30b5d65b43d6",
+              "description": "",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2016-12-21T23:58:27Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Teaching people to drive",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/driving",
+                    "base_path": "/browse/driving",
+                    "content_id": "03531ffd-314b-4fed-9361-fa9816005c31",
+                    "description": "Apply for a driving licence, tax your vehicle, book your driving test, and find out the legal requirements for buying, owning, importing or scrapping a car or motorcycle, and read about your rights and responsibilities as a driver",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2016-10-07T22:18:32Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Driving and transport",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/driving",
+                    "web_url": "http://www.dev.gov.uk/browse/driving"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/driving/teaching-people-to-drive",
+              "web_url": "http://www.dev.gov.uk/browse/driving/teaching-people-to-drive"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/approved-driving-instructor-adi-fees",
+        "web_url": "http://www.dev.gov.uk/approved-driving-instructor-adi-fees"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/manage-approved-driving-instructor-registration",
+        "base_path": "/manage-approved-driving-instructor-registration",
+        "content_id": "e189f4b6-39e8-4805-8a77-2c4c6ad2d58c",
+        "description": "Display, renew (including criminal records check), cancel, keep up to date and report lost or stolen approved driving instruction certificates (ADI)",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2014-11-24T18:11:44Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Manage your approved driving instructor (ADI) registration",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/driving/teaching-people-to-drive",
+              "base_path": "/browse/driving/teaching-people-to-drive",
+              "content_id": "ae54d8dc-0d05-4b30-8d56-30b5d65b43d6",
+              "description": "",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2016-12-21T23:58:27Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Teaching people to drive",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/driving",
+                    "base_path": "/browse/driving",
+                    "content_id": "03531ffd-314b-4fed-9361-fa9816005c31",
+                    "description": "Apply for a driving licence, tax your vehicle, book your driving test, and find out the legal requirements for buying, owning, importing or scrapping a car or motorcycle, and read about your rights and responsibilities as a driver",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2016-10-07T22:18:32Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Driving and transport",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/driving",
+                    "web_url": "http://www.dev.gov.uk/browse/driving"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/driving/teaching-people-to-drive",
+              "web_url": "http://www.dev.gov.uk/browse/driving/teaching-people-to-drive"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/manage-approved-driving-instructor-registration",
+        "web_url": "http://www.dev.gov.uk/manage-approved-driving-instructor-registration"
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "EA570",
+        "api_path": "/api/content/government/organisations/driver-and-vehicle-standards-agency",
+        "base_path": "/government/organisations/driver-and-vehicle-standards-agency",
+        "content_id": "d39237a5-678b-4bb5-a372-eb2cb036933d",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2016-11-18T12:50:04Z",
+        "schema_name": "placeholder",
+        "title": "Driver and Vehicle Standards Agency",
+        "withdrawn": false,
+        "details": {
+          "brand": "department-for-transport",
+          "logo": {
+            "formatted_title": "Driver &amp; Vehicle<br/>Standards<br/>Agency",
+            "crest": "single-identity"
+          }
+        },
+        "links": {
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/government/organisations/driver-and-vehicle-standards-agency",
+        "web_url": "http://www.dev.gov.uk/government/organisations/driver-and-vehicle-standards-agency"
+      }
+    ],
+    "parent": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/driving/teaching-people-to-drive",
+        "base_path": "/browse/driving/teaching-people-to-drive",
+        "content_id": "ae54d8dc-0d05-4b30-8d56-30b5d65b43d6",
+        "description": "",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2016-12-21T23:58:27Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Teaching people to drive",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/driving",
+              "base_path": "/browse/driving",
+              "content_id": "03531ffd-314b-4fed-9361-fa9816005c31",
+              "description": "Apply for a driving licence, tax your vehicle, book your driving test, and find out the legal requirements for buying, owning, importing or scrapping a car or motorcycle, and read about your rights and responsibilities as a driver",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2016-10-07T22:18:32Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Driving and transport",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/driving",
+              "web_url": "http://www.dev.gov.uk/browse/driving"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/browse/driving/teaching-people-to-drive",
+        "web_url": "http://www.dev.gov.uk/browse/driving/teaching-people-to-drive"
+      }
+    ],
+    "topics": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/topic/driving-motorcyle-instructors/approved-driving-instructors",
+        "base_path": "/topic/driving-motorcyle-instructors/approved-driving-instructors",
+        "content_id": "bb85c76f-b660-4426-a1c3-37313a2cea81",
+        "description": "Services and information for approved driving instructors (ADIs), including qualifying and managing your registration.",
+        "document_type": "topic",
+        "locale": "en",
+        "public_updated_at": "2016-09-30T15:13:23Z",
+        "schema_name": "topic",
+        "title": "Approved driving instructors (ADIs)",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/topic/driving-motorcyle-instructors/approved-driving-instructors",
+        "web_url": "http://www.dev.gov.uk/topic/driving-motorcyle-instructors/approved-driving-instructors"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Become a driving instructor",
+        "public_updated_at": "2017-02-22T13:50:49Z",
+        "analytics_identifier": null,
+        "document_type": "simple_smart_answer",
+        "schema_name": "simple_smart_answer",
+        "base_path": "/become-a-driving-instructor",
+        "description": "Find out if you can become an approved driving instructor (ADI) and what you need to do to qualify",
+        "api_path": "/api/content/become-a-driving-instructor",
+        "withdrawn": false,
+        "content_id": "bc1c2f06-8601-452b-8f18-37520ba7d1f8",
+        "locale": "en",
+        "api_url": "http://www.dev.gov.uk/api/content/become-a-driving-instructor",
+        "web_url": "http://www.dev.gov.uk/become-a-driving-instructor",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "Find out if you can become an approved driving instructor (ADI) and what you need to do to qualify",
+  "details": {
+    "start_button_text": "Start now",
+    "body": "<p>Find out if you can become an approved driving instructor (<abbr title=\"approved driving instructor\">ADI</abbr>) in Great Britain and what you need to do to qualify.</p>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>There’s a different process in <a rel=\"external\" href=\"http://www.nidirect.gov.uk/index/information-and-services/motoring/driving-for-a-living/driving-instructors/how-to-become-an-approved-driving-instructor-adi.htm\">Northern Ireland.</a></p>\n</div>\n\n",
+    "nodes": [
+      {
+        "kind": "question",
+        "slug": "question-1",
+        "title": "Are you already registered as a driving instructor in another EU country?",
+        "options": [
+          {
+            "label": "Yes",
+            "slug": "yes",
+            "next_node": "outcome-1"
+          },
+          {
+            "label": "No",
+            "slug": "no",
+            "next_node": "question-2"
+          }
+        ]
+      },
+      {
+        "kind": "question",
+        "slug": "question-2",
+        "title": "How old are you?",
+        "options": [
+          {
+            "label": "21 or over",
+            "slug": "21-or-over",
+            "next_node": "question-3"
+          },
+          {
+            "label": "20 or under",
+            "slug": "20-or-under",
+            "next_node": "outcome-2"
+          }
+        ]
+      },
+      {
+        "kind": "question",
+        "slug": "question-3",
+        "title": "Have you had a full car driving licence for at least 3 years?",
+        "options": [
+          {
+            "label": "Yes",
+            "slug": "yes",
+            "next_node": "question-4"
+          },
+          {
+            "label": "No",
+            "slug": "no",
+            "next_node": "outcome-3"
+          }
+        ]
+      },
+      {
+        "kind": "question",
+        "slug": "question-4",
+        "title": "What type of car is your driving licence for?",
+        "options": [
+          {
+            "label": "Manual",
+            "slug": "manual",
+            "next_node": "outcome-4"
+          },
+          {
+            "label": "Automatic",
+            "slug": "automatic",
+            "next_node": "outcome-5"
+          }
+        ]
+      },
+      {
+        "kind": "outcome",
+        "slug": "outcome-1",
+        "title": "You can apply to transfer your driving instructor registration to Great Britain",
+        "options": [
+
+        ],
+        "body": "<ol class=\"steps\">\n<li>\n<p>Apply to register your non-GB driving licence if you got yours in another <a href=\"/eu-eea\"><abbr title=\"European Union\">EU</abbr> country</a>.</p>\n</li>\n<li>\n<p>Apply to the Driver and Vehicle Standards Agency (<abbr title=\"Driver and Vehicle Standards Agency\">DVSA</abbr>) to transfer your instructor registration.</p>\n</li>\n</ol>\n\n<h2 id=\"register-your-non-gb-driving-licence\">Register your non-GB driving licence</h2>\n\n<p>Download and fill in <a href=\"/government/publications/d9-application-to-register-a-non-gb-driving-licence\">D9 - Application to register a non-GB driving licence</a> and send it to <abbr title=\"Driver and Vehicle Licensing Agency\">DVLA</abbr>.</p>\n\n<div class=\"address\"><div class=\"adr org fn\"><p>\n\n<abbr title=\"Driver and Vehicle Licensing Agency\">DVLA</abbr>\n<br>Swansea\n<br>SA99 1BH\n<br>\n</p></div></div>\n\n<h2 id=\"transfer-your-registration\">Transfer your registration</h2>\n\n<p>When you’ve registered your non-GB licence you can <a href=\"/transfer-driving-instructor-registration-gb\">transfer your driving instructor registration to Great Britain</a>.</p>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>You must read <a href=\"/guide-to-the-approved-driving-instructor-register\"><abbr title=\"Driver and Vehicle Standards Agency\">DVSA</abbr>’s guide to the <abbr title=\"approved driving instructor\">ADI</abbr> register</a>.</p>\n</div>\n\n"
+      },
+      {
+        "kind": "outcome",
+        "slug": "outcome-2",
+        "title": "You can’t become an approved driving instructor (ADI) until you're 21",
+        "options": [
+
+        ],
+        "body": "<p>You have to be 21 or older to supervise a learner driver.</p>\n\n<p>You can usually apply to start the qualifying process 6 months before your 21st birthday. This is because it will take at least 6 months to qualify as an <abbr title=\"approved driving instructor\">ADI</abbr>.</p>\n\n<div role=\"note\" aria-label=\"Help\" class=\"application-notice help-notice\">\n<p>It’s against the law for you to charge a fee to teach someone to drive if you’re not an <abbr title=\"approved driving instructor\">ADI</abbr>.</p>\n</div>\n\n"
+      },
+      {
+        "kind": "outcome",
+        "slug": "outcome-3",
+        "title": "You can’t become an approved driving instructor (ADI) until you've had a full licence for 3 years or more",
+        "options": [
+
+        ],
+        "body": "<p>You have to have had your full licence for at least 3 years to supervise a learner driver.</p>\n\n<p>You can usually apply to start the qualifying process 6 months before the 3rd anniversary of getting your full licence. This is because it will take at least 6 months to qualify as an <abbr title=\"approved driving instructor\">ADI</abbr>.</p>\n\n<div role=\"note\" aria-label=\"Help\" class=\"application-notice help-notice\">\n<p>It’s against the law for you to charge a fee to teach someone to drive if you’re not an <abbr title=\"approved driving instructor\">ADI</abbr>.</p>\n</div>\n\n"
+      },
+      {
+        "kind": "outcome",
+        "slug": "outcome-4",
+        "title": "You can start applying to become an approved driving instructor (ADI)",
+        "options": [
+
+        ],
+        "body": "<ol class=\"steps\">\n<li>\n<p><a href=\"/criminal-record-check-become-driving-instructor\">Get a criminal record check to become an <abbr title=\"approved driving instructor\">ADI</abbr></a>.</p>\n</li>\n<li>\n<p>Read the <a href=\"/guidance/guide-to-the-approved-driving-instructor-register\">guide to the <abbr title=\"approved driving instructor\">ADI</abbr> register</a>.</p>\n</li>\n<li>\n<p><a href=\"/apply-to-become-a-driving-instructor\">Apply to start the <abbr title=\"approved driving instructor\">ADI</abbr> qualifying process</a>.</p>\n</li>\n<li>\n<p>Take <a href=\"/driving-instructor-training\">training to qualify as an <abbr title=\"approved driving instructor\">ADI</abbr></a>.</p>\n</li>\n<li>\n<p>Take and pass the 3 <abbr title=\"approved driving instructor\">ADI</abbr> qualifying tests.</p>\n</li>\n<li>\n<p>Apply for your first <abbr title=\"approved driving instructor\">ADI</abbr> badge.</p>\n</li>\n</ol>\n\n<h2 id=\"motoring-offences-and-other-convictions\">Motoring offences and other convictions</h2>\n\n<p>Your application can be refused if you have:</p>\n\n<ul>\n  <li>been banned from driving</li>\n  <li>6 or more penalty points</li>\n  <li>been convicted of any non-motoring offences</li>\n</ul>\n\n<p>The <abbr title=\"approved driving instructor\">ADI</abbr> Registrar will consider whether or not you’re <a href=\"/government/publications/suitability-of-ex-offenders-to-become-or-remain-a-driving-instructor\">suitable to become a driving instructor</a>.</p>\n\n<p>Your application is unlikely to be accepted if you’ve been:</p>\n\n<ul>\n  <li>convicted of a sexual, violent, financial or drug-related crime</li>\n  <li>banned from working with children</li>\n</ul>\n\n"
+      },
+      {
+        "kind": "outcome",
+        "slug": "outcome-5",
+        "title": "You can start applying to become an approved driving instructor (ADI)",
+        "options": [
+
+        ],
+        "body": "<ol class=\"steps\">\n<li>\n<p><a href=\"/criminal-record-check-become-driving-instructor\">Get a criminal record check to become an <abbr title=\"approved driving instructor\">ADI</abbr></a>.</p>\n</li>\n<li>\n<p>Read the <a href=\"/guidance/guide-to-the-approved-driving-instructor-register\">guide to the <abbr title=\"approved driving instructor\">ADI</abbr> register</a>.</p>\n</li>\n<li>\n<p><a href=\"/apply-to-become-a-driving-instructor\">Apply to start the <abbr title=\"approved driving instructor\">ADI</abbr> qualifying process</a>.</p>\n</li>\n<li>\n<p>Take <a href=\"/driving-instructor-training\">training to qualify as an <abbr title=\"approved driving instructor\">ADI</abbr></a>.</p>\n</li>\n<li>\n<p>Take and pass the 3 <abbr title=\"approved driving instructor\">ADI</abbr> qualifying tests.</p>\n</li>\n<li>\n<p>Apply for your first <abbr title=\"approved driving instructor\">ADI</abbr> badge.</p>\n</li>\n</ol>\n\n<h2 id=\"teaching-in-an-automatic-car\">Teaching in an automatic car</h2>\n\n<div role=\"note\" aria-label=\"Help\" class=\"application-notice help-notice\">\n<p>You must only teach people to drive in an automatic car.</p>\n</div>\n\n<h3 id=\"if-you-want-to-teach-in-a-manual-car\">If you want to teach in a manual car</h3>\n<p>You must pass the <a href=\"/practical-driving-test-for-cars\">car driving test</a> in a manual car and then wait 3 years.</p>\n\n<h3 id=\"automatic-licence-because-you-have-a-disability\">Automatic licence because you have a disability</h3>\n<p>You might need to take an extra assessment if you’ve got an automatic licence because you have a disability. This is to prove that you can keep control of your car in an emergency. The Driver and Vehicle Standards Agency (<abbr title=\"Driver and Vehicle Standards Agency\">DVSA</abbr>) will tell you if you need to do this.</p>\n\n<h2 id=\"motoring-offences-and-other-convictions\">Motoring offences and other convictions</h2>\n\n<p>Your application can be refused if you have:</p>\n\n<ul>\n  <li>been banned from driving</li>\n  <li>6 or more penalty points</li>\n  <li>been convicted of any non-motoring offences</li>\n</ul>\n\n<p>The <abbr title=\"approved driving instructor\">ADI</abbr> Registrar will consider whether or not you’re <a href=\"/government/publications/suitability-of-ex-offenders-to-become-or-remain-a-driving-instructor\">suitable to become a driving instructor</a>.</p>\n\n<p>Your application is unlikely to be accepted if you’ve been:</p>\n\n<ul>\n  <li>convicted of a sexual, violent, financial or drug-related crime</li>\n  <li>banned from working with children</li>\n</ul>\n\n"
+      },
+      {
+        "kind": "outcome",
+        "slug": "outcome-6",
+        "title": "You can start applying to become an approved driving instructor (ADI)",
+        "options": [
+
+        ],
+        "body": "<ol class=\"steps\">\n<li>\n<p>Get a criminal record check for driving instructors.</p>\n</li>\n<li>\n<p>Apply to the Driver and Vehicle Standards Agency (<abbr title=\"Driver and Vehicle Standards Agency\">DVSA</abbr>) to start the qualifying process.</p>\n</li>\n<li>\n<p>Take and pass the 3 <abbr title=\"approved driving instructor\">ADI</abbr> qualifying tests.</p>\n</li>\n<li>\n<p>Apply for your first <abbr title=\"approved driving instructor\">ADI</abbr> badge.</p>\n</li>\n</ol>\n\n<h2 id=\"criminal-record-check\">Criminal record check</h2>\n\n<p>You need to <a href=\"/criminal-record-check-become-driving-instructor\">get a criminal record check to become a driving instructor</a>. You can’t use any other type of criminal record check.</p>\n\n<h2 id=\"apply-to-dvsa\">Apply to <abbr title=\"Driver and Vehicle Standards Agency\">DVSA</abbr>\n</h2>\n\n<p>When you have your criminal record disclosure, you can <a href=\"/apply-to-become-a-driving-instructor\">apply to become an <abbr title=\"approved driving instructor\">ADI</abbr></a>.</p>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>You must read <a href=\"/guide-to-the-approved-driving-instructor-register\"><abbr title=\"Driver and Vehicle Standards Agency\">DVSA</abbr>’s guide to the <abbr title=\"approved driving instructor\">ADI</abbr> register</a>.</p>\n</div>\n\n"
+      }
+    ],
+    "external_related_links": [
+
+    ]
+  }
+}

--- a/examples/transaction/frontend/transaction-with-step-navs.json
+++ b/examples/transaction/frontend/transaction-with-step-navs.json
@@ -1,0 +1,826 @@
+{
+  "details": {
+    "external_related_links": [
+
+    ],
+    "more_information": "<p>Search for homes in Scotland on the <a rel=\"external\" href=\"http://www.saa.gov.uk\">Scottish Assessors</a> website.</p>\n\n",
+    "transaction_start_link": "http://cti.voa.gov.uk/cti/inits.asp",
+    "will_continue_on": "the Council Tax valuation list",
+    "introductory_paragraph": "<p>Find out the Council Tax band for a home in England or Wales by looking up its postcode.</p>\n",
+    "department_analytics_profile": "UA-12345-6"
+  },
+  "description": "Find out the Council Tax band for a property in England, Scotland or Wales by looking up the property's postcode online",
+  "links": {
+    "part_of_step_navs": [
+      {
+        "api_path": "/api/content/learn-to-drive-a-car",
+        "base_path": "/learn-to-drive-a-car",
+        "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+        "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+        "document_type": "step_by_step_nav",
+        "locale": "en",
+        "public_updated_at": "2018-03-02T11:53:13Z",
+        "schema_name": "step_by_step_nav",
+        "title": "Learn to drive a car: step by step",
+        "withdrawn": false,
+        "details": {
+          "step_by_step_nav": {
+            "title": "Learn to drive a car: step by step",
+            "introduction": [
+              {
+                "content_type": "text/govspeak",
+                "content": "Check what you need to do to learn to drive."
+              }
+            ],
+            "steps": [
+              {
+                "title": "Check you're allowed to drive",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "Most people can start learning to drive when they’re 17."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/vehicles-can-drive",
+                        "text": "Check what age you can drive"
+                      },
+                      {
+                        "href": "/legal-obligations-drivers-riders",
+                        "text": "Requirements for driving legally"
+                      },
+                      {
+                        "href": "/driving-eyesight-rules",
+                        "text": "Driving eyesight rules"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Get a provisional driving licence",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/apply-first-provisional-driving-licence",
+                        "text": "Apply for your first provisional driving licence",
+                        "context": "£34 - £43"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Driving lessons and practice",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to take lessons or practice."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/guidance/the-highway-code",
+                        "text": "The Highway Code"
+                      },
+                      {
+                        "href": "/driving-lessons-learning-to-drive",
+                        "text": "Taking driving lessons"
+                      },
+                      {
+                        "href": "/find-driving-schools-and-lessons",
+                        "text": "Find driving schools, lessons and instructors"
+                      },
+                      {
+                        "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                        "text": "Practise vehicle safety questions"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Prepare for your theory test",
+                "logic": "and",
+                "contents": [
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/theory-test/revision-and-practice",
+                        "text": "Theory test revision and practice"
+                      },
+                      {
+                        "href": "/take-practice-theory-test",
+                        "text": "Take a practice theory test"
+                      },
+                      {
+                        "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                        "text": "Theory and hazard perception test app"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your theory test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You need a provisional driving licence to book your theory test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-theory-test",
+                        "text": "Book your theory test",
+                        "context": "£23"
+                      },
+                      {
+                        "href": "/theory-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-theory-test",
+                        "text": "Change your theory test appointment"
+                      },
+                      {
+                        "href": "/check-theory-test",
+                        "text": "Check your theory test appointment details"
+                      },
+                      {
+                        "href": "/cancel-theory-test",
+                        "text": "Cancel your theory test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "Book and manage your driving test",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You must pass your theory test before you can book your driving test."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/book-driving-test",
+                        "text": "Book your driving test",
+                        "context": "£62"
+                      },
+                      {
+                        "href": "/driving-test/what-to-take",
+                        "text": "What to take to your test"
+                      },
+                      {
+                        "href": "/change-driving-test",
+                        "text": "Change your driving test appointment"
+                      },
+                      {
+                        "href": "/check-driving-test",
+                        "text": "Check your driving test appointment details"
+                      },
+                      {
+                        "href": "/cancel-driving-test",
+                        "text": "Cancel your driving test"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "title": "When you pass",
+                "contents": [
+                  {
+                    "type": "paragraph",
+                    "text": "You can start driving as soon as you pass your driving test."
+                  },
+                  {
+                    "type": "paragraph",
+                    "text": "You must have an insurance policy that allows you to drive without supervision."
+                  },
+                  {
+                    "type": "list",
+                    "style": "required",
+                    "contents": [
+                      {
+                        "href": "/pass-plus",
+                        "text": "Find out about Pass Plus training courses"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "links": {
+          "pages_part_of_step_nav": [
+            {
+              "api_path": "/api/content/theory-test",
+              "base_path": "/theory-test",
+              "content_id": "b5d8c773-3a31-45f2-838d-255afef5511a",
+              "description": "When to book your car theory test, what to take with you, how the multiple-choice questions and hazard perception test work, and the pass mark",
+              "document_type": "guide",
+              "locale": "en",
+              "public_updated_at": "2016-12-20T13:49:20Z",
+              "schema_name": "guide",
+              "title": "Theory test: cars",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "https://www.gov.uk/api/content/theory-test",
+              "web_url": "https://www.gov.uk/theory-test"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/learn-to-drive-a-car",
+        "web_url": "https://www.gov.uk/learn-to-drive-a-car"
+      }
+    ],
+    "available_translations": [
+      {
+        "links": {
+        },
+        "web_url": "http://www.dev.gov.uk/council-tax-bands",
+        "api_url": "http://www.dev.gov.uk/api/content/council-tax-bands",
+        "locale": "en",
+        "content_id": "515c819e-34bd-421d-8261-eaa06c4786c5",
+        "withdrawn": false,
+        "title": "Check your Council Tax band",
+        "public_updated_at": "2015-01-14T13:47:41Z",
+        "analytics_identifier": null,
+        "document_type": "transaction",
+        "schema_name": "transaction",
+        "base_path": "/council-tax-bands",
+        "description": "Find out the Council Tax band for a property in England, Scotland or Wales by looking up the property's postcode online",
+        "api_path": "/api/content/council-tax-bands"
+      }
+    ],
+    "topics": [
+      {
+        "web_url": "http://www.dev.gov.uk/topic/local-government/council-tax",
+        "api_url": "http://www.dev.gov.uk/api/content/topic/local-government/council-tax",
+        "links": {
+        },
+        "withdrawn": false,
+        "title": "Council Tax",
+        "schema_name": "topic",
+        "analytics_identifier": null,
+        "api_path": "/api/content/topic/local-government/council-tax",
+        "base_path": "/topic/local-government/council-tax",
+        "content_id": "7eca7540-a65f-453e-b92f-df21b406d829",
+        "description": "List of information about Council Tax.",
+        "document_type": "topic",
+        "locale": "en",
+        "public_updated_at": "2017-01-26T10:26:48Z"
+      }
+    ],
+    "parent": [
+      {
+        "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",
+        "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/council-tax",
+        "links": {
+          "parent": [
+            {
+              "web_url": "http://www.dev.gov.uk/browse/housing-local-services",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services",
+              "links": {
+              },
+              "withdrawn": false,
+              "title": "Housing and local services",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/housing-local-services",
+              "base_path": "/browse/housing-local-services",
+              "content_id": "61d038ad-ba54-40a1-b6ca-18b390138b41",
+              "description": "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-03T13:25:46Z"
+            }
+          ]
+        },
+        "withdrawn": false,
+        "title": "Council Tax",
+        "schema_name": "mainstream_browse_page",
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/housing-local-services/council-tax",
+        "base_path": "/browse/housing-local-services/council-tax",
+        "content_id": "d958a860-3e80-4377-9d97-a491c77dbfc5",
+        "description": "Includes council tax appeals, bands, discounts and reductions",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-08-03T13:27:50Z"
+      }
+    ],
+    "organisations": [
+      {
+        "web_url": "http://www.dev.gov.uk/government/organisations/department-for-communities-and-local-government",
+        "api_url": "http://www.dev.gov.uk/api/content/government/organisations/department-for-communities-and-local-government",
+        "links": {
+        },
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Department for <br/>Communities and<br/>Local Government"
+          },
+          "brand": "department-for-communities-and-local-government"
+        },
+        "withdrawn": false,
+        "title": "Department for Communities and Local Government",
+        "schema_name": "placeholder",
+        "analytics_identifier": "D4",
+        "api_path": "/api/content/government/organisations/department-for-communities-and-local-government",
+        "base_path": "/government/organisations/department-for-communities-and-local-government",
+        "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2016-07-18T17:26:50Z"
+      },
+      {
+        "web_url": "http://www.dev.gov.uk/government/organisations/valuation-office-agency",
+        "api_url": "http://www.dev.gov.uk/api/content/government/organisations/valuation-office-agency",
+        "links": {
+        },
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Valuation Office Agency"
+          },
+          "brand": "hm-revenue-customs"
+        },
+        "withdrawn": false,
+        "title": "Valuation Office Agency",
+        "schema_name": "placeholder",
+        "analytics_identifier": "EA87",
+        "api_path": "/api/content/government/organisations/valuation-office-agency",
+        "base_path": "/government/organisations/valuation-office-agency",
+        "content_id": "ae98edb5-87b4-4a69-a31a-e0e5298f949d",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2014-12-01T10:49:55Z"
+      }
+    ],
+    "ordered_related_items": [
+      {
+        "web_url": "http://www.dev.gov.uk/council-tax",
+        "api_url": "http://www.dev.gov.uk/api/content/council-tax",
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/council-tax",
+              "links": {
+                "parent": [
+                  {
+                    "web_url": "http://www.dev.gov.uk/browse/housing-local-services",
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services",
+                    "links": {
+                    },
+                    "withdrawn": false,
+                    "title": "Housing and local services",
+                    "schema_name": "mainstream_browse_page",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/housing-local-services",
+                    "base_path": "/browse/housing-local-services",
+                    "content_id": "61d038ad-ba54-40a1-b6ca-18b390138b41",
+                    "description": "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-08-03T13:25:46Z"
+                  }
+                ]
+              },
+              "withdrawn": false,
+              "title": "Council Tax",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/housing-local-services/council-tax",
+              "base_path": "/browse/housing-local-services/council-tax",
+              "content_id": "d958a860-3e80-4377-9d97-a491c77dbfc5",
+              "description": "Includes council tax appeals, bands, discounts and reductions",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-03T13:27:50Z"
+            }
+          ]
+        },
+        "withdrawn": false,
+        "title": "Council Tax",
+        "schema_name": "guide",
+        "analytics_identifier": null,
+        "api_path": "/api/content/council-tax",
+        "base_path": "/council-tax",
+        "content_id": "428c2bae-56c2-48bd-a917-3d04df0a63fd",
+        "description": "Your Council Tax bill - how to work it out, who has to pay, discounts and exemptions for students and disabled people, second homes, empty properties, paying the bill",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2014-11-21T15:54:42Z"
+      },
+      {
+        "web_url": "http://www.dev.gov.uk/council-tax-appeals",
+        "api_url": "http://www.dev.gov.uk/api/content/council-tax-appeals",
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/council-tax",
+              "links": {
+                "parent": [
+                  {
+                    "web_url": "http://www.dev.gov.uk/browse/housing-local-services",
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services",
+                    "links": {
+                    },
+                    "withdrawn": false,
+                    "title": "Housing and local services",
+                    "schema_name": "mainstream_browse_page",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/housing-local-services",
+                    "base_path": "/browse/housing-local-services",
+                    "content_id": "61d038ad-ba54-40a1-b6ca-18b390138b41",
+                    "description": "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-08-03T13:25:46Z"
+                  }
+                ]
+              },
+              "withdrawn": false,
+              "title": "Council Tax",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/housing-local-services/council-tax",
+              "base_path": "/browse/housing-local-services/council-tax",
+              "content_id": "d958a860-3e80-4377-9d97-a491c77dbfc5",
+              "description": "Includes council tax appeals, bands, discounts and reductions",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-03T13:27:50Z"
+            }
+          ]
+        },
+        "withdrawn": false,
+        "title": "Council Tax appeals",
+        "schema_name": "guide",
+        "analytics_identifier": null,
+        "api_path": "/api/content/council-tax-appeals",
+        "base_path": "/council-tax-appeals",
+        "content_id": "96cc0e17-c228-4f0c-97f9-fb505b5d07a1",
+        "description": "How to challenge your Council Tax band, or appeal to your council or the Valuation Tribunal about a Council Tax bill, fine or completion notice",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2014-11-25T12:33:59Z"
+      },
+      {
+        "web_url": "http://www.dev.gov.uk/council-tax-arrears",
+        "api_url": "http://www.dev.gov.uk/api/content/council-tax-arrears",
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/council-tax",
+              "links": {
+                "parent": [
+                  {
+                    "web_url": "http://www.dev.gov.uk/browse/housing-local-services",
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services",
+                    "links": {
+                    },
+                    "withdrawn": false,
+                    "title": "Housing and local services",
+                    "schema_name": "mainstream_browse_page",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/housing-local-services",
+                    "base_path": "/browse/housing-local-services",
+                    "content_id": "61d038ad-ba54-40a1-b6ca-18b390138b41",
+                    "description": "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-08-03T13:25:46Z"
+                  }
+                ]
+              },
+              "withdrawn": false,
+              "title": "Council Tax",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/housing-local-services/council-tax",
+              "base_path": "/browse/housing-local-services/council-tax",
+              "content_id": "d958a860-3e80-4377-9d97-a491c77dbfc5",
+              "description": "Includes council tax appeals, bands, discounts and reductions",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-03T13:27:50Z"
+            }
+          ]
+        },
+        "withdrawn": false,
+        "title": "Pay Council Tax arrears",
+        "schema_name": "generic_with_external_related_links",
+        "analytics_identifier": null,
+        "api_path": "/api/content/council-tax-arrears",
+        "base_path": "/council-tax-arrears",
+        "content_id": "6adfc952-86b2-4a05-9332-f835c5ee2423",
+        "description": "How your local council can help if you're struggling to pay Council Tax - and what action they can take to get any money you owe from you",
+        "document_type": "answer",
+        "locale": "en",
+        "public_updated_at": "2014-11-25T12:31:22Z"
+      },
+      {
+        "web_url": "http://www.dev.gov.uk/apply-council-tax-reduction",
+        "api_url": "http://www.dev.gov.uk/api/content/apply-council-tax-reduction",
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "web_url": "http://www.dev.gov.uk/browse/benefits/heating",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/benefits/heating",
+              "links": {
+                "parent": [
+                  {
+                    "web_url": "http://www.dev.gov.uk/browse/benefits",
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/benefits",
+                    "links": {
+                    },
+                    "withdrawn": false,
+                    "title": "Benefits",
+                    "schema_name": "mainstream_browse_page",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/benefits",
+                    "base_path": "/browse/benefits",
+                    "content_id": "f141fa95-0d79-4aed-8429-ed223a8f106a",
+                    "description": "Includes tax credits, eligibility and appeals",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:40Z"
+                  }
+                ]
+              },
+              "withdrawn": false,
+              "title": "Heating and housing benefits",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/benefits/heating",
+              "base_path": "/browse/benefits/heating",
+              "content_id": "280073f8-9553-4437-a83f-b129bc5f6799",
+              "description": "Includes Winter Fuel Payment and Cold Weather Payment",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:49Z"
+            },
+            {
+              "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/council-tax",
+              "links": {
+                "parent": [
+                  {
+                    "web_url": "http://www.dev.gov.uk/browse/housing-local-services",
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services",
+                    "links": {
+                    },
+                    "withdrawn": false,
+                    "title": "Housing and local services",
+                    "schema_name": "mainstream_browse_page",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/housing-local-services",
+                    "base_path": "/browse/housing-local-services",
+                    "content_id": "61d038ad-ba54-40a1-b6ca-18b390138b41",
+                    "description": "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-08-03T13:25:46Z"
+                  }
+                ]
+              },
+              "withdrawn": false,
+              "title": "Council Tax",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/housing-local-services/council-tax",
+              "base_path": "/browse/housing-local-services/council-tax",
+              "content_id": "d958a860-3e80-4377-9d97-a491c77dbfc5",
+              "description": "Includes council tax appeals, bands, discounts and reductions",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-03T13:27:50Z"
+            }
+          ]
+        },
+        "withdrawn": false,
+        "title": "Apply for Council Tax Reduction",
+        "schema_name": "generic_with_external_related_links",
+        "analytics_identifier": null,
+        "api_path": "/api/content/apply-council-tax-reduction",
+        "base_path": "/apply-council-tax-reduction",
+        "content_id": "d9b95f99-f3ce-4b88-900e-1cc58089c952",
+        "description": "Apply to your local council for Council Tax Reduction if you're on a low income or benefits - this has replaced Council Tax Benefit",
+        "document_type": "local_transaction",
+        "locale": "en",
+        "public_updated_at": "2013-03-26T15:20:14Z"
+      },
+      {
+        "web_url": "http://www.dev.gov.uk/apply-for-council-tax-discount",
+        "api_url": "http://www.dev.gov.uk/api/content/apply-for-council-tax-discount",
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/council-tax",
+              "links": {
+                "parent": [
+                  {
+                    "web_url": "http://www.dev.gov.uk/browse/housing-local-services",
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services",
+                    "links": {
+                    },
+                    "withdrawn": false,
+                    "title": "Housing and local services",
+                    "schema_name": "mainstream_browse_page",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/housing-local-services",
+                    "base_path": "/browse/housing-local-services",
+                    "content_id": "61d038ad-ba54-40a1-b6ca-18b390138b41",
+                    "description": "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-08-03T13:25:46Z"
+                  }
+                ]
+              },
+              "withdrawn": false,
+              "title": "Council Tax",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/housing-local-services/council-tax",
+              "base_path": "/browse/housing-local-services/council-tax",
+              "content_id": "d958a860-3e80-4377-9d97-a491c77dbfc5",
+              "description": "Includes council tax appeals, bands, discounts and reductions",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-03T13:27:50Z"
+            },
+            {
+              "web_url": "http://www.dev.gov.uk/browse/housing-local-services/local-councils",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/local-councils",
+              "links": {
+                "parent": [
+                  {
+                    "web_url": "http://www.dev.gov.uk/browse/housing-local-services",
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services",
+                    "links": {
+                    },
+                    "withdrawn": false,
+                    "title": "Housing and local services",
+                    "schema_name": "mainstream_browse_page",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/housing-local-services",
+                    "base_path": "/browse/housing-local-services",
+                    "content_id": "61d038ad-ba54-40a1-b6ca-18b390138b41",
+                    "description": "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-08-03T13:25:46Z"
+                  }
+                ]
+              },
+              "withdrawn": false,
+              "title": "Local councils and services",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/housing-local-services/local-councils",
+              "base_path": "/browse/housing-local-services/local-councils",
+              "content_id": "4f8f62a8-9ff9-45ab-b4f7-aec5d1cffbad",
+              "description": "Find and access local services",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-03T13:28:57Z"
+            }
+          ]
+        },
+        "withdrawn": false,
+        "title": "Apply for a Council Tax discount",
+        "schema_name": "generic_with_external_related_links",
+        "analytics_identifier": null,
+        "api_path": "/api/content/apply-for-council-tax-discount",
+        "base_path": "/apply-for-council-tax-discount",
+        "content_id": "47b2fc1b-271a-41eb-833d-b9b4259d9222",
+        "description": "Check with your council if you're eligible for a discount on your Council Tax",
+        "document_type": "local_transaction",
+        "locale": "en",
+        "public_updated_at": "2012-05-02T16:27:19Z"
+      },
+      {
+        "web_url": "http://www.dev.gov.uk/pay-council-tax",
+        "api_url": "http://www.dev.gov.uk/api/content/pay-council-tax",
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",
+              "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/council-tax",
+              "links": {
+                "parent": [
+                  {
+                    "web_url": "http://www.dev.gov.uk/browse/housing-local-services",
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services",
+                    "links": {
+                    },
+                    "withdrawn": false,
+                    "title": "Housing and local services",
+                    "schema_name": "mainstream_browse_page",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/housing-local-services",
+                    "base_path": "/browse/housing-local-services",
+                    "content_id": "61d038ad-ba54-40a1-b6ca-18b390138b41",
+                    "description": "Includes owning or renting, council services, planning and building, neighbours, noise and pets",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-08-03T13:25:46Z"
+                  }
+                ]
+              },
+              "withdrawn": false,
+              "title": "Council Tax",
+              "schema_name": "mainstream_browse_page",
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/housing-local-services/council-tax",
+              "base_path": "/browse/housing-local-services/council-tax",
+              "content_id": "d958a860-3e80-4377-9d97-a491c77dbfc5",
+              "description": "Includes council tax appeals, bands, discounts and reductions",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-08-03T13:27:50Z"
+            }
+          ]
+        },
+        "withdrawn": false,
+        "title": "Pay your Council Tax",
+        "schema_name": "generic_with_external_related_links",
+        "analytics_identifier": null,
+        "api_path": "/api/content/pay-council-tax",
+        "base_path": "/pay-council-tax",
+        "content_id": "b7b077e3-e03a-4fea-a6a5-853f145dfcdf",
+        "description": "Pay Council Tax online or by other methods, like direct debit to your local council",
+        "document_type": "local_transaction",
+        "locale": "en",
+        "public_updated_at": "2012-05-02T16:27:17Z"
+      }
+    ],
+    "mainstream_browse_pages": [
+      {
+        "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",
+        "api_url": "http://www.dev.gov.uk/api/content/browse/housing-local-services/council-tax",
+        "links": {
+        },
+        "withdrawn": false,
+        "title": "Council Tax",
+        "schema_name": "mainstream_browse_page",
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/housing-local-services/council-tax",
+        "base_path": "/browse/housing-local-services/council-tax",
+        "content_id": "d958a860-3e80-4377-9d97-a491c77dbfc5",
+        "description": "Includes council tax appeals, bands, discounts and reductions",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-08-03T13:27:50Z"
+      }
+    ]
+  },
+  "withdrawn_notice": {
+  },
+  "user_journey_document_supertype": "thing",
+  "navigation_document_supertype": "guidance",
+  "locale": "en",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "document_type": "transaction",
+  "content_id": "515c819e-34bd-421d-8261-eaa06c4786c5",
+  "base_path": "/council-tax-bands",
+  "analytics_identifier": null,
+  "need_ids": [
+
+  ],
+  "phase": "live",
+  "public_updated_at": "2015-01-14T13:47:41.000+00:00",
+  "publishing_app": "publisher",
+  "rendering_app": "frontend",
+  "schema_name": "transaction",
+  "title": "Check your Council Tax band",
+  "updated_at": "2017-03-06T17:26:25.143Z"
+}


### PR DESCRIPTION
I didn't want to edit the existing samples because step by step navigation takes precedence over a lot of other things when it exists. I could see edits to existing ones breaking unrelated tests.

These are the document types that are in our current step by step navigation. They're in frontend, government-frontend and manuals-frontend.