### PR TITLE
Allow email document supertype in finders

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -459,6 +459,12 @@
         "document_type": {
           "type": "string"
         },
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },
@@ -481,6 +487,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "policies": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -514,6 +514,12 @@
         "document_type": {
           "type": "string"
         },
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },
@@ -536,6 +542,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "policies": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -311,6 +311,12 @@
         "document_type": {
           "type": "string"
         },
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },
@@ -333,6 +339,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "policies": {
           "type": "array",
           "items": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -486,6 +486,12 @@
         "document_type": {
           "type": "string"
         },
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -551,6 +551,12 @@
         "document_type": {
           "type": "string"
         },
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -328,6 +328,12 @@
         "document_type": {
           "type": "string"
         },
+        "email_document_supertype": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "type": "string"
         },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -19,6 +19,12 @@
       document_type: {
         type: "string",
       },
+      email_document_supertype: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
       organisations: {
         type: "array",
         items: {
@@ -41,6 +47,12 @@
     type: "object",
     additionalProperties: false,
     properties: {
+      email_document_supertype: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
       policies: {
         type: "array",
         items: {


### PR DESCRIPTION
We want to use this for the new organisation finder as it's more likely to be accurate than specifying all the document types.

https://trello.com/c/fSv9RhjE/199-migrate-latest-pages-from-organisations