### PR TITLE
Add links between people, roles and organisations

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -253,7 +253,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ordered_contacts": {
-          "description": "Contact details primarily for use with Whitehall orgaisations.",
+          "description": "Contact details primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ordered_featured_policies": {
@@ -270,6 +270,10 @@
         },
         "ordered_related_items_overrides": {
           "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_roles": {
+          "description": "Organisational roles primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ordered_successor_organisations": {

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -254,7 +254,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ordered_contacts": {
-          "description": "Contact details primarily for use with Whitehall orgaisations.",
+          "description": "Contact details primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ordered_featured_policies": {
@@ -271,6 +271,10 @@
         },
         "ordered_related_items_overrides": {
           "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_roles": {
+          "description": "Organisational roles primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ordered_successor_organisations": {
@@ -348,7 +352,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "ordered_contacts": {
-          "description": "Contact details primarily for use with Whitehall orgaisations.",
+          "description": "Contact details primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_featured_policies": {
@@ -365,6 +369,10 @@
         },
         "ordered_related_items_overrides": {
           "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_roles": {
+          "description": "Organisational roles primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_successor_organisations": {

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -206,7 +206,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "ordered_contacts": {
-          "description": "Contact details primarily for use with Whitehall orgaisations.",
+          "description": "Contact details primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_featured_policies": {
@@ -215,6 +215,10 @@
         },
         "ordered_parent_organisations": {
           "description": "Parent organisations primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_roles": {
+          "description": "Organisational roles primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_successor_organisations": {

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -248,6 +248,14 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ordered_current_appointments": {
+          "description": "Roles that are currently assigned to this person.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_previous_appointments": {
+          "description": "Roles that were previously assigned to this person.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -249,6 +249,14 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ordered_current_appointments": {
+          "description": "Roles that are currently assigned to this person.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_previous_appointments": {
+          "description": "Roles that were previously assigned to this person.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -321,6 +329,14 @@
         },
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_current_appointments": {
+          "description": "Roles that are currently assigned to this person.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_previous_appointments": {
+          "description": "Roles that were previously assigned to this person.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -201,6 +201,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "ordered_current_appointments": {
+          "description": "Roles that are currently assigned to this person.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_previous_appointments": {
+          "description": "Roles that were previously assigned to this person.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -248,6 +248,18 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ordered_current_appointments": {
+          "description": "People who are currently assigned to this role.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_parent_organisations": {
+          "description": "Organisations that own this role.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_previous_appointments": {
+          "description": "People who were previously assigned to this role.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -249,6 +249,18 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ordered_current_appointments": {
+          "description": "People who are currently assigned to this role.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_parent_organisations": {
+          "description": "Organisations that own this role.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_previous_appointments": {
+          "description": "People who were previously assigned to this role.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -321,6 +333,18 @@
         },
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_current_appointments": {
+          "description": "People who are currently assigned to this role.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_parent_organisations": {
+          "description": "Organisations that own this role.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_previous_appointments": {
+          "description": "People who were previously assigned to this role.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -199,6 +199,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "ordered_current_appointments": {
+          "description": "People who are currently assigned to this role.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_parent_organisations": {
+          "description": "Organisations that own this role.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_previous_appointments": {
+          "description": "People who were previously assigned to this role.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -265,10 +265,11 @@
     },
   },
   edition_links: (import "shared/base_edition_links.jsonnet") + {
-    ordered_contacts: "Contact details primarily for use with Whitehall orgaisations.",
+    ordered_contacts: "Contact details primarily for use with Whitehall organisations.",
     ordered_featured_policies: "Featured policies primarily for use with Whitehall organisations.",
     ordered_parent_organisations: "Parent organisations primarily for use with Whitehall organisations.",
     ordered_child_organisations: "Child organisations primarily for use with Whitehall organisations.",
-    ordered_successor_organisations: "Successor organisations primarily for use with closed Whitehall organisations."
+    ordered_successor_organisations: "Successor organisations primarily for use with closed Whitehall organisations.",
+    ordered_roles: "Organisational roles primarily for use with Whitehall organisations.",
   },
 }

--- a/formats/person.jsonnet
+++ b/formats/person.jsonnet
@@ -26,4 +26,8 @@
       },
     },
   },
+  edition_links: (import "shared/base_edition_links.jsonnet") + {
+    ordered_current_appointments: "Roles that are currently assigned to this person.",
+    ordered_previous_appointments: "Roles that were previously assigned to this person.",
+  },
 }

--- a/formats/role.jsonnet
+++ b/formats/role.jsonnet
@@ -37,4 +37,9 @@
       },
     },
   },
+  edition_links: (import "shared/base_edition_links.jsonnet") + {
+    ordered_parent_organisations: "Organisations that own this role.",
+    ordered_current_appointments: "People who are currently assigned to this role.",
+    ordered_previous_appointments: "People who were previously assigned to this role.",
+  },
 }


### PR DESCRIPTION
This commit adds links from people -> roles, roles -> people, roles -> organisations and organisations -> roles.

Trello: https://trello.com/c/UDOsklt8/71-link-people-to-roles-in-publishing-api and https://trello.com/c/rhJHzjPP/72-link-roles-to-organisations