### PR TITLE
Make certain organisation fields nullable

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -535,94 +535,10 @@
           }
         },
         "ordered_board_members": {
-          "description": "A list of the organisation's board members, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_chief_professional_officers": {
-          "description": "A list of the organisation's chief professional officers, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_corporate_information_pages": {
           "description": "A set of links to corporate information pages to display for the organisation.",
@@ -660,7 +576,10 @@
             "additionalProperties": false,
             "properties": {
               "document_type": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "href": {
                 "type": "string"
@@ -669,7 +588,10 @@
                 "$ref": "#/definitions/image"
               },
               "public_updated_at": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "summary": {
                 "type": "string"
@@ -701,184 +623,16 @@
           }
         },
         "ordered_military_personnel": {
-          "description": "A list of the organisation's military personnel, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_ministers": {
-          "description": "A list of the organisation's ministers, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_special_representatives": {
-          "description": "A list of the organisation's special representatives, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_traffic_commissioners": {
-          "description": "A list of the organisation's traffic commissioners, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "organisation_featuring_priority": {
           "description": "Whether to prioritise news or services on the organisation's home page.",
@@ -1163,6 +917,57 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "people": {
+      "description": "A list of people. Turn into proper links once organisations, people and roles are fully migrated.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "role",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "attends_cabinet_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "name": {
+            "type": "string"
+          },
+          "name_prefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role": {
+            "type": "string"
+          },
+          "role_href": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -598,94 +598,10 @@
           }
         },
         "ordered_board_members": {
-          "description": "A list of the organisation's board members, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_chief_professional_officers": {
-          "description": "A list of the organisation's chief professional officers, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_corporate_information_pages": {
           "description": "A set of links to corporate information pages to display for the organisation.",
@@ -723,7 +639,10 @@
             "additionalProperties": false,
             "properties": {
               "document_type": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "href": {
                 "type": "string"
@@ -732,7 +651,10 @@
                 "$ref": "#/definitions/image"
               },
               "public_updated_at": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "summary": {
                 "type": "string"
@@ -764,184 +686,16 @@
           }
         },
         "ordered_military_personnel": {
-          "description": "A list of the organisation's military personnel, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_ministers": {
-          "description": "A list of the organisation's ministers, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_special_representatives": {
-          "description": "A list of the organisation's special representatives, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_traffic_commissioners": {
-          "description": "A list of the organisation's traffic commissioners, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "organisation_featuring_priority": {
           "description": "Whether to prioritise news or services on the organisation's home page.",
@@ -1243,6 +997,57 @@
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",
       "type": "integer"
+    },
+    "people": {
+      "description": "A list of people. Turn into proper links once organisations, people and roles are fully migrated.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "role",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "attends_cabinet_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "name": {
+            "type": "string"
+          },
+          "name_prefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role": {
+            "type": "string"
+          },
+          "role_href": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -396,94 +396,10 @@
           }
         },
         "ordered_board_members": {
-          "description": "A list of the organisation's board members, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_chief_professional_officers": {
-          "description": "A list of the organisation's chief professional officers, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_corporate_information_pages": {
           "description": "A set of links to corporate information pages to display for the organisation.",
@@ -521,7 +437,10 @@
             "additionalProperties": false,
             "properties": {
               "document_type": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "href": {
                 "type": "string"
@@ -530,7 +449,10 @@
                 "$ref": "#/definitions/image"
               },
               "public_updated_at": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "summary": {
                 "type": "string"
@@ -562,184 +484,16 @@
           }
         },
         "ordered_military_personnel": {
-          "description": "A list of the organisation's military personnel, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_ministers": {
-          "description": "A list of the organisation's ministers, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_special_representatives": {
-          "description": "A list of the organisation's special representatives, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "ordered_traffic_commissioners": {
-          "description": "A list of the organisation's traffic commissioners, if appropriate. Turn into proper links once organisations are fully migrated.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "role",
-              "href"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "attends_cabinet_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "href": {
-                "type": "string"
-              },
-              "image": {
-                "$ref": "#/definitions/image"
-              },
-              "name": {
-                "type": "string"
-              },
-              "name_prefix": {
-                "type": "string"
-              },
-              "payment_type": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "role": {
-                "type": "string"
-              },
-              "role_href": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/people"
         },
         "organisation_featuring_priority": {
           "description": "Whether to prioritise news or services on the organisation's home page.",
@@ -964,6 +718,57 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "people": {
+      "description": "A list of people. Turn into proper links once organisations, people and roles are fully migrated.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "role",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "attends_cabinet_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/definitions/image"
+          },
+          "name": {
+            "type": "string"
+          },
+          "name_prefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role": {
+            "type": "string"
+          },
+          "role_href": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -123,284 +123,38 @@
                 type: "string",
               },
               public_updated_at: {
-                type: "string",
+                type: [
+                  "string",
+                  "null",
+                ],
               },
               document_type: {
-                type: "string",
+                type: [
+                  "string",
+                  "null",
+                ],
               },
             },
           },
           description: "A set of featured documents to display for the organisation. Turn into proper links once organisations are fully migrated.",
         },
         ordered_ministers: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "name",
-              "role",
-              "href",
-            ],
-            properties: {
-              name_prefix: {
-                type: "string",
-              },
-              name: {
-                type: "string",
-              },
-              role: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-              },
-              role_href: {
-                type: "string",
-              },
-              image: {
-                "$ref": "#/definitions/image",
-              },
-              payment_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-              attends_cabinet_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-            },
-          },
-          description: "A list of the organisation's ministers, if appropriate. Turn into proper links once organisations are fully migrated.",
+          "$ref": "#/definitions/people",
         },
         ordered_board_members: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "name",
-              "role",
-              "href",
-            ],
-            properties: {
-              name_prefix: {
-                type: "string",
-              },
-              name: {
-                type: "string",
-              },
-              role: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-              },
-              role_href: {
-                type: "string",
-              },
-              image: {
-                "$ref": "#/definitions/image",
-              },
-              payment_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-              attends_cabinet_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-            },
-          },
-          description: "A list of the organisation's board members, if appropriate. Turn into proper links once organisations are fully migrated.",
+          "$ref": "#/definitions/people",
         },
         ordered_military_personnel: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "name",
-              "role",
-              "href",
-            ],
-            properties: {
-              name_prefix: {
-                type: "string",
-              },
-              name: {
-                type: "string",
-              },
-              role: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-              },
-              role_href: {
-                type: "string",
-              },
-              image: {
-                "$ref": "#/definitions/image",
-              },
-              payment_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-              attends_cabinet_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-            },
-          },
-          description: "A list of the organisation's military personnel, if appropriate. Turn into proper links once organisations are fully migrated.",
+          "$ref": "#/definitions/people",
         },
         ordered_traffic_commissioners: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "name",
