### PR TITLE
Add promotional features to organisations

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -502,6 +502,76 @@
         "ordered_ministers": {
           "$ref": "#/definitions/people"
         },
+        "ordered_promotional_features": {
+          "description": "A set of promotional features to display for the organisation. Turn into proper links once organisations are fully migrated.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "items"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "summary",
+                    "double_width"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "double_width": {
+                      "type": "boolean"
+                    },
+                    "href": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "image": {
+                      "$ref": "#/definitions/image"
+                    },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "title",
+                          "href"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "href": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "ordered_special_representatives": {
           "$ref": "#/definitions/people"
         },

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -580,6 +580,76 @@
         "ordered_ministers": {
           "$ref": "#/definitions/people"
         },
+        "ordered_promotional_features": {
+          "description": "A set of promotional features to display for the organisation. Turn into proper links once organisations are fully migrated.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "items"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "summary",
+                    "double_width"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "double_width": {
+                      "type": "boolean"
+                    },
+                    "href": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "image": {
+                      "$ref": "#/definitions/image"
+                    },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "title",
+                          "href"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "href": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "ordered_special_representatives": {
           "$ref": "#/definitions/people"
         },

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -359,6 +359,76 @@
         "ordered_ministers": {
           "$ref": "#/definitions/people"
         },
+        "ordered_promotional_features": {
+          "description": "A set of promotional features to display for the organisation. Turn into proper links once organisations are fully migrated.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "items"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "summary",
+                    "double_width"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "double_width": {
+                      "type": "boolean"
+                    },
+                    "href": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "image": {
+                      "$ref": "#/definitions/image"
+                    },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "title",
+                          "href"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "href": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "ordered_special_representatives": {
           "$ref": "#/definitions/people"
         },

--- a/examples/organisation/frontend/organisation.json
+++ b/examples/organisation/frontend/organisation.json
@@ -82,6 +82,37 @@
         "document_type": "Collection"
       }
     ],
+    "ordered_promotional_features":[
+      {
+        "title": "Transparency",
+        "items": [
+          {
+            "title": "",
+            "href": "https://www.gov.uk/government/policies?keywords=&topics%5B%5D=government-efficiency-transparency-and-accountability&departments%5B%5D=all",
+            "summary": "Greater transparency across government is at the heart of our commitment to let you hold politicians and public bodies to account.",
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/1/s300_Transparency.jpg",
+              "alt_text": "Magnifying glass studying a graph"
+            },
+            "double_width": false,
+            "links": [
+              {
+                "title": "Single departmental plans",
+                "href": "https://www.gov.uk/government/collections/a-country-that-works-for-everyone-the-governments-plan"
+              },
+              {
+                "title": "Prime Minister's and Cabinet Office ministers' transparency publications",
+                "href": "https://www.gov.uk/government/collections/ministers-transparency-publications"
+              },
+              {
+                "title": "Government transparency data",
+                "href": "https://www.gov.uk/government/publications?keywords=&publication_filter_option=transparency-data&topics%5B%5D=all&departments%5B%5D=all&world_locations%5B%5D=all&direction=before&date=2013-05-01"
+              }
+            ]
+          }
+        ]
+      }
+    ],
     "ordered_ministers": [
       {
         "name_prefix": "The Rt Hon",

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -146,6 +146,76 @@
           },
           description: "A set of featured documents to display for the organisation. Turn into proper links once organisations are fully migrated.",
         },
+        ordered_promotional_features: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "title",
+              "items",
+            ],
+            properties: {
+              title: {
+                type: "string",
+              },
+              items: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: [
+                    "summary",
+                    "double_width",
+                  ],
+                  properties: {
+                    title: {
+                      type: [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    href: {
+                      type: [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    summary: {
+                      type: "string",
+                    },
+                    image: {
+                      "$ref": "#/definitions/image",
+                    },
+                    double_width: {
+                      type: "boolean",
+                    },
+                    links: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        additionalProperties: false,
+                        required: [
+                          "title",
+                          "href",
+                        ],
+                        properties: {
+                          title: {
+                            type: "string",
+                          },
+                          href: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          description: "A set of promotional features to display for the organisation. Turn into proper links once organisations are fully migrated.",
+        },
         ordered_ministers: {
           "$ref": "#/definitions/people",
         },


### PR DESCRIPTION
This commit adds promotional features to organisations, which are used by some organisations to add extra sections to their homepages.

Trello: https://trello.com/c/zzD0d2N5/196-add-promotional-features-to-organisation-content-items