### PR TITLE
More tweaks to the organisation schema

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -484,7 +484,10 @@
         },
         "brand": {
           "description": "The organisation's brand class name, which is mapped to a colour in the frontend.",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
@@ -857,7 +860,10 @@
               ]
             },
             "updated_at": {
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "format": "date-time"
             }
           }

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -547,7 +547,10 @@
         },
         "brand": {
           "description": "The organisation's brand class name, which is mapped to a colour in the frontend.",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
@@ -920,7 +923,10 @@
               ]
             },
             "updated_at": {
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "format": "date-time"
             }
           }

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -348,7 +348,10 @@
         },
         "brand": {
           "description": "The organisation's brand class name, which is mapped to a colour in the frontend.",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "change_note": {
           "$ref": "#/definitions/change_note"
@@ -718,7 +721,10 @@
               ]
             },
             "updated_at": {
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "format": "date-time"
             }
           }

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -14,7 +14,10 @@
           "$ref": "#/definitions/change_note",
         },
         brand: {
-          type: "string",
+          type: [
+            "string",
+            "null",
+          ],
           description: "The organisation's brand class name, which is mapped to a colour in the frontend.",
         },
         foi_exempt: {
@@ -378,7 +381,10 @@
               ],
             },
             updated_at: {
-              type: "string",
+              type: [
+                "string",
+                "null",
+              ],
               format: "date-time",
             },
           },


### PR DESCRIPTION
This commit makes the `brand` and `updated_at` (for closed status) fields optional since they won’t always be used.

Trello: https://trello.com/c/IftdS5pN/25-get-whitehall-to-publish-organisation-data-to-the-content-store