### PR TITLE
Expand Whitehall summary_organisations

### DIFF
--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -599,7 +599,55 @@
         ],
         "additionalProperties": false,
         "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
           "brand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "brand_colour_class": {
+            "type": "string"
+          },
+          "child_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "closed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "format": {
+            "type": "string"
+          },
+          "govuk_closed_status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "govuk_status": {
             "type": [
               "string",
               "null"
@@ -636,14 +684,66 @@
               },
               "image": {
                 "$ref": "#/definitions/image"
+              },
+              "type_class_name": {
+                "type": "string"
+              }
+            }
+          },
+          "parent_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
               }
             }
           },
           "separate_website": {
             "type": "boolean"
           },
+          "superseded_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "superseding_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
           "title": {
             "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
           },
           "works_with": {
             "type": "object",

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -675,7 +675,55 @@
         ],
         "additionalProperties": false,
         "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
           "brand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "brand_colour_class": {
+            "type": "string"
+          },
+          "child_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "closed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "format": {
+            "type": "string"
+          },
+          "govuk_closed_status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "govuk_status": {
             "type": [
               "string",
               "null"
@@ -712,14 +760,66 @@
               },
               "image": {
                 "$ref": "#/definitions/image"
+              },
+              "type_class_name": {
+                "type": "string"
+              }
+            }
+          },
+          "parent_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
               }
             }
           },
           "separate_website": {
             "type": "boolean"
           },
+          "superseded_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "superseding_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
           "title": {
             "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
           },
           "works_with": {
             "type": "object",

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -406,7 +406,55 @@
         ],
         "additionalProperties": false,
         "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
           "brand": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "brand_colour_class": {
+            "type": "string"
+          },
+          "child_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "closed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "format": {
+            "type": "string"
+          },
+          "govuk_closed_status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "govuk_status": {
             "type": [
               "string",
               "null"
@@ -443,14 +491,66 @@
               },
               "image": {
                 "$ref": "#/definitions/image"
+              },
+              "type_class_name": {
+                "type": "string"
+              }
+            }
+          },
+          "parent_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
               }
             }
           },
           "separate_website": {
             "type": "boolean"
           },
+          "superseded_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "superseding_organisations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uri"
+              },
+              "web_url": {
+                "description": "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
           "title": {
             "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
           },
           "works_with": {
             "type": "object",

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -122,9 +122,109 @@
             "null",
           ],
         },
+        format: {
+          type: "string"
+        },
+        updated_at: {
+          type: "string",
+          format: "date-time",
+        },
+        analytics_identifier: {
+          "$ref": "#/definitions/analytics_identifier",
+        },
+        content_id: {
+          "$ref": "#/definitions/guid",
+        },
+        abbreviation: {
+          type: "string"
+        },
+        brand_colour_class: {
+          type: "string",
+        },
+        closed_at: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+        govuk_status: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+        govuk_closed_status: {
+          type: [
+            "string",
+            "null",
+          ],
+        },
+        parent_organisations: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            id: {
+              type: "string",
+              format: "uri",
+            },
+            web_url: {
+              description: "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+              type: "string",
+              format: "uri",
+            }
+          }
+        },
+        child_organisations: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            id: {
+              type: "string",
+              format: "uri",
+            },
+            web_url: {
+              description: "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+              type: "string",
+              format: "uri",
+            }
+          }
+        },
+        superseded_organisations: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            id: {
+              type: "string",
+              format: "uri",
+            },
+            web_url: {
+              description: "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+              type: "string",
+              format: "uri",
+            }
+          }
+        },
+        superseding_organisations: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            id: {
+              type: "string",
+              format: "uri",
+            },
+            web_url: {
+              description: "There are references that this field is DEPRECATED and base_path should be used, although we need to keep /api as is for consumers compatibility",
+              type: "string",
+              format: "uri",
+            }
+          }
+        },
         logo: {
           type: "object",
           properties: {
+            type_class_name: {
+              type: "string",
+            },
             formatted_title: {
               type: "string",
             },


### PR DESCRIPTION
We need more information in `summary_organisations`.
The reason behind this is that we need to maintain the `/api/organisations` current endpoint, this endpoint is managed by Whitehall::Api and since organisations are being extracted from Whitehall we are moving this functionality to be rendered by collections app.

The main objective is to keep the endpoint exactly as it is but being fetched from content-store.
Without this change, the alternative is to find each content_item (organisation) by base_path and retrieve the necessary information, although this would cause several more requests. We think this is the best approach.

Trello: https://trello.com/c/p7ywlbk1/130-migrate-organisations-api