### PR TITLE
Add search as finder document type

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -46,7 +46,8 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "finder"
+        "finder",
+        "search"
       ]
     },
     "email_document_supertype": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -61,7 +61,8 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "finder"
+        "finder",
+        "search"
       ]
     },
     "email_document_supertype": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -37,7 +37,8 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "finder"
+        "finder",
+        "search"
       ]
     },
     "first_published_at": {

--- a/formats/finder.jsonnet
+++ b/formats/finder.jsonnet
@@ -1,5 +1,8 @@
 (import "shared/default_format.jsonnet") + {
-  document_type: "finder",
+  document_type: [
+    "finder",
+    "search"
+  ],
   definitions: {
     details: {
       type: "object",


### PR DESCRIPTION
Part of https://trello.com/c/ACZBT7Dk/120-build-a-way-to-publish-the-new-finder

We don't want the advanced search finder at `/search/advanced` to be indexed in search, giving it a document type of `search` will circumvent indexing.

See https://github.com/alphagov/rummager/pull/1196 for details of the finder.