### PR TITLE
 Add scheduled publishing delay to the frontend schemas

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -534,6 +544,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -504,6 +514,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -203,6 +203,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -651,6 +661,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -507,6 +517,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -543,6 +553,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -210,6 +210,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -709,6 +719,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -197,6 +197,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -720,6 +730,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -188,6 +188,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -590,6 +600,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -204,6 +204,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -660,6 +670,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -205,6 +205,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -603,6 +613,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -568,6 +578,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -209,6 +209,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -543,6 +553,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -199,6 +199,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -704,6 +714,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -196,6 +196,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -596,6 +606,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -343,6 +343,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -646,6 +656,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -343,6 +343,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -672,6 +682,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/gone/frontend/schema.json
+++ b/dist/formats/gone/frontend/schema.json
@@ -152,6 +152,16 @@
     "rendering_app": {
       "type": "null"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -437,6 +447,10 @@
       "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
       "type": "string",
       "format": "date-time"
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "withdrawn_notice": {
       "type": "object",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -559,6 +569,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -534,6 +544,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -619,6 +629,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -623,6 +633,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -157,6 +157,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -459,6 +469,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -191,6 +191,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -529,6 +539,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -553,6 +563,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -577,6 +587,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -172,6 +172,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -498,6 +508,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -161,6 +161,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -579,6 +589,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -195,6 +195,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -596,6 +606,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -564,6 +574,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -220,6 +220,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -685,6 +695,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -543,6 +553,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -347,6 +347,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility.",
       "type": "string",
@@ -768,6 +778,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -209,6 +209,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -722,6 +732,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -232,6 +232,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -721,6 +731,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/redirect/frontend/schema.json
+++ b/dist/formats/redirect/frontend/schema.json
@@ -158,6 +158,16 @@
     "rendering_app": {
       "type": "null"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -455,6 +465,10 @@
         "$ref": "#/definitions/redirect_route"
       },
       "minItems": 1
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "withdrawn_notice": {
       "type": "object",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -202,6 +202,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -555,6 +565,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -497,6 +507,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -198,6 +198,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -513,6 +523,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -546,6 +556,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -206,6 +206,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -526,6 +536,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "service_manual_topic_groups": {
       "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -579,6 +589,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -596,6 +606,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -346,6 +346,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app_optional"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -629,6 +639,10 @@
           "type": "null"
         }
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title_optional": {
       "type": "string"

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -216,6 +216,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -1809,6 +1819,10 @@
           ]
         }
       }
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "service_standard_report_metadata": {
       "type": "object",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -222,6 +222,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -702,6 +712,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -564,6 +574,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -197,6 +197,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -536,6 +546,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -160,6 +160,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -513,6 +523,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "step_by_step_nav": {
       "type": "object",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -537,6 +547,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -206,6 +206,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -520,6 +530,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -198,6 +198,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -514,6 +524,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "taxonomy_internal_name": {
       "description": "An internal name for taxonomy admin interfaces. Includes parent.",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -511,6 +521,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -572,6 +582,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "start_button_text": {
       "description": "Custom text to be displayed on the green button that takes you to another page",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -197,6 +197,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -643,6 +653,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -197,6 +197,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -521,6 +531,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -520,6 +530,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -194,6 +194,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -507,6 +517,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -198,6 +198,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -543,6 +553,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -203,6 +203,16 @@
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schema_name": {
       "type": "string",
       "enum": [
@@ -658,6 +668,10 @@
         "whitehall-admin",
         "whitehall-frontend"
       ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "tags": {
       "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",

--- a/examples/publication/frontend/scheduled_publication.json
+++ b/examples/publication/frontend/scheduled_publication.json
@@ -7,6 +7,7 @@
   "updated_at": "2016-05-03T14:11:53.023Z",
   "public_updated_at": "2016-05-03T14:11:50.000+00:00",
   "publishing_scheduled_at": "2016-05-03T14:10:00.000+00:00",
+  "scheduled_publishing_delay_seconds": 110,
   "government_document_supertype": "notices",
   "details": {
     "body": "Body text",

--- a/formats/shared/default_properties/frontend.jsonnet
+++ b/formats/shared/default_properties/frontend.jsonnet
@@ -36,4 +36,14 @@
       },
     ],
   },
+  scheduled_publishing_delay_seconds: {
+    anyOf: [
+      {
+        "$ref": "#/definitions/scheduled_publishing_delay_seconds",
+      },
+      {
+        type: "null",
+      },
+    ],
+  },
 }

--- a/formats/shared/definitions/publishing_api_base.jsonnet
+++ b/formats/shared/definitions/publishing_api_base.jsonnet
@@ -149,6 +149,10 @@
     type: "string",
     format: "date-time",
   },
+  scheduled_publishing_delay_seconds: {
+    description: "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+    type: "integer",
+  },
   publishing_request_id: {
     description: "A unique identifier used to track publishing requests to rendered content",
     oneOf: [


### PR DESCRIPTION
Add optional `scheduled_publishing_delay_seconds` to the frontend schemas. This field will be added by the content store to let publishers check publishing delays.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting