### PR TITLE
Add organisations edition links

### DIFF
--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -131,7 +131,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "description": "Associated organisations for this document",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "original_primary_publishing_organisation": {
@@ -156,9 +156,8 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/frontend_links_with_base_path",
-          "maxItems": 1
+          "description": "The primary organisation for this document",
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "related_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -131,7 +131,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "description": "Associated organisations for this document",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "original_primary_publishing_organisation": {
@@ -156,9 +156,8 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/frontend_links_with_base_path",
-          "maxItems": 1
+          "description": "The primary organisation for this document",
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "related_to_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -215,7 +214,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "description": "Associated organisations for this document",
           "$ref": "#/definitions/guid_list"
         },
         "original_primary_publishing_organisation": {
@@ -232,9 +231,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
+          "description": "The primary organisation for this document",
+          "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -78,6 +78,14 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1,
           "minItems": 1
+        },
+        "organisations": {
+          "description": "Associated organisations for this document",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The primary organisation for this document",
+          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/formats/specialist_document.jsonnet
+++ b/formats/specialist_document.jsonnet
@@ -61,5 +61,11 @@
       minItems: 1,
       maxItems: 1,
     },
+    primary_publishing_organisation: {
+      description: "The primary organisation for this document",
+    },
+    organisations: {
+      description: "Associated organisations for this document",
+    },
   },
 }


### PR DESCRIPTION
https://trello.com/c/Hf90xZZq/219-drop-down-for-organisations-in-eu-exit-statutory-instrument-specialist-publisher-document-type

Adds edition links for `primary_publishing_organisation` and `organisations`

see https://github.com/alphagov/govuk-content-schemas/pull/778