### PR TITLE
Change email_signup_link in examples

### DIFF
--- a/examples/travel_advice/frontend/no-parts.json
+++ b/examples/travel_advice/frontend/no-parts.json
@@ -14,7 +14,7 @@
     "alert_status": [
 
     ],
-    "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+    "email_signup_link": "/foreign-travel-advice/email-signup",
     "parts": [
 
     ],

--- a/examples/travel_advice/publisher_v2/travel_advice.json
+++ b/examples/travel_advice/publisher_v2/travel_advice.json
@@ -23,7 +23,7 @@
     "alert_status": [
 
     ],
-    "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+    "email_signup_link": "/foreign-travel-advice/email-signup",
     "image": {
       "url": "https://assets.digital.cabinet-office.gov.uk/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg",
       "content_type": "image/jpeg"

--- a/examples/travel_advice_index/frontend/index.json
+++ b/examples/travel_advice_index/frontend/index.json
@@ -4,7 +4,7 @@
   "title": "Foreign travel advice",
   "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
   "details": {
-    "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+    "email_signup_link": "/foreign-travel-advice/email-signup",
     "max_cache_time": 10,
     "publishing_request_id": "2546-1460985144476-19268198-3242"
   },

--- a/examples/travel_advice_index/publisher_v2/travel_advice_index.json
+++ b/examples/travel_advice_index/publisher_v2/travel_advice_index.json
@@ -4,7 +4,7 @@
   "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
   "public_updated_at": "2015-10-26T13:00:37+00:00",
   "details": {
-    "email_signup_link": "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+    "email_signup_link": "/foreign-travel-advice/email-signup",
     "max_cache_time": 10,
     "publishing_request_id": "2546-1460985144476-19268198-3242"
   },


### PR DESCRIPTION
This commit changes the `email_signup_link` field in the relevant examples to point to a more realistic location.

Trello: https://trello.com/c/VK18GrmW/736-clean-up-all-remaining-govdelivery-references-across-all-repos