### PR TITLE
Duplicate stat data set links as edition links

### DIFF
--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -52,9 +52,22 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         }
       }
     },

--- a/formats/statistical_data_set.jsonnet
+++ b/formats/statistical_data_set.jsonnet
@@ -34,4 +34,12 @@
       },
     },
   },
+  edition_links: (import "shared/base_edition_links.jsonnet") + {
+    organisations: "All organisations linked to this content item. This should include lead organisations.",
+    primary_publishing_organisation: {
+      description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+      maxItems: 1,
+    },
+    original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+  }
 }


### PR DESCRIPTION
The new Content Publisher app will take the approach of using edition
links wherever possible, the key advantage being that edition links are
part of the published content and can therefore be scheduled/versioned.

Note this should have no effect on current publishing tools, as existing
linkset links will be used if edition links do not exist for a document.