### PR TITLE
Update Person Schema

### DIFF
--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -445,11 +445,24 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "full_name": {
+          "description": "Name of the person, including titles and any letters, eg: 'Sir Lord Snoopy DOG'",
+          "type": "string"
+        },
         "image": {
           "$ref": "#/definitions/image"
+        },
+        "minister": {
+          "type": "boolean"
+        },
+        "privy_counsellor": {
+          "type": "boolean"
         }
       }
     },

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -488,11 +488,24 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "full_name": {
+          "description": "Name of the person, including titles and any letters, eg: 'Sir Lord Snoopy DOG'",
+          "type": "string"
+        },
         "image": {
           "$ref": "#/definitions/image"
+        },
+        "minister": {
+          "type": "boolean"
+        },
+        "privy_counsellor": {
+          "type": "boolean"
         }
       }
     },

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -309,8 +309,21 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "analytics_identifier": {
+          "$ref": "#/definitions/analytics_identifier"
+        },
+        "full_name": {
+          "description": "Name of the person, including titles and any letters, eg: 'Sir Lord Snoopy DOG'",
+          "type": "string"
+        },
         "image": {
           "$ref": "#/definitions/image"
+        },
+        "minister": {
+          "type": "boolean"
+        },
+        "privy_counsellor": {
+          "type": "boolean"
         }
       }
     },

--- a/formats/person.jsonnet
+++ b/formats/person.jsonnet
@@ -4,6 +4,19 @@
       type: "object",
       additionalProperties: false,
       properties: {
+        analytics_identifier: {
+          "$ref": "#/definitions/analytics_identifier",
+        },
+        full_name: {
+          type: "string",
+          description: "Name of the person, including titles and any letters, eg: 'Sir Lord Snoopy DOG'",
+        },
+        minister: {
+          type: "boolean",
+        },
+        privy_counsellor: {
+          type: "boolean",
+        },
         image: {
           "$ref": "#/definitions/image",
         },


### PR DESCRIPTION
We are moving Organisations away from Whitehall, in this commit we would like to expand the Person schema so we can start sending information to Publishing API.

There might be more fields to be added in the future, such as person role.

Trello: https://trello.com/c/32LO2xT8/30-work-out-what-information-we-need-to-publish-to-the-content-store-for-people-and-fix-the-schema-for-it