### PR TITLE
Add signup link to finder schema

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -340,6 +340,9 @@
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
+        "signup_link": {
+          "$ref": "#/definitions/finder_signup_link"
+        },
         "summary": {
           "$ref": "#/definitions/finder_summary"
         }
@@ -470,6 +473,16 @@
     },
     "finder_show_summaries": {
       "type": "boolean"
+    },
+    "finder_signup_link": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "finder_summary": {
       "anyOf": [

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -392,6 +392,9 @@
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
+        "signup_link": {
+          "$ref": "#/definitions/finder_signup_link"
+        },
         "summary": {
           "$ref": "#/definitions/finder_summary"
         }
@@ -522,6 +525,16 @@
     },
     "finder_show_summaries": {
       "type": "boolean"
+    },
+    "finder_signup_link": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "finder_summary": {
       "anyOf": [

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -204,6 +204,9 @@
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
+        "signup_link": {
+          "$ref": "#/definitions/finder_signup_link"
+        },
         "summary": {
           "$ref": "#/definitions/finder_summary"
         }
@@ -334,6 +337,16 @@
     },
     "finder_show_summaries": {
       "type": "boolean"
+    },
+    "finder_signup_link": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "finder_summary": {
       "anyOf": [

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -49,6 +49,9 @@
         show_summaries: {
           "$ref": "#/definitions/finder_show_summaries",
         },
+        signup_link: {
+          "$ref": "#/definitions/finder_signup_link",
+        },
         summary: {
           "$ref": "#/definitions/finder_summary",
         },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -114,6 +114,16 @@
   finder_show_summaries: {
     type: "boolean",
   },
+  finder_signup_link: {
+    anyOf: [
+      {
+        type: "string",
+      },
+      {
+        type: "null",
+      },
+    ],
+  },
   finder_summary: {
     anyOf: [
       {


### PR DESCRIPTION
This commit adds `signup_link` to the finder content schema. This element is used by finder-frontend to override the normal email signup link if required.