### PR TITLE
Duplicate news article links as edition links

### DIFF
--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -171,6 +171,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "topical_events": {
+          "description": "The topical events this content item relates to.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "topics": {
@@ -178,9 +179,11 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "world_locations": {
+          "description": "The world locations this content item is about.",
           "$ref": "#/definitions/frontend_links"
         },
         "worldwide_organisations": {
+          "description": "The worldwide organisations associated with this content item.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -171,6 +171,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "topical_events": {
+          "description": "The topical events this content item relates to.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "topics": {
@@ -178,9 +179,11 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "world_locations": {
+          "description": "The world locations this content item is about.",
           "$ref": "#/definitions/frontend_links"
         },
         "worldwide_organisations": {
+          "description": "The worldwide organisations associated with this content item.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
@@ -260,6 +263,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
+          "description": "The topical events this content item relates to.",
           "$ref": "#/definitions/guid_list"
         },
         "topics": {
@@ -267,9 +271,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {
+          "description": "The world locations this content item is about.",
           "$ref": "#/definitions/guid_list"
         },
         "worldwide_organisations": {
+          "description": "The worldwide organisations associated with this content item.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -68,6 +68,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
+          "description": "The topical events this content item relates to.",
           "$ref": "#/definitions/guid_list"
         },
         "topics": {
@@ -75,9 +76,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {
+          "description": "The world locations this content item is about.",
           "$ref": "#/definitions/guid_list"
         },
         "worldwide_organisations": {
+          "description": "The worldwide organisations associated with this content item.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -55,8 +55,33 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "topical_events": {
+          "description": "The topical events this content item relates to.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "description": "The world locations this content item is about.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisations": {
+          "description": "The worldwide organisations associated with this content item.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/formats/news_article.jsonnet
+++ b/formats/news_article.jsonnet
@@ -45,10 +45,21 @@
   links: (import "shared/base_links.jsonnet") + {
     related_policies: "",
     ministers: "",
-    topical_events: "",
-    world_locations: "",
-    worldwide_organisations: "",
+    topical_events: "The topical events this content item relates to.",
+    world_locations: "The world locations this content item is about.",
+    worldwide_organisations: "The worldwide organisations associated with this content item.",
     roles: "Used to power Email Alert Api subscriptions for Whitehall content",
     people: "Used to power Email Alert Api subscriptions for Whitehall content",
   },
+  edition_links: (import "shared/base_edition_links.jsonnet") + {
+    topical_events: "The topical events this content item relates to.",
+    world_locations: "The world locations this content item is about.",
+    worldwide_organisations: "The worldwide organisations associated with this content item.",
+    organisations: "All organisations linked to this content item. This should include lead organisations.",
+    primary_publishing_organisation: {
+      description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+      maxItems: 1,
+    },
+    original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+  }
 }


### PR DESCRIPTION
https://trello.com/c/4sTwhdPN/87-make-associations-available-to-select-when-creating-a-document-l

The new Content Publisher app will take the approach of using edition
links wherever possible, the key advantage being that edition links are
part of the published content and can therefore be scheduled/versioned.

Initially we would like to support a subset of the current links, such
as world_locations and organisations; other kinds of links, such as
roles and people, are technically more challenging and will come later.

Note this should have no effect on current publishing tools, as existing
linkset links will be used if edition links do not exist for a document.