### PR TITLE
Make title and intro mandatory for step by steps

### DIFF
--- a/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/dist/formats/step_by_step_nav/frontend/schema.json
@@ -543,6 +543,8 @@
     "step_by_step_nav": {
       "type": "object",
       "required": [
+        "title",
+        "introduction",
         "steps"
       ],
       "additionalProperties": false,

--- a/dist/formats/step_by_step_nav/notification/schema.json
+++ b/dist/formats/step_by_step_nav/notification/schema.json
@@ -608,6 +608,8 @@
     "step_by_step_nav": {
       "type": "object",
       "required": [
+        "title",
+        "introduction",
         "steps"
       ],
       "additionalProperties": false,

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -407,6 +407,8 @@
     "step_by_step_nav": {
       "type": "object",
       "required": [
+        "title",
+        "introduction",
         "steps"
       ],
       "additionalProperties": false,

--- a/examples/step_by_step_nav/frontend/step_by_step_nav.json
+++ b/examples/step_by_step_nav/frontend/step_by_step_nav.json
@@ -14,6 +14,8 @@
   },
   "details": {
     "step_by_step_nav": {
+      "title": "Get a divorce: step by step",
+      "introduction": "<p>Check what you need to do to get a divorce.</p>",
       "steps": [
         {
           "title": "Get support and advice",

--- a/examples/step_by_step_nav/publisher_v2/step_by_step_nav.json
+++ b/examples/step_by_step_nav/publisher_v2/step_by_step_nav.json
@@ -22,6 +22,13 @@
   },
   "details": {
     "step_by_step_nav": {
+      "title": "Get a divorce: step by step",
+      "introduction": [
+        {
+          "content_type": "text/govspeak",
+          "content": "Check what you need to do to get a divorce."
+        }
+      ],
       "steps": [
         {
           "title": "Get support and advice",

--- a/formats/shared/definitions/_step_by_step_nav.jsonnet
+++ b/formats/shared/definitions/_step_by_step_nav.jsonnet
@@ -3,6 +3,8 @@
     type: "object",
     additionalProperties: false,
     required: [
+      "title",
+      "introduction",
       "steps",
     ],
     properties: {


### PR DESCRIPTION
They're always populated by the publisher and are required for rendering in the
view.

This was causing an intermittent failure on Collections tests because one of the examples didn't have the title.