### PR TITLE
Add field for number of important board members

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -376,6 +376,10 @@
           "description": "Whether the organisation is exempt from Freedom of Information requests.",
           "type": "boolean"
         },
+        "important_board_members": {
+          "description": "The number of board members that will have photos displayed for them.",
+          "type": "integer"
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -454,6 +454,10 @@
           "description": "Whether the organisation is exempt from Freedom of Information requests.",
           "type": "boolean"
         },
+        "important_board_members": {
+          "description": "The number of board members that will have photos displayed for them.",
+          "type": "integer"
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -233,6 +233,10 @@
           "description": "Whether the organisation is exempt from Freedom of Information requests.",
           "type": "boolean"
         },
+        "important_board_members": {
+          "description": "The number of board members that will have photos displayed for them.",
+          "type": "integer"
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/formats/organisation.jsonnet
+++ b/formats/organisation.jsonnet
@@ -238,6 +238,10 @@
         ordered_special_representatives: {
           "$ref": "#/definitions/people",
         },
+        important_board_members: {
+          type: "integer",
+          description: "The number of board members that will have photos displayed for them.",
+        },
         organisation_featuring_priority: {
           type: "string",
           enum: [


### PR DESCRIPTION
This commit adds a new field to the organisation schema for the number of important board members. This field determines how many board members will have their photos displayed on the organisation’s home page.

Trello: https://trello.com/c/bQTgWtGh/43-img-missing