### PR TITLE
Add property to hide chapter navigation in guides

### DIFF
--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -318,6 +318,10 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
+        "hide_chapter_navigation": {
+          "description": "Hide guide elements if this guide is part of a step by step navigation",
+          "type": "boolean"
+        },
         "parts": {
           "description": "List of guide parts",
           "$ref": "#/definitions/parts"

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -368,6 +368,10 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
+        "hide_chapter_navigation": {
+          "description": "Hide guide elements if this guide is part of a step by step navigation",
+          "type": "boolean"
+        },
         "parts": {
           "description": "List of guide parts",
           "$ref": "#/definitions/parts"

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -171,6 +171,10 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
+        "hide_chapter_navigation": {
+          "description": "Hide guide elements if this guide is part of a step by step navigation",
+          "type": "boolean"
+        },
         "parts": {
           "description": "List of guide parts",
           "$ref": "#/definitions/parts"

--- a/examples/guide/frontend/guide-with-step-navs.json
+++ b/examples/guide/frontend/guide-with-step-navs.json
@@ -882,6 +882,7 @@
   },
   "description": "The English national curriculum means children in different schools (at primary and secondary level) study the same subjects to similar standards - it's split into key stages with tests",
   "details": {
+    "hide_chapter_navigation": true,
     "parts": [
       {
         "title": "Overview",

--- a/formats/guide.jsonnet
+++ b/formats/guide.jsonnet
@@ -12,6 +12,10 @@
         external_related_links: {
           "$ref": "#/definitions/external_related_links",
         },
+        hide_chapter_navigation: {
+          type: "boolean",
+          description: "Hide guide elements if this guide is part of a step by step navigation"
+        },
       },
     },
   },


### PR DESCRIPTION
- will be used to control the display of contents list and other guide elements where the guide is inside a step by step navigation

Trello card: https://trello.com/c/RNsA7E4Q/763-hide-chapter-navigation-on-mainstream-guides

Supercedes #802.