### PR TITLE
Add original primary publishing organisation

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/calendar/frontend/schema.json
+++ b/dist/formats/calendar/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/calendar/notification/schema.json
+++ b/dist/formats/calendar/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/calendar/publisher_v2/links.json
+++ b/dist/formats/calendar/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -192,6 +196,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -116,6 +116,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -116,6 +116,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
@@ -201,6 +205,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -30,6 +30,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -61,6 +61,10 @@
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -186,6 +190,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -117,6 +117,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -117,6 +117,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -164,6 +168,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -78,6 +78,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -112,6 +112,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -112,6 +112,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -193,6 +197,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -113,6 +113,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -113,6 +113,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
@@ -196,6 +200,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -58,6 +58,10 @@
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -118,6 +118,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -118,6 +118,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -206,6 +210,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -34,6 +34,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -64,6 +64,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "people": {
           "description": "Used to power Email Alert Api subscriptions for Whitehall content",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -114,6 +114,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -114,6 +114,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -195,6 +199,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -33,6 +33,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -110,6 +110,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -110,6 +110,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -184,6 +188,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -26,6 +26,10 @@
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -272,6 +272,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -272,6 +272,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -344,6 +348,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -272,6 +272,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -272,6 +272,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -344,6 +348,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -110,6 +110,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -110,6 +110,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
@@ -179,6 +183,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -55,6 +55,10 @@
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -109,6 +109,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -109,6 +109,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -186,6 +190,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -29,6 +29,10 @@
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -112,6 +112,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -112,6 +112,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -189,6 +193,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -32,6 +32,10 @@
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -117,6 +117,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -117,6 +117,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -212,6 +216,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -30,6 +30,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -143,6 +143,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -143,6 +143,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -247,6 +251,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/organisation/publisher_v2/links.json
+++ b/dist/formats/organisation/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/organisations_homepage/publisher_v2/links.json
+++ b/dist/formats/organisations_homepage/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -119,6 +119,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -119,6 +119,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -199,6 +203,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/person/publisher_v2/links.json
+++ b/dist/formats/person/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -276,6 +276,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -276,6 +276,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -352,6 +356,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -117,6 +117,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -117,6 +117,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -208,6 +212,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -37,6 +37,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -132,6 +132,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -132,6 +132,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
@@ -223,6 +227,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -30,6 +30,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -77,6 +77,10 @@
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "$ref": "#/definitions/guid_list"
         },

--- a/dist/formats/role/frontend/schema.json
+++ b/dist/formats/role/frontend/schema.json
@@ -134,6 +134,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/role/notification/schema.json
+++ b/dist/formats/role/notification/schema.json
@@ -134,6 +134,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -218,6 +222,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/role/publisher_v2/links.json
+++ b/dist/formats/role/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/role_appointment/frontend/schema.json
+++ b/dist/formats/role_appointment/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/role_appointment/notification/schema.json
+++ b/dist/formats/role_appointment/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -191,6 +195,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/role_appointment/publisher_v2/links.json
+++ b/dist/formats/role_appointment/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -115,6 +115,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -115,6 +115,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -195,6 +199,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -31,6 +31,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -115,6 +115,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -115,6 +115,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -191,6 +195,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -31,6 +31,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -123,6 +123,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -123,6 +123,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -207,6 +211,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -39,6 +39,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/service_sign_in/publisher_v2/links.json
+++ b/dist/formats/service_sign_in/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -275,6 +275,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -275,6 +275,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -347,6 +351,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -133,6 +133,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -133,6 +133,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -211,6 +215,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -117,6 +117,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -117,6 +117,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -214,6 +218,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -30,6 +30,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -114,6 +114,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -114,6 +114,10 @@
         "organisations": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -185,6 +189,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -26,6 +26,10 @@
         "organisations": {
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -119,6 +119,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -119,6 +119,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -207,6 +211,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -31,6 +31,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -115,6 +115,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -115,6 +115,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -191,6 +195,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -31,6 +31,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -186,6 +190,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -186,6 +190,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -183,6 +187,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -115,6 +115,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -115,6 +115,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -191,6 +195,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -111,6 +111,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",
@@ -192,6 +196,10 @@
         },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -27,6 +27,10 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/formats/corporate_information_page.jsonnet
+++ b/formats/corporate_information_page.jsonnet
@@ -61,6 +61,7 @@
       description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
       maxItems: 1,
     },
+    original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   },
   links: {
     corporate_information_pages: "",

--- a/formats/fatality_notice.jsonnet
+++ b/formats/fatality_notice.jsonnet
@@ -38,6 +38,7 @@
       description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
       maxItems: 1,
     },
+    original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
     roles: "Used to power Email Alert Api subscriptions for Whitehall content",
   },
   links: (import "shared/base_links.jsonnet") + {

--- a/formats/html_publication.jsonnet
+++ b/formats/html_publication.jsonnet
@@ -46,5 +46,6 @@
       description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
       maxItems: 1,
     },
+    original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   },
 }

--- a/formats/shared/base_links.jsonnet
+++ b/formats/shared/base_links.jsonnet
@@ -15,4 +15,5 @@
     description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
     maxItems: 1,
   },
+  original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
 }

--- a/formats/shared/whitehall_edition_links.jsonnet
+++ b/formats/shared/whitehall_edition_links.jsonnet
@@ -5,6 +5,7 @@
     description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
     maxItems: 1,
   },
+  original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   related_policies: "",
   topical_events: "",
   topics: "",


### PR DESCRIPTION
This commit adds a new link type for the organisation that originally published a particular page in whitehall. This is so we can display it for pages which have a different current organisational owner to that which originally published it.

Trello: https://trello.com/c/u80rFvuW/152-retain-org-ownership-history-of-content