### PR TITLE
Add new option to completed_transaction schema

### DIFF
--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -312,6 +312,7 @@
           "properties": {
             "category": {
               "enum": [
+                "mot_reminder",
                 "organ_donor",
                 "register_to_vote"
               ]

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -355,6 +355,7 @@
           "properties": {
             "category": {
               "enum": [
+                "mot_reminder",
                 "organ_donor",
                 "register_to_vote"
               ]

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -173,6 +173,7 @@
           "properties": {
             "category": {
               "enum": [
+                "mot_reminder",
                 "organ_donor",
                 "register_to_vote"
               ]

--- a/formats/completed_transaction.jsonnet
+++ b/formats/completed_transaction.jsonnet
@@ -18,6 +18,7 @@
           properties: {
             category: {
               enum: [
+                "mot_reminder",
                 "organ_donor",
                 "register_to_vote",
               ],


### PR DESCRIPTION
A new promotion option `MOT reminder` needs to be added to the `completed_transaction` schema, and is required before updates in `Publisher` can be made.

Part of work required for Trello card: [Request for new option in Completed Transaction 'promotion' slot](https://trello.com/c/fQQYxNIK/70-request-for-new-option-in-completed-transaction-promotion-slot)