### PR TITLE
Add acronym for organisations

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -343,6 +343,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "acronym": {
+          "description": "The organisation's acronym, if it has one.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -421,6 +421,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "acronym": {
+          "description": "The organisation's acronym, if it has one.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -203,6 +203,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "acronym": {
+          "description": "The organisation's acronym, if it has one.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -603,8 +603,11 @@
         ],
         "additionalProperties": false,
         "properties": {
-          "abbreviation": {
-            "type": "string"
+          "acronym": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "analytics_identifier": {
             "$ref": "#/definitions/analytics_identifier"

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -683,8 +683,11 @@
         ],
         "additionalProperties": false,
         "properties": {
-          "abbreviation": {
-            "type": "string"
+          "acronym": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "analytics_identifier": {
             "$ref": "#/definitions/analytics_identifier"

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -406,8 +406,11 @@
         ],
         "additionalProperties": false,
         "properties": {
-          "abbreviation": {
-            "type": "string"
+          "acronym": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "analytics_identifier": {
             "$ref": "#/definitions/analytics_identifier"

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -5,6 +5,13 @@
       type: "object",
       additionalProperties: false,
       properties: {
+        acronym: {
+          type: [
+            "string",
+            "null",
+          ],
+          description: "The organisation's acronym, if it has one.",
+        },
         analytics_identifier: {
           "$ref": "#/definitions/analytics_identifier",
         },

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -135,8 +135,11 @@
         content_id: {
           "$ref": "#/definitions/guid",
         },
-        abbreviation: {
-          type: "string"
+        acronym: {
+          type: [
+            "string",
+            "null",
+          ],
         },
         brand_colour_class: {
           type: "string",


### PR DESCRIPTION
This commit adds a new field to the organisation schema for an optional acronym, and amends the definition for an acronym in the organisations_homepage schema to match.

Trello: https://trello.com/c/lTOLkzUo/148-org-show-page-issues