### PR TITLE
Add FoI contacts and sub organisations to organisations

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -272,6 +272,14 @@
           "description": "Featured policies primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ordered_foi_contacts": {
+          "description": "FoI contact details primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_high_profile_groups": {
+          "description": "High profile groups primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_parent_organisations": {
           "description": "Parent organisations primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -273,6 +273,14 @@
           "description": "Featured policies primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ordered_foi_contacts": {
+          "description": "FoI contact details primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_high_profile_groups": {
+          "description": "High profile groups primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_parent_organisations": {
           "description": "Parent organisations primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -369,6 +377,14 @@
         },
         "ordered_featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_foi_contacts": {
+          "description": "FoI contact details primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_high_profile_groups": {
+          "description": "High profile groups primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_parent_organisations": {

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -225,6 +225,14 @@
           "description": "Featured policies primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "ordered_foi_contacts": {
+          "description": "FoI contact details primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_high_profile_groups": {
+          "description": "High profile groups primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
         "ordered_parent_organisations": {
           "description": "Parent organisations primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/guid_list"

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -266,10 +266,12 @@
   },
   edition_links: (import "shared/base_edition_links.jsonnet") + {
     ordered_contacts: "Contact details primarily for use with Whitehall organisations.",
+    ordered_foi_contacts: "FoI contact details primarily for use with Whitehall organisations.",
     ordered_featured_policies: "Featured policies primarily for use with Whitehall organisations.",
     ordered_parent_organisations: "Parent organisations primarily for use with Whitehall organisations.",
     ordered_child_organisations: "Child organisations primarily for use with Whitehall organisations.",
     ordered_successor_organisations: "Successor organisations primarily for use with closed Whitehall organisations.",
+    ordered_high_profile_groups: "High profile groups primarily for use with Whitehall organisations.",
     ordered_roles: "Organisational roles primarily for use with Whitehall organisations.",
   },
 }


### PR DESCRIPTION
This commit adds FoI contacts and sub organisations (high profile groups) to organisations for rendering.

Trello: https://trello.com/c/Fnixoocj/128-add-more-data-to-the-organisations-content-item