### PR TITLE
Add URL to organisation status

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -617,6 +617,12 @@
                 "null"
               ],
               "format": "date-time"
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         },

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -695,6 +695,12 @@
                 "null"
               ],
               "format": "date-time"
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         },

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -474,6 +474,12 @@
                 "null"
               ],
               "format": "date-time"
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         },

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -266,6 +266,12 @@
                 "transitioning",
               ],
             },
+            url: {
+              type: [
+                "string",
+                "null",
+              ],
+            },
             updated_at: {
               type: [
                 "string",


### PR DESCRIPTION
This commit adds a new URL field to the organisation status. This will be used for non-live organisations to point to their current or new website.