-              "role",
-              "href",
-            ],
-            properties: {
-              name_prefix: {
-                type: "string",
-              },
-              name: {
-                type: "string",
-              },
-              role: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-              },
-              role_href: {
-                type: "string",
-              },
-              image: {
-                "$ref": "#/definitions/image",
-              },
-              payment_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-              attends_cabinet_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-            },
-          },
-          description: "A list of the organisation's traffic commissioners, if appropriate. Turn into proper links once organisations are fully migrated.",
+          "$ref": "#/definitions/people",
         },
         ordered_chief_professional_officers: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "name",
-              "role",
-              "href",
-            ],
-            properties: {
-              name_prefix: {
-                type: "string",
-              },
-              name: {
-                type: "string",
-              },
-              role: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-              },
-              role_href: {
-                type: "string",
-              },
-              image: {
-                "$ref": "#/definitions/image",
-              },
-              payment_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-              attends_cabinet_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-            },
-          },
-          description: "A list of the organisation's chief professional officers, if appropriate. Turn into proper links once organisations are fully migrated.",
+          "$ref": "#/definitions/people",
         },
         ordered_special_representatives: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "name",
-              "role",
-              "href",
-            ],
-            properties: {
-              name_prefix: {
-                type: "string",
-              },
-              name: {
-                type: "string",
-              },
-              role: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-              },
-              role_href: {
-                type: "string",
-              },
-              image: {
-                "$ref": "#/definitions/image",
-              },
-              payment_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-              attends_cabinet_type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-              },
-            },
-          },
-          description: "A list of the organisation's special representatives, if appropriate. Turn into proper links once organisations are fully migrated.",
+          "$ref": "#/definitions/people",
         },
         organisation_featuring_priority: {
           type: "string",

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -48,6 +48,57 @@
       },
     },
   },
+  people: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "name",
+        "role",
+        "href",
+      ],
+      properties: {
+        name_prefix: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+        name: {
+          type: "string",
+        },
+        role: {
+          type: "string",
+        },
+        href: {
+          type: "string",
+        },
+        role_href: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+        image: {
+          "$ref": "#/definitions/image",
+        },
+        payment_type: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+        attends_cabinet_type: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+      },
+    },
+    description: "A list of people. Turn into proper links once organisations, people and roles are fully migrated.",
+  },
   political: {
     type: "boolean",
     description: "If the content is considered political in nature, reflecting views of the government it was published under.",


### PR DESCRIPTION
This commit allows `name_prefix` and `role_href` for people and `public_updated_at` and `document_type` for featured documents be `null`, since these fields are not always expected to be populated. It also moves the person definition into a shared file since all person definitions for organisations are identical.

Trello: https://trello.com/c/IftdS5pN/25-get-whitehall-to-publish-organisation-data-to-the-content-store