### PR TITLE
Add payment_type and attends_cabinet_type to organisation schema

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -546,6 +546,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -558,14 +564,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -582,6 +591,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -594,14 +609,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -694,6 +712,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -706,14 +730,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -730,6 +757,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -742,14 +775,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -766,6 +802,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -778,14 +820,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -802,6 +847,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -814,14 +865,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -609,6 +609,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -621,14 +627,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -645,6 +654,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -657,14 +672,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -757,6 +775,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -769,14 +793,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -793,6 +820,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -805,14 +838,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -829,6 +865,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -841,14 +883,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -865,6 +910,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -877,14 +928,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -407,6 +407,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -419,14 +425,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -443,6 +452,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -455,14 +470,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -555,6 +573,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -567,14 +591,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -591,6 +618,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -603,14 +636,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -627,6 +663,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -639,14 +681,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }
@@ -663,6 +708,12 @@
             ],
             "additionalProperties": false,
             "properties": {
+              "attends_cabinet_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "href": {
                 "type": "string"
               },
@@ -675,14 +726,17 @@
               "name_prefix": {
                 "type": "string"
               },
+              "payment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "role": {
                 "type": "string"
               },
               "role_href": {
                 "type": "string"
-              },
-              "unpaid": {
-                "type": "boolean"
               }
             }
           }

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -161,8 +161,17 @@
               image: {
                 "$ref": "#/definitions/image",
               },
-              unpaid: {
-                type: "boolean",
+              payment_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
+              },
+              attends_cabinet_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
               },
             },
           },
@@ -197,8 +206,17 @@
               image: {
                 "$ref": "#/definitions/image",
               },
-              unpaid: {
-                type: "boolean",
+              payment_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
+              },
+              attends_cabinet_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
               },
             },
           },
@@ -233,8 +251,17 @@
               image: {
                 "$ref": "#/definitions/image",
               },
-              unpaid: {
-                type: "boolean",
+              payment_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
+              },
+              attends_cabinet_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
               },
             },
           },
@@ -269,8 +296,17 @@
               image: {
                 "$ref": "#/definitions/image",
               },
-              unpaid: {
-                type: "boolean",
+              payment_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
+              },
+              attends_cabinet_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
               },
             },
           },
@@ -305,8 +341,17 @@
               image: {
                 "$ref": "#/definitions/image",
               },
-              unpaid: {
-                type: "boolean",
+              payment_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
+              },
+              attends_cabinet_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
               },
             },
           },
@@ -341,8 +386,17 @@
               image: {
                 "$ref": "#/definitions/image",
               },
-              unpaid: {
-                type: "boolean",
+              payment_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
+              },
+              attends_cabinet_type: {
+                type: [
+                  "string",
+                  "null",
+                ],
               },
             },
           },


### PR DESCRIPTION
This commit adds `payment_type` and `attends_cabinet_type` fields to the organisation schema. These fields contain strings if the relevant people are unpaid/paid as part of another role, and if they are non-Cabinet members who attend Cabinet.

Trello: https://trello.com/c/IftdS5pN/25-get-whitehall-to-publish-organisation-data-to-the-content-store