### PR TITLE
Add hidden facet type for finders

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -431,7 +431,8 @@
             "enum": [
               "text",
               "date",
-              "topical"
+              "topical",
+              "hidden"
             ]
           }
         }

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -483,7 +483,8 @@
             "enum": [
               "text",
               "date",
-              "topical"
+              "topical",
+              "hidden"
             ]
           }
         }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -291,7 +291,8 @@
             "enum": [
               "text",
               "date",
-              "topical"
+              "topical",
+              "hidden"
             ]
           }
         }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -459,7 +459,8 @@
             "enum": [
               "text",
               "date",
-              "topical"
+              "topical",
+              "hidden"
             ]
           }
         }

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -521,7 +521,8 @@
             "enum": [
               "text",
               "date",
-              "topical"
+              "topical",
+              "hidden"
             ]
           }
         }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -309,7 +309,8 @@
             "enum": [
               "text",
               "date",
-              "topical"
+              "topical",
+              "hidden"
             ]
           }
         }

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -91,6 +91,7 @@
             "text",
             "date",
             "topical",
+            "hidden",
           ],
         },
         allowed_values: {


### PR DESCRIPTION
https://trello.com/c/ACZBT7Dk/120-build-a-way-to-publish-the-new-finder

Finders will soon accept a `hidden` facet type. So make sure this type is declared in the facet type enum.