### PR TITLE
Add content purpose supergroup to finder schema

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -456,6 +456,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },
@@ -487,6 +493,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "email_document_supertype": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -511,6 +511,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },
@@ -542,6 +548,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "email_document_supertype": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -308,6 +308,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },
@@ -339,6 +345,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "email_document_supertype": {
           "type": "array",
           "items": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -483,6 +483,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -548,6 +548,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -325,6 +325,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "content_purpose_supergroup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "document_type": {
           "type": "string"
         },

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -19,6 +19,12 @@
       document_type: {
         type: "string",
       },
+      content_purpose_supergroup: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
       email_document_supertype: {
         type: "array",
         items: {
@@ -47,6 +53,12 @@
     type: "object",
     additionalProperties: false,
     properties: {
+      content_purpose_supergroup: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
       email_document_supertype: {
         type: "array",
         items: {


### PR DESCRIPTION
This lets us create finders using [content purpose supergroups](https://github.com/alphagov/govuk_document_types/blob/5d572a6439c20593d448c83cfc68e21e82d49b91/data/supertypes.yml#L486-L572)!

We need this in this instance so we can match up the latest content for orgs
page with what is in the atom feeds and in the "latest content from" section
on the org pages themselves.