### PR TITLE
Move organisations homepage links to details

### DIFF
--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -248,34 +248,6 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "ordered_agencies_and_other_public_bodies": {
-          "description": "All organisations of the type 'agency' and other public bodies, ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_devolved_administrations": {
-          "description": "All organisations of the type 'devolved administration', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_executive_offices": {
-          "description": "All organisations of the type 'executive office', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_high_profile_groups": {
-          "description": "All organisations that have a parent organisation, ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_ministerial_departments": {
-          "description": "All organisations of the type 'ministerial department', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_non_ministerial_departments": {
-          "description": "All organisations of the type 'non-ministerial department', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_public_corporations": {
-          "description": "All organisations of the type 'public corporation', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -475,6 +447,27 @@
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "ordered_agencies_and_other_public_bodies": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_devolved_administrations": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_executive_offices": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_high_profile_groups": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_ministerial_departments": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_non_ministerial_departments": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_public_corporations": {
+          "$ref": "#/definitions/summary_organisations"
         }
       }
     },
@@ -553,6 +546,52 @@
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "list_of_sub_organisations": {
+      "description": "A list of all sub-organisations of a particular type for a parent organisation. Turn into proper links once details for organisations no longer need to be expanded.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "locale": {
       "type": "string",
@@ -696,6 +735,115 @@
     "scheduled_publishing_delay_seconds": {
       "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
       "type": "integer"
+    },
+    "summary_organisations": {
+      "description": "A list of all organisations of a particular type. Turn into proper links once details for organisations no longer need to be expanded.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "separate_website"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "brand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "logo": {
+            "type": "object",
+            "properties": {
+              "crest": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "bis",
+                  "dit",
+                  "eo",
+                  "hmrc",
+                  "ho",
+                  "mod",
+                  "portcullis",
+                  "single-identity",
+                  "so",
+                  "ukaea",
+                  "wales",
+                  null
+                ]
+              },
+              "formatted_title": {
+                "type": "string"
+              },
+              "image": {
+                "$ref": "#/definitions/image"
+              }
+            }
+          },
+          "separate_website": {
+            "type": "boolean"
+          },
+          "title": {
+            "type": "string"
+          },
+          "works_with": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "adhoc_advisory_group": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "advisory_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "civil_service": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "devolved_administration": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_agency": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_office": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "independent_monitoring_body": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "ministerial_department": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "non_ministerial_department": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "other": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "public_corporation": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "sub_organisation": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "tribunal_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              }
+            }
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -249,34 +249,6 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "ordered_agencies_and_other_public_bodies": {
-          "description": "All organisations of the type 'agency' and other public bodies, ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_devolved_administrations": {
-          "description": "All organisations of the type 'devolved administration', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_executive_offices": {
-          "description": "All organisations of the type 'executive office', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_high_profile_groups": {
-          "description": "All organisations that have a parent organisation, ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_ministerial_departments": {
-          "description": "All organisations of the type 'ministerial department', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_non_ministerial_departments": {
-          "description": "All organisations of the type 'non-ministerial department', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_public_corporations": {
-          "description": "All organisations of the type 'public corporation', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -349,34 +321,6 @@
         },
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_agencies_and_other_public_bodies": {
-          "description": "All organisations of the type 'agency' and other public bodies, ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_devolved_administrations": {
-          "description": "All organisations of the type 'devolved administration', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_executive_offices": {
-          "description": "All organisations of the type 'executive office', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_high_profile_groups": {
-          "description": "All organisations that have a parent organisation, ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_ministerial_departments": {
-          "description": "All organisations of the type 'ministerial department', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_non_ministerial_departments": {
-          "description": "All organisations of the type 'non-ministerial department', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_public_corporations": {
-          "description": "All organisations of the type 'public corporation', ordered alphabetically ignoring any prefixes.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
@@ -546,6 +490,27 @@
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "ordered_agencies_and_other_public_bodies": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_devolved_administrations": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_executive_offices": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_high_profile_groups": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_ministerial_departments": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_non_ministerial_departments": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_public_corporations": {
+          "$ref": "#/definitions/summary_organisations"
         }
       }
     },
@@ -637,6 +602,52 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "list_of_sub_organisations": {
+      "description": "A list of all sub-organisations of a particular type for a parent organisation. Turn into proper links once details for organisations no longer need to be expanded.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "locale": {
       "type": "string",
@@ -801,6 +812,115 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "summary_organisations": {
+      "description": "A list of all organisations of a particular type. Turn into proper links once details for organisations no longer need to be expanded.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "separate_website"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "brand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "logo": {
+            "type": "object",
+            "properties": {
+              "crest": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "bis",
+                  "dit",
+                  "eo",
+                  "hmrc",
+                  "ho",
+                  "mod",
+                  "portcullis",
+                  "single-identity",
+                  "so",
+                  "ukaea",
+                  "wales",
+                  null
+                ]
+              },
+              "formatted_title": {
+                "type": "string"
+              },
+              "image": {
+                "$ref": "#/definitions/image"
+              }
+            }
+          },
+          "separate_website": {
+            "type": "boolean"
+          },
+          "title": {
+            "type": "string"
+          },
+          "works_with": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "adhoc_advisory_group": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "advisory_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "civil_service": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "devolved_administration": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_agency": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_office": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "independent_monitoring_body": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "ministerial_department": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "non_ministerial_department": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "other": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "public_corporation": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "sub_organisation": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "tribunal_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              }
+            }
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/dist/formats/organisations_homepage/publisher_v2/links.json
+++ b/dist/formats/organisations_homepage/publisher_v2/links.json
@@ -15,34 +15,6 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "ordered_agencies_and_other_public_bodies": {
-          "description": "All organisations of the type 'agency' and other public bodies, ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_devolved_administrations": {
-          "description": "All organisations of the type 'devolved administration', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_executive_offices": {
-          "description": "All organisations of the type 'executive office', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_high_profile_groups": {
-          "description": "All organisations that have a parent organisation, ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_ministerial_departments": {
-          "description": "All organisations of the type 'ministerial department', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_non_ministerial_departments": {
-          "description": "All organisations of the type 'non-ministerial department', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_public_corporations": {
-          "description": "All organisations of the type 'public corporation', ordered alphabetically ignoring any prefixes.",
-          "$ref": "#/definitions/guid_list"
-        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -309,6 +309,27 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "ordered_agencies_and_other_public_bodies": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_devolved_administrations": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_executive_offices": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_high_profile_groups": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_ministerial_departments": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_non_ministerial_departments": {
+          "$ref": "#/definitions/summary_organisations"
+        },
+        "ordered_public_corporations": {
+          "$ref": "#/definitions/summary_organisations"
+        }
       }
     },
     "first_published_at": {
@@ -326,6 +347,52 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "list_of_sub_organisations": {
+      "description": "A list of all sub-organisations of a particular type for a parent organisation. Turn into proper links once details for organisations no longer need to be expanded.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
     },
     "locale": {
       "type": "string",
@@ -475,6 +542,115 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
+    },
+    "summary_organisations": {
+      "description": "A list of all organisations of a particular type. Turn into proper links once details for organisations no longer need to be expanded.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href",
+          "separate_website"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "brand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "href": {
+            "type": "string"
+          },
+          "logo": {
+            "type": "object",
+            "properties": {
+              "crest": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "bis",
+                  "dit",
+                  "eo",
+                  "hmrc",
+                  "ho",
+                  "mod",
+                  "portcullis",
+                  "single-identity",
+                  "so",
+                  "ukaea",
+                  "wales",
+                  null
+                ]
+              },
+              "formatted_title": {
+                "type": "string"
+              },
+              "image": {
+                "$ref": "#/definitions/image"
+              }
+            }
+          },
+          "separate_website": {
+            "type": "boolean"
+          },
+          "title": {
+            "type": "string"
+          },
+          "works_with": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "adhoc_advisory_group": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "advisory_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "civil_service": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "devolved_administration": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_agency": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "executive_office": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "independent_monitoring_body": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "ministerial_department": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "non_ministerial_department": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "other": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "public_corporation": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "sub_organisation": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              },
+              "tribunal_ndpb": {
+                "$ref": "#/definitions/list_of_sub_organisations"
+              }
+            }
+          }
+        }
+      }
     },
     "title": {
       "type": "string"

--- a/examples/organisations_homepage/frontend/organisations_homepage.json
+++ b/examples/organisations_homepage/frontend/organisations_homepage.json
@@ -1,0 +1,93 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/government/organisations",
+  "content_id": "fde62e52-dfb6-42ae-b336-2c4faf068101",
+  "document_type": "finder",
+  "first_published_at": "2017-03-17T15:09:33.000+00:00",
+  "locale": "en",
+  "need_ids": [
+
+  ],
+  "phase": "live",
+  "public_updated_at": "2018-04-04T09:11:52.000+00:00",
+  "publishing_app": "whitehall",
+  "rendering_app": "whitehall-frontend",
+  "schema_name": "organisations_homepage",
+  "title": "Departments, agencies and public bodies",
+  "updated_at": "2018-04-04T09:11:53.270Z",
+  "links": {
+    "available_translations": [
+      {
+        "title": "Departments, agencies and public bodies",
+        "public_updated_at": "2018-04-04T09:11:52Z",
+        "analytics_identifier": null,
+        "document_type": "finder",
+        "schema_name": "organisations_homepage",
+        "base_path": "/government/organisations",
+        "api_path": "/api/content/government/organisations",
+        "content_id": "fde62e52-dfb6-42ae-b336-2c4faf068101",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/government/organisations",
+        "web_url": "https://www.gov.uk/government/organisations",
+        "links": {
+
+        }
+      }
+    ]
+  },
+  "description": "Information from government departments, agencies and public bodies, including news, campaigns, policies and contact details.",
+  "details": {
+    "ordered_executive_offices": [
+      {
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "href": "/government/organisations/prime-ministers-office-10-downing-street",
+        "brand": "cabinet-office",
+        "logo": {
+          "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street",
+          "crest": "eo"
+        },
+        "separate_website": false,
+        "works_with": {}
+      }
+    ],
+    "ordered_ministerial_departments": [
+      {
+        "title": "Attorney General's Office",
+        "href": "/government/organisations/attorney-generals-office",
+        "brand": "attorney-generals-office",
+        "logo": {
+          "formatted_title": "Attorney <br/>General&#39;s <br/>Office",
+          "crest": "single-identity"
+        },
+        "separate_website": false,
+        "works_with": {
+          "non_ministerial_department": [
+            {
+              "title": "Crown Prosecution Service",
+              "href": "/government/organisations/crown-prosecution-service"
+            },
+            {
+              "title": "Government Legal Department",
+              "href": "/government/organisations/government-legal-department"
+            },
+            {
+              "title": "Serious Fraud Office",
+              "href": "/government/organisations/serious-fraud-office"
+            }
+          ],
+          "other": [
+            {
+              "title": "HM Crown Prosecution Service Inspectorate",
+              "href": "/government/organisations/hm-crown-prosecution-service-inspectorate"
+            }
+          ]
+        }
+      }
+    ],
+    "ordered_non_ministerial_departments": [],
+    "ordered_agencies_and_other_public_bodies": [],
+    "ordered_high_profile_groups": [],
+    "ordered_public_corporations": [],
+    "ordered_devolved_administrations": []
+  }
+}

--- a/formats/organisations_homepage.jsonnet
+++ b/formats/organisations_homepage.jsonnet
@@ -1,18 +1,31 @@
 (import "shared/default_format.jsonnet") + {
-  definitions: {
+  definitions: (import "shared/definitions/_whitehall.jsonnet") + {
     details: {
       type: "object",
       additionalProperties: false,
-      properties: {},
+      properties: {
+        ordered_executive_offices: {
+          "$ref": "#/definitions/summary_organisations",
+        },
+        ordered_ministerial_departments: {
+          "$ref": "#/definitions/summary_organisations",
+        },
+        ordered_non_ministerial_departments: {
+          "$ref": "#/definitions/summary_organisations",
+        },
+        ordered_agencies_and_other_public_bodies: {
+          "$ref": "#/definitions/summary_organisations",
+        },
+        ordered_high_profile_groups: {
+          "$ref": "#/definitions/summary_organisations",
+        },
+        ordered_public_corporations: {
+          "$ref": "#/definitions/summary_organisations",
+        },
+        ordered_devolved_administrations: {
+          "$ref": "#/definitions/summary_organisations",
+        },
+      },
     },
-  },
-  links: (import "shared/base_links.jsonnet") + {
-    ordered_executive_offices: "All organisations of the type 'executive office', ordered alphabetically ignoring any prefixes.",
-    ordered_ministerial_departments: "All organisations of the type 'ministerial department', ordered alphabetically ignoring any prefixes.",
-    ordered_non_ministerial_departments: "All organisations of the type 'non-ministerial department', ordered alphabetically ignoring any prefixes.",
-    ordered_agencies_and_other_public_bodies: "All organisations of the type 'agency' and other public bodies, ordered alphabetically ignoring any prefixes.",
-    ordered_high_profile_groups: "All organisations that have a parent organisation, ordered alphabetically ignoring any prefixes.",
-    ordered_public_corporations: "All organisations of the type 'public corporation', ordered alphabetically ignoring any prefixes.",
-    ordered_devolved_administrations: "All organisations of the type 'devolved administration', ordered alphabetically ignoring any prefixes.",
   },
 }

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -99,6 +99,135 @@
     },
     description: "A list of people. Turn into proper links once organisations, people and roles are fully migrated.",
   },
+  summary_organisations: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "title",
+        "href",
+        "separate_website",
+      ],
+      properties: {
+        title: {
+          type: "string",
+        },
+        href: {
+          type: "string",
+        },
+        brand: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+        logo: {
+          type: "object",
+          properties: {
+            formatted_title: {
+              type: "string",
+            },
+            crest: {
+              type: [
+                "string",
+                "null",
+              ],
+              enum: [
+                "bis",
+                "dit",
+                "eo",
+                "hmrc",
+                "ho",
+                "mod",
+                "portcullis",
+                "single-identity",
+                "so",
+                "ukaea",
+                "wales",
+                null,
+              ],
+            },
+            image: {
+              "$ref": "#/definitions/image",
+            },
+          },
+        },
+        separate_website: {
+          type: "boolean",
+        },
+        works_with: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            adhoc_advisory_group: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            advisory_ndpb: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            civil_service: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            devolved_administration: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            executive_agency: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            executive_ndpb: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            executive_office: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            independent_monitoring_body: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            ministerial_department: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            non_ministerial_department: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            other: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            public_corporation: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            sub_organisation: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+            tribunal_ndpb: {
+              "$ref": "#/definitions/list_of_sub_organisations",
+            },
+          },
+        },
+      },
+    },
+    description: "A list of all organisations of a particular type. Turn into proper links once details for organisations no longer need to be expanded.",
+  },
+  list_of_sub_organisations: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "title",
+        "href",
+      ],
+      properties: {
+        title: {
+          type: "string",
+        },
+        href: {
+          type: "string",
+        },
+      },
+    },
+    description: "A list of all sub-organisations of a particular type for a parent organisation. Turn into proper links once details for organisations no longer need to be expanded.",
+  },
   political: {
     type: "boolean",
     description: "If the content is considered political in nature, reflecting views of the government it was published under.",


### PR DESCRIPTION
This commit moves the links to all organisations on the organisations homepage to the details hash, in order to be able to make them much smaller.

Trello: https://trello.com/c/kMgJ1gqF/56-link-to-all-organisations-from-the-organisation-list-content-item