### PR TITLE
Fix contact schema

### DIFF
--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -207,7 +207,7 @@
       ]
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "scheduled_publishing_delay_seconds": {
       "anyOf": [
@@ -302,8 +302,7 @@
     "details": {
       "type": "object",
       "required": [
-        "title",
-        "contact_groups"
+        "title"
       ],
       "additionalProperties": false,
       "properties": {
@@ -351,7 +350,10 @@
           "type": "string"
         },
         "description": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "email_addresses": {
           "type": "array",
@@ -741,6 +743,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "scheduled_publishing_delay_seconds": {

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -264,7 +264,7 @@
       }
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "routes": {
       "$ref": "#/definitions/routes_optional"
@@ -361,8 +361,7 @@
     "details": {
       "type": "object",
       "required": [
-        "title",
-        "contact_groups"
+        "title"
       ],
       "additionalProperties": false,
       "properties": {
@@ -410,7 +409,10 @@
           "type": "string"
         },
         "description": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "email_addresses": {
           "type": "array",
@@ -812,6 +814,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "routes_optional": {

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -5,7 +5,6 @@
     "details",
     "document_type",
     "publishing_app",
-    "rendering_app",
     "schema_name",
     "title"
   ],
@@ -90,7 +89,7 @@
       }
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "routes": {
       "$ref": "#/definitions/routes_optional"
@@ -167,8 +166,7 @@
     "details": {
       "type": "object",
       "required": [
-        "title",
-        "contact_groups"
+        "title"
       ],
       "additionalProperties": false,
       "properties": {
@@ -213,7 +211,10 @@
           "type": "string"
         },
         "description": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "email_addresses": {
           "type": "array",
@@ -527,6 +528,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "routes_optional": {

--- a/formats/contact.jsonnet
+++ b/formats/contact.jsonnet
@@ -2,11 +2,14 @@
   document_type: "contact",
   base_path: "optional",
   routes: "optional",
+  rendering_app: "optional",
   definitions: {
     details: {
       type: "object",
       additionalProperties: false,
-      required: ["title", "contact_groups"],
+      required: [
+        "title"
+      ],
       properties: {
         slug: {
           type: "string",
@@ -15,7 +18,10 @@
           type: "string",
         },
         description: {
-          type: "string",
+          type: [
+            "string",
+            "null",
+          ],
         },
         quick_links: {
           type: "array",


### PR DESCRIPTION
This commit fixes the contact schema to match reality:

* `rendering_app` is made optional since contacts are not normally rendered as standalone items
* `contact_groups` is made optional since whitehall doesn’t support them
* `description` is allowed to be null since it’s optional in whitehall