### PR TITLE
Add filter key to finder facets

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -406,6 +406,10 @@
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",
             "type": "boolean"
           },
+          "filter_key": {
+            "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -458,6 +458,10 @@
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",
             "type": "boolean"
           },
+          "filter_key": {
+            "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -262,6 +262,10 @@
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",
             "type": "boolean"
           },
+          "filter_key": {
+            "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -434,6 +434,10 @@
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",
             "type": "boolean"
           },
+          "filter_key": {
+            "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -496,6 +496,10 @@
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",
             "type": "boolean"
           },
+          "filter_key": {
+            "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -280,6 +280,10 @@
             "description": "Include this in search result metadata. Can be set for non-filterable facets.",
             "type": "boolean"
           },
+          "filter_key": {
+            "description": "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+            "type": "string"
+          },
           "filterable": {
             "description": "This must be true to show the facet to users.",
             "type": "boolean"

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -61,6 +61,10 @@
         "display_as_result_metadata",
       ],
       properties: {
+        filter_key: {
+          description: "The exact rummager field name for this facet. Allows 'key' to be aliased to a rummager filter field",
+          type: "string",
+        },
         key: {
           description: "The rummager field name used for this facet.",
           type: "string",


### PR DESCRIPTION
Prerequisite of https://trello.com/c/ACZBT7Dk/120-build-a-way-to-publish-the-new-finder
and related to https://github.com/alphagov/finder-frontend/pull/443

An optional property `filter_key` can be used to [alias a key to a facet search filter](https://github.com/alphagov/finder-frontend/pull/443/commits/a7355c42a68e0f0de2f5b929a15020d420783609#diff-bfcfe8d4326f22af7b796495a237e0e3R43) for finders,
this allows URL parameters to differ from the underlying search details.