### PR TITLE
Add change_history to Corporate Information Pages

### DIFF
--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -187,6 +187,27 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
     "description_optional": {
       "anyOf": [
         {
@@ -207,6 +228,9 @@
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
         "corporate_information_groups": {
           "description": "Groups of corporate information to display on about pages",

--- a/formats/corporate_information_page.jsonnet
+++ b/formats/corporate_information_page.jsonnet
@@ -33,16 +33,19 @@
         body: {
           "$ref": "#/definitions/body",
         },
+        change_history: {
+          "$ref": "#/definitions/change_history",
+        },
+        corporate_information_groups: {
+          description: "Groups of corporate information to display on about pages",
+          "$ref": "#/definitions/grouped_lists_of_links",
+        },
         organisation: {
           description: "A single organisation that is the subject of this corporate information page",
           "$ref": "#/definitions/guid",
         },
         tags: {
           "$ref": "#/definitions/tags",
-        },
-        corporate_information_groups: {
-          description: "Groups of corporate information to display on about pages",
-          "$ref": "#/definitions/grouped_lists_of_links",
         },
       },
     },


### PR DESCRIPTION
Trello: https://trello.com/c/dwniZAC4/71-investigate-change-note-lag-bug-in-emails

Currently these have an incorrect history and the alerts for them are
coming out incorrect. I've decided to go with the deprecated
change_history appraoch rather than using change_note since Whitehall
already does all of it's change_history through `change_history` and
this seems less likely to cause surprises than introducing a
`change_note` field.