### PR TITLE
Make rendering_app optional for role appointments

### DIFF
--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -208,7 +208,7 @@
       ]
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "scheduled_publishing_delay_seconds": {
       "anyOf": [
@@ -533,6 +533,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "scheduled_publishing_delay_seconds": {

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -267,7 +267,7 @@
       }
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "routes": {
       "$ref": "#/definitions/routes_optional"
@@ -606,6 +606,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "routes_optional": {

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -5,7 +5,6 @@
     "details",
     "document_type",
     "publishing_app",
-    "rendering_app",
     "schema_name",
     "title"
   ],
@@ -98,7 +97,7 @@
       }
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "routes": {
       "$ref": "#/definitions/routes_optional"
@@ -326,6 +325,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "routes_optional": {

--- a/formats/role_appointment.jsonnet
+++ b/formats/role_appointment.jsonnet
@@ -2,6 +2,7 @@
   document_type: "role_appointment",
   base_path: "optional",
   routes: "optional",
+  rendering_app: "optional",
   definitions: {
     details: {
       type: "object",


### PR DESCRIPTION
This commit makes `rendering_app` optional for role appointments since they won’t be rendered.