### PR TITLE
Tweak organisation schema

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -828,7 +828,7 @@
           "type": "string",
           "enum": [
             "news",
-            "services"
+            "service"
           ]
         },
         "organisation_govuk_status": {
@@ -891,17 +891,13 @@
             "required": [
               "service_type",
               "title",
-              "href",
-              "image"
+              "href"
             ],
             "additionalProperties": false,
             "properties": {
               "href": {
                 "type": "string",
                 "format": "uri"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
               },
               "service_type": {
                 "type": "string",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -891,7 +891,7 @@
           "type": "string",
           "enum": [
             "news",
-            "services"
+            "service"
           ]
         },
         "organisation_govuk_status": {
@@ -954,17 +954,13 @@
             "required": [
               "service_type",
               "title",
-              "href",
-              "image"
+              "href"
             ],
             "additionalProperties": false,
             "properties": {
               "href": {
                 "type": "string",
                 "format": "uri"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
               },
               "service_type": {
                 "type": "string",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -689,7 +689,7 @@
           "type": "string",
           "enum": [
             "news",
-            "services"
+            "service"
           ]
         },
         "organisation_govuk_status": {
@@ -752,17 +752,13 @@
             "required": [
               "service_type",
               "title",
-              "href",
-              "image"
+              "href"
             ],
             "additionalProperties": false,
             "properties": {
               "href": {
                 "type": "string",
                 "format": "uri"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
               },
               "service_type": {
                 "type": "string",

--- a/examples/organisation/frontend/organisation.json
+++ b/examples/organisation/frontend/organisation.json
@@ -145,11 +145,7 @@
       {
         "service_type": "twitter",
         "title": "Twitter - @DExEUgov",
-        "href": "https://twitter.com/DExEUgov",
-        "image": {
-          "url": "https://assets.publishing.service.gov.uk/government/assets/social-icons-white-e159ffee9ba2dc13b92eed98fbf9fc5696f5fab245ac41a217e3665ef28a7c9a.png",
-          "alt_text": "Twitter"
-        }
+        "href": "https://twitter.com/DExEUgov"
       }
     ],
     "body": "We are responsible for overseeing negotiations to leave the EU and establishing the future relationship between the UK and EU."

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -349,7 +349,7 @@
           type: "string",
           enum: [
             "news",
-            "services",
+            "service",
           ],
           description: "Whether to prioritise news or services on the organisation's home page.",
         },
@@ -414,7 +414,6 @@
               "service_type",
               "title",
               "href",
-              "image",
             ],
             properties: {
               service_type: {
@@ -440,9 +439,6 @@
               href: {
                 type: "string",
                 format: "uri",
-              },
-              image: {
-                "$ref": "#/definitions/image",
               },
             },
           },


### PR DESCRIPTION
This commit tweaks the organisation schema with the following changes:

* Change `services` to `service` for the homepage priority types to match the name in whitehall
* Remove `image` from social media links since this is determined in CSS from the service name

Trello: https://trello.com/c/IftdS5pN/25-get-whitehall-to-publish-organisation-data-to-the-content-store