### PR TITLE
Add example guide with hide chapter navigation but not in a step by step

### DIFF
--- a/examples/guide/frontend/guide-with-hide-navigation.json
+++ b/examples/guide/frontend/guide-with-hide-navigation.json
@@ -1,0 +1,842 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/renew-adult-passport",
+  "content_id": "82248bb1-c4d6-41e0-9494-d98123475626",
+  "content_purpose_document_supertype": "guidance",
+  "content_purpose_supergroup": "guidance_and_regulation",
+  "content_purpose_subgroup": "guidance",
+  "document_type": "guide",
+  "email_document_supertype": "other",
+  "first_published_at": "2012-10-10T19:37:20.000+00:00",
+  "government_document_supertype": "other",
+  "locale": "en",
+  "navigation_document_supertype": "guidance",
+  "phase": "live",
+  "public_updated_at": "2015-01-12T00:01:07.000+00:00",
+  "publishing_app": "publisher",
+  "publishing_scheduled_at": null,
+  "rendering_app": "government-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "guide",
+  "search_user_need_document_supertype": "core",
+  "title": "Renew or replace your adult passport",
+  "updated_at": "2018-08-02T08:58:29.045Z",
+  "user_journey_document_supertype": "thing",
+  "withdrawn_notice": {},
+  "publishing_request_id": "1926-1531408404.622-213.86.153.236-14532",
+  "links": {
+    "mainstream_browse_pages": [
+    {
+      "api_path": "/api/content/browse/abroad/passports",
+      "base_path": "/browse/abroad/passports",
+      "content_id": "dd842862-e148-4fe3-b363-e57d6a2689aa",
+      "description": "Eligibility, fees, applying, renewing and updating",
+      "document_type": "mainstream_browse_page",
+      "locale": "en",
+      "public_updated_at": "2016-12-05T17:00:29Z",
+      "schema_name": "mainstream_browse_page",
+      "title": "Passports",
+      "withdrawn": false,
+      "links": {},
+      "api_url": "https://www.gov.uk/api/content/browse/abroad/passports",
+      "web_url": "https://www.gov.uk/browse/abroad/passports"
+    }
+    ],
+    "meets_user_needs": [
+    {
+      "api_path": "/api/content/needs/apply-for-or-renew-a-passport",
+      "base_path": "/needs/apply-for-or-renew-a-passport",
+      "content_id": "add6e7e9-9e49-40ea-b230-316197d43b70",
+      "document_type": "need",
+      "locale": "en",
+      "schema_name": "need",
+      "title": "As a British person, I need to apply for or renew a passport, so that I can travel across borders (100129)",
+      "withdrawn": false,
+      "details": {
+        "applies_to_all_organisations": false,
+        "benefit": "I can travel across borders ",
+        "goal": "apply for or renew a passport",
+        "impact": "Has serious consequences for your users and/or their customers",
+        "justifications": [
+        "It's something only government does",
+        "There is clear demand for it from users",
+        "It's something the government provides/does/pays for"
+        ],
+        "met_when": [
+        "the user knows the rules about passport photos",
+        "the user knows how long it takes to get a passport",
+        "the user knows the different ways they can apply for a passport, including Check and Send",
+        "understands the eligibility criteria to get a passport",
+        "the user knows the rules about when their passport may be taken away",
+        "knows what to do if they are abroad",
+        "knows how to get dual citizenship if they already have a passport from another country",
+        "knows how to renew a passport",
+        "as a British national born before 2 September 1929, knows how to get a free passport"
+        ],
+        "role": "British person ",
+        "yearly_need_views": 13164031,
+        "yearly_user_contacts": 1028,
+        "need_id": "100129"
+      },
+      "links": {},
+      "api_url": "https://www.gov.uk/api/content/needs/apply-for-or-renew-a-passport",
+      "web_url": "https://www.gov.uk/needs/apply-for-or-renew-a-passport"
+    }
+    ],
+    "ordered_related_items": [
+    {
+      "api_path": "/api/content/report-a-lost-or-stolen-passport",
+      "base_path": "/report-a-lost-or-stolen-passport",
+      "content_id": "f02fc2c9-f5ff-4ea2-acc4-730bbda957bb",
+      "description": "What you need to do if your passport has been lost or stolen and you need to travel urgently - emergency travel document and replacement passport.",
+      "document_type": "transaction",
+      "locale": "en",
+      "public_updated_at": "2018-07-30T13:20:40Z",
+      "schema_name": "transaction",
+      "title": "Cancel a lost or stolen passport",
+      "withdrawn": false,
+      "links": {
+        "mainstream_browse_pages": [
+        {
+          "api_path": "/api/content/browse/abroad/passports",
+          "base_path": "/browse/abroad/passports",
+          "content_id": "dd842862-e148-4fe3-b363-e57d6a2689aa",
+          "description": "Eligibility, fees, applying, renewing and updating",
+          "document_type": "mainstream_browse_page",
+          "locale": "en",
+          "public_updated_at": "2016-12-05T17:00:29Z",
+          "schema_name": "mainstream_browse_page",
+          "title": "Passports",
+          "withdrawn": false,
+          "links": {
+            "parent": [
+            {
+              "api_path": "/api/content/browse/abroad",
+              "base_path": "/browse/abroad",
+              "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+              "description": "Includes renewing passports and travel advice by country",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-04-08T10:48:43Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Passports, travel and living abroad",
+              "withdrawn": false,
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/browse/abroad",
+              "web_url": "https://www.gov.uk/browse/abroad"
+            }
+            ]
+          },
+          "api_url": "https://www.gov.uk/api/content/browse/abroad/passports",
+          "web_url": "https://www.gov.uk/browse/abroad/passports"
+        }
+        ]
+      },
+      "api_url": "https://www.gov.uk/api/content/report-a-lost-or-stolen-passport",
+      "web_url": "https://www.gov.uk/report-a-lost-or-stolen-passport"
+    },
+    {
+      "api_path": "/api/content/apply-first-adult-passport",
+      "base_path": "/apply-first-adult-passport",
+      "content_id": "a6657a49-a0b8-4f86-a3a4-131c681e07bd",
+      "description": "Apply for your first adult British passport - who can apply, how long it takes, costs, how to apply, documents you need, passport interviews",
+      "document_type": "guide",
+      "locale": "en",
+      "public_updated_at": "2015-01-12T00:01:06Z",
+      "schema_name": "guide",
+      "title": "Getting your first adult passport",
+      "withdrawn": false,
+      "links": {
+        "mainstream_browse_pages": [
+        {
+          "api_path": "/api/content/browse/abroad/passports",
+          "base_path": "/browse/abroad/passports",
+          "content_id": "dd842862-e148-4fe3-b363-e57d6a2689aa",
+          "description": "Eligibility, fees, applying, renewing and updating",
+          "document_type": "mainstream_browse_page",
+          "locale": "en",
+          "public_updated_at": "2016-12-05T17:00:29Z",
+          "schema_name": "mainstream_browse_page",
+          "title": "Passports",
+          "withdrawn": false,
+          "links": {
+            "parent": [
+            {
+              "api_path": "/api/content/browse/abroad",
+              "base_path": "/browse/abroad",
+              "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+              "description": "Includes renewing passports and travel advice by country",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-04-08T10:48:43Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Passports, travel and living abroad",
+              "withdrawn": false,
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/browse/abroad",
+              "web_url": "https://www.gov.uk/browse/abroad"
+            }
+            ]
+          },
+          "api_url": "https://www.gov.uk/api/content/browse/abroad/passports",
+          "web_url": "https://www.gov.uk/browse/abroad/passports"
+        }
+        ]
+      },
+      "api_url": "https://www.gov.uk/api/content/apply-first-adult-passport",
+      "web_url": "https://www.gov.uk/apply-first-adult-passport"
+    },
+    {
+      "api_path": "/api/content/get-a-passport-urgently",
+      "base_path": "/get-a-passport-urgently",
+      "content_id": "89426190-c98e-4997-8149-7e0f03aecc8d",
+      "description": "Renew or replace a passport urgently with the 1 day Premium service or the 1 week Fast Track service",
+      "document_type": "guide",
+      "locale": "en",
+      "public_updated_at": "2016-02-02T08:00:00Z",
+      "schema_name": "guide",
+      "title": "Get a passport urgently",
+      "withdrawn": false,
+      "links": {
+        "mainstream_browse_pages": [
+        {
+          "api_path": "/api/content/browse/abroad/passports",
+          "base_path": "/browse/abroad/passports",
+          "content_id": "dd842862-e148-4fe3-b363-e57d6a2689aa",
+          "description": "Eligibility, fees, applying, renewing and updating",
+          "document_type": "mainstream_browse_page",
+          "locale": "en",
+          "public_updated_at": "2016-12-05T17:00:29Z",
+          "schema_name": "mainstream_browse_page",
+          "title": "Passports",
+          "withdrawn": false,
+          "links": {
+            "parent": [
+            {
+              "api_path": "/api/content/browse/abroad",
+              "base_path": "/browse/abroad",
+              "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+              "description": "Includes renewing passports and travel advice by country",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-04-08T10:48:43Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Passports, travel and living abroad",
+              "withdrawn": false,
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/browse/abroad",
+              "web_url": "https://www.gov.uk/browse/abroad"
+            }
+            ]
+          },
+          "api_url": "https://www.gov.uk/api/content/browse/abroad/passports",
+          "web_url": "https://www.gov.uk/browse/abroad/passports"
+        }
+        ]
+      },
+      "api_url": "https://www.gov.uk/api/content/get-a-passport-urgently",
+      "web_url": "https://www.gov.uk/get-a-passport-urgently"
+    },
+    {
+      "api_path": "/api/content/get-a-child-passport",
+      "base_path": "/get-a-child-passport",
+      "content_id": "dabfc6b3-d88c-458f-a9fb-f286b987509b",
+      "description": "Get a passport for your child or baby - renewals and first child passports, application form, supporting paperwork, eligibility, costs\r\n",
+      "document_type": "guide",
+      "locale": "en",
+      "public_updated_at": "2014-12-23T16:15:15Z",
+      "schema_name": "guide",
+      "title": "Get a passport for your child",
+      "withdrawn": false,
+      "links": {
+        "mainstream_browse_pages": [
+        {
+          "api_path": "/api/content/browse/abroad/passports",
+          "base_path": "/browse/abroad/passports",
+          "content_id": "dd842862-e148-4fe3-b363-e57d6a2689aa",
+          "description": "Eligibility, fees, applying, renewing and updating",
+          "document_type": "mainstream_browse_page",
+          "locale": "en",
+          "public_updated_at": "2016-12-05T17:00:29Z",
+          "schema_name": "mainstream_browse_page",
+          "title": "Passports",
+          "withdrawn": false,
+          "links": {
+            "parent": [
+            {
+              "api_path": "/api/content/browse/abroad",
+              "base_path": "/browse/abroad",
+              "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+              "description": "Includes renewing passports and travel advice by country",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-04-08T10:48:43Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Passports, travel and living abroad",
+              "withdrawn": false,
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/browse/abroad",
+              "web_url": "https://www.gov.uk/browse/abroad"
+            }
+            ]
+          },
+          "api_url": "https://www.gov.uk/api/content/browse/abroad/passports",
+          "web_url": "https://www.gov.uk/browse/abroad/passports"
+        }
+        ]
+      },
+      "api_url": "https://www.gov.uk/api/content/get-a-child-passport",
+      "web_url": "https://www.gov.uk/get-a-child-passport"
+    },
+    {
+      "api_path": "/api/content/passport-fees",
+      "base_path": "/passport-fees",
+      "content_id": "8b59b474-9775-4366-97ee-97a66740411c",
+      "description": "How much it costs to renew or get a new adult or child passport and ways you can pay",
+      "document_type": "answer",
+      "locale": "en",
+      "public_updated_at": "2015-01-12T00:01:06Z",
+      "schema_name": "answer",
+      "title": "Passport fees",
+      "withdrawn": false,
+      "links": {
+        "mainstream_browse_pages": [
+        {
+          "api_path": "/api/content/browse/abroad/passports",
+          "base_path": "/browse/abroad/passports",
+          "content_id": "dd842862-e148-4fe3-b363-e57d6a2689aa",
+          "description": "Eligibility, fees, applying, renewing and updating",
+          "document_type": "mainstream_browse_page",
+          "locale": "en",
+          "public_updated_at": "2016-12-05T17:00:29Z",
+          "schema_name": "mainstream_browse_page",
+          "title": "Passports",
+          "withdrawn": false,
+          "links": {
+            "parent": [
+            {
+              "api_path": "/api/content/browse/abroad",
+              "base_path": "/browse/abroad",
+              "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+              "description": "Includes renewing passports and travel advice by country",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-04-08T10:48:43Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Passports, travel and living abroad",
+              "withdrawn": false,
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/browse/abroad",
+              "web_url": "https://www.gov.uk/browse/abroad"
+            }
+            ]
+          },
+          "api_url": "https://www.gov.uk/api/content/browse/abroad/passports",
+          "web_url": "https://www.gov.uk/browse/abroad/passports"
+        }
+        ]
+      },
+      "api_url": "https://www.gov.uk/api/content/passport-fees",
+      "web_url": "https://www.gov.uk/passport-fees"
+    }
+    ],
+    "organisations": [
+    {
+      "analytics_identifier": "EA66",
+      "api_path": "/api/content/government/organisations/hm-passport-office",
+      "base_path": "/government/organisations/hm-passport-office",
+      "content_id": "3a96a1e0-21e3-4aae-8e84-f90860ed3dbf",
+      "document_type": "organisation",
+      "locale": "en",
+      "public_updated_at": "2014-10-15T14:35:28Z",
+      "schema_name": "organisation",
+      "title": "HM Passport Office",
+      "withdrawn": false,
+      "details": {
+        "acronym": "HM Passport Office",
+        "body": "<div class=\"govspeak\"><p>HM Passport Office is the sole issuer of UK passports and responsible for civil registration services through the General Register Office.</p>\n\n<p><abbr title=\"HM Passport Office\">HM Passport Office</abbr> is part of the <a class=\"brand__color\" href=\"/government/organisations/home-office\">Home Office</a>.</p>\n</div>",
+        "brand": "home-office",
+        "logo": {
+          "formatted_title": "HM Passport<br/>Office",
+          "crest": "ho"
+        },
+        "foi_exempt": false,
+        "ordered_corporate_information_pages": [
+        {
+          "title": "Our governance",
+          "href": "/government/organisations/hm-passport-office/about/our-governance"
+        },
+        {
+          "title": "Equality and diversity",
+          "href": "/government/organisations/hm-passport-office/about/equality-and-diversity"
+        },
+        {
+          "title": "Complaints procedure",
+          "href": "/government/organisations/hm-passport-office/about/complaints-procedure"
+        },
+        {
+          "title": "Corporate reports",
+          "href": "/government/publications?departments%5B%5D=hm-passport-office&publication_type=corporate-reports"
+        },
+        {
+          "title": "Transparency data",
+          "href": "/government/publications?departments%5B%5D=hm-passport-office&publication_type=transparency-data"
+        },
+        {
+          "title": "Working for HM Passport Office",
+          "href": "/government/organisations/hm-passport-office/about/recruitment"
+        },
+        {
+          "title": "Jobs",
+          "href": "https://www.civilservicejobs.service.gov.uk/csr"
+        }
+        ],
+        "secondary_corporate_information_pages": "Read about the types of information we routinely publish in our <a class=\"brand__color\" href=\"/government/organisations/hm-passport-office/about/publication-scheme\">Publication scheme</a>. Our <a class=\"brand__color\" href=\"/government/organisations/hm-passport-office/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
+        "ordered_featured_links": [
+        {
+          "title": "Renew your adult passport",
+          "href": "https://www.gov.uk/renew-adult-passport"
+        },
+        {
+          "title": "Buy birth, death or marriage certificates",
+          "href": "https://www.gov.uk/order-copy-birth-death-marriage-certificate"
+        },
+        {
+          "title": "Privacy policy",
+          "href": "https://www.gov.uk/government/publications/ips-privacy-policy"
+        }
+        ],
+        "ordered_featured_documents": [
+        {
+          "title": "Gemalto awarded the new passport contract",
+          "href": "/government/news/gemalto-awarded-the-new-passport-contract",
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62151/s960_blue_passport_govuk.jpg",
+            "alt_text": "Blue passport."
+          },
+          "summary": "<div class=\"govspeak\"><p>Gemalto UK Ltd have been awarded the UK passport manufacturing and personalisation contract by Her Majesty’s Passport Office today.</p>\n</div>",
+          "public_updated_at": "2018-04-18T16:51:45.000+01:00",
+          "document_type": "News story"
+        }
+        ],
+        "ordered_promotional_features": [],
+        "ordered_ministers": [],
+        "ordered_board_members": [
+        {
+          "name_prefix": null,
+          "name": "Mark Thomson",
+          "role": "Director General, Her Majesty's Passport Office",
+          "href": "/government/people/mark-thomson",
+          "role_href": null,
+          "payment_type": null,
+          "attends_cabinet_type": null,
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2259/Mark_thomson_960x640.jpg",
+            "alt_text": "Mark Thomson"
+          }
+        },
+        {
+          "name_prefix": null,
+          "name": "Mark Thomson",
+          "role": "Registrar General for England and Wales",
+          "href": "/government/people/mark-thomson",
+          "role_href": null,
+          "payment_type": null,
+          "attends_cabinet_type": null,
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2259/Mark_thomson_960x640.jpg",
+            "alt_text": "Mark Thomson"
+          }
+        }
+        ],
+        "ordered_military_personnel": [],
+        "ordered_traffic_commissioners": [],
+        "ordered_chief_professional_officers": [],
+        "ordered_special_representatives": [],
+        "important_board_members": 1,
+        "organisation_featuring_priority": "news",
+        "organisation_govuk_status": {
+          "status": "live",
+          "url": null,
+          "updated_at": null
+        },
+        "organisation_type": "sub_organisation",
+        "social_media_links": [
+        {
+          "service_type": "twitter",
+          "title": "Twitter",
+          "href": "https://twitter.com/HM_Passport"
+        },
+        {
+          "service_type": "instagram",
+          "title": "Instagram",
+          "href": "https://www.instagram.com/ukhomeoffice/"
+        },
+        {
+          "service_type": "facebook",
+          "title": "Facebook",
+          "href": "https://www.facebook.com/ukhomeofficegov"
+        },
+        {
+          "service_type": "linkedin",
+          "title": "LinkedIn",
+          "href": "https://www.linkedin.com/company/the-home-office"
+        },
+        {
+          "service_type": "youtube",
+          "title": "YouTube",
+          "href": "http://www.youtube.com/ukhomeoffice"
+        },
+        {
+          "service_type": "blog",
+          "title": "Home Office in the Media blog",
+          "href": "https://homeofficemedia.blog.gov.uk/"
+        }
+        ]
+      },
+      "links": {},
+      "api_url": "https://www.gov.uk/api/content/government/organisations/hm-passport-office",
+      "web_url": "https://www.gov.uk/government/organisations/hm-passport-office"
+    }
+    ],
+    "parent": [
+    {
+      "api_path": "/api/content/browse/abroad/passports",
+      "base_path": "/browse/abroad/passports",
+      "content_id": "dd842862-e148-4fe3-b363-e57d6a2689aa",
+      "description": "Eligibility, fees, applying, renewing and updating",
+      "document_type": "mainstream_browse_page",
+      "locale": "en",
+      "public_updated_at": "2016-12-05T17:00:29Z",
+      "schema_name": "mainstream_browse_page",
+      "title": "Passports",
+      "withdrawn": false,
+      "links": {
+        "parent": [
+        {
+          "api_path": "/api/content/browse/abroad",
+          "base_path": "/browse/abroad",
+          "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+          "description": "Includes renewing passports and travel advice by country",
+          "document_type": "mainstream_browse_page",
+          "locale": "en",
+          "public_updated_at": "2015-04-08T10:48:43Z",
+          "schema_name": "mainstream_browse_page",
+          "title": "Passports, travel and living abroad",
+          "withdrawn": false,
+          "links": {},
+          "api_url": "https://www.gov.uk/api/content/browse/abroad",
+          "web_url": "https://www.gov.uk/browse/abroad"
+        }
+        ]
+      },
+      "api_url": "https://www.gov.uk/api/content/browse/abroad/passports",
+      "web_url": "https://www.gov.uk/browse/abroad/passports"
+    }
+    ],
+    "primary_publishing_organisation": [
+    {
+      "analytics_identifier": "OT1056",
+      "api_path": "/api/content/government/organisations/government-digital-service",
+      "base_path": "/government/organisations/government-digital-service",
+      "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+      "document_type": "organisation",
+      "locale": "en",
+      "public_updated_at": "2017-12-21T09:51:19Z",
+      "schema_name": "organisation",
+      "title": "Government Digital Service",
+      "withdrawn": false,
+      "details": {
+        "acronym": "GDS",
+        "body": "<div class=\"govspeak\"><p>We help departments work together to transform government and meet user needs.</p>\n\n<p><abbr title=\"Government Digital Service\">GDS</abbr> is part of the <a class=\"brand__color\" href=\"/government/organisations/cabinet-office\">Cabinet Office</a>.</p>\n</div>",
+        "brand": "cabinet-office",
+        "logo": {
+          "formatted_title": "Government Digital Service",
+          "crest": "single-identity"
+        },
+        "foi_exempt": false,
+        "ordered_corporate_information_pages": [
+        {
+          "title": "Our governance",
+          "href": "/government/organisations/government-digital-service/about/our-governance"
+        },
+        {
+          "title": "Corporate reports",
+          "href": "/government/publications?departments%5B%5D=government-digital-service&publication_type=corporate-reports"
+        },
+        {
+          "title": "Transparency data",
+          "href": "/government/publications?departments%5B%5D=government-digital-service&publication_type=transparency-data"
+        },
+        {
+          "title": "Working for GDS",
+          "href": "/government/organisations/government-digital-service/about/recruitment"
+        },
+        {
+          "title": "Jobs",
+          "href": "https://www.gov.uk/government/organisations/government-digital-service/about/recruitment"
+        }
+        ],
+        "secondary_corporate_information_pages": "Our <a class=\"brand__color\" href=\"/government/organisations/government-digital-service/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
+        "ordered_featured_links": [
+        {
+          "title": "Service Toolkit",
+          "href": "https://www.gov.uk/service-toolkit"
+        },
+        {
+          "title": "Digital Marketplace",
+          "href": "https://www.gov.uk/government/collections/digital-marketplace-buyers-and-suppliers-information"
+        },
+        {
+          "title": "Introducing Verify",
+          "href": "https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify"
+        },
+        {
+          "title": "Technology Code of Practice",
+          "href": "https://www.gov.uk/government/publications/technology-code-of-practice/technology-code-of-practice"
+        },
+        {
+          "title": "GOV.UK Design System",
+          "href": "https://design-system.service.gov.uk"
+        }
+        ],
+        "ordered_featured_documents": [
+        {
+          "title": "Why GOV.UK content should be published in HTML and not PDF",
+          "href": "https://gds.blog.gov.uk/2018/07/16/why-gov-uk-content-should-be-published-in-html-and-not-pdf/",
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/64394/pdf.jpg",
+            "alt_text": "A mobile phone with a PDF logo on the screen"
+          },
+          "summary": "<div class=\"govspeak\"><p>We’re not huge fans of PDFs on GOV.UK. We hope this post will help publishers explain to colleagues the problems with using them and support moving towards an HTML-first culture.</p>\n</div>",
+          "public_updated_at": "2018-07-16T00:00:00.000+01:00",
+          "document_type": "Blog post"
+        },
+        {
+          "title": "GovTech Catalyst information",
+          "href": "/government/collections/govtech-catalyst-information",
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/64392/Govtech-logo.png",
+            "alt_text": "GovTech Catalyst logo"
+          },
+          "summary": "<div class=\"govspeak\"><p>Information about the GovTech Catalyst process, current challenges and competitions, news and historical data.</p>\n</div>",
+          "public_updated_at": "2018-07-12T16:11:52.000+01:00",
+          "document_type": "Collection"
+        },
+        {
+          "title": "The importance of content designers in government",
+          "href": "https://gds.blog.gov.uk/2018/07/11/the-importance-of-content-designers-in-government/",
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/64395/content_community_poster.jpg",
+            "alt_text": "A poster saying \"Advocate for the user\""
+          },
+          "summary": "<div class=\"govspeak\"><p>The content designer community gathered for ConCon7 last month. Find out what was on the agenda and why it was the most inspiring cross-government conference yet.</p>\n</div>",
+          "public_updated_at": "2018-07-11T00:00:00.000+01:00",
+          "document_type": "Blog post"
+        },
+        {
+          "title": "GDS across the globe: Where our alumni are now",
+          "href": "https://gds.blog.gov.uk/2018/07/06/gds-across-the-globe-where-our-alumni-are-now/",
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/64396/GDS_Global_Blog_2.png",
+            "alt_text": "GDS alumni Ross Ferguson, Olivia Neal, Jordan Hatch and Annette Sweeney"
+          },
+          "summary": "<div class=\"govspeak\"><p>Former GDS staff who now work for foreign governments share what they’ve learnt working abroad, what they’ve contributed and discuss GDS’ impact.</p>\n\n</div>",
+          "public_updated_at": "2018-07-06T00:00:00.000+01:00",
+          "document_type": "Blog post"
+        },
+        {
+          "title": "Building the GOV.UK of the future",
+          "href": "https://gds.blog.gov.uk/2018/06/27/building-the-gov-uk-of-the-future/",
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/64397/Slide03x.jpg",
+            "alt_text": "A laptop with the GOV.UK homepage on the screen"
+          },
+          "summary": "<div class=\"govspeak\"><p>Head of GOV.UK Neil Williams talks about the work that’s been happening to future proof the government’s content, including keeping up with new technologies and turning to robots to help.</p>\n</div>",
+          "public_updated_at": "2018-06-27T00:00:00.000+01:00",
+          "document_type": "Blog post"
+        },
+        {
+          "title": "Introducing the GOV.UK Design System",
+          "href": "https://gds.blog.gov.uk/2018/06/22/introducing-the-gov-uk-design-system/",
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/63843/Design_system_960x640.png",
+            "alt_text": "Screenshot of Design System navigation page."
+          },
+          "summary": "<div class=\"govspeak\"><p>The GOV.UK Design System is now ready for teams across government to use. Take a look at how we developed it and why we think it will make things easier for service teams.</p>\n</div>",
+          "public_updated_at": "2018-06-22T00:00:00.000+01:00",
+          "document_type": "Blog post"
+        }
+        ],
+        "ordered_promotional_features": [],
+        "ordered_ministers": [],
+        "ordered_board_members": [
+        {
+          "name_prefix": null,
+          "name": "Kevin  Cunnington",
+          "role": "Director General, Government Digital Service",
+          "href": "/government/people/kevin-cunnington",
+          "role_href": null,
+          "payment_type": null,
+          "attends_cabinet_type": null,
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/1362/kc-960.jpg",
+            "alt_text": "Kevin  Cunnington"
+          }
+        }
+        ],
+        "ordered_military_personnel": [],
+        "ordered_traffic_commissioners": [],
+        "ordered_chief_professional_officers": [],
+        "ordered_special_representatives": [],
+        "important_board_members": 1,
+        "organisation_featuring_priority": "service",
+        "organisation_govuk_status": {
+          "status": "live",
+          "url": null,
+          "updated_at": null
+        },
+        "organisation_type": "sub_organisation",
+        "social_media_links": [
+        {
+          "service_type": "twitter",
+          "title": "Twitter",
+          "href": "https://twitter.com/gdsteam"
+        },
+        {
+          "service_type": "blog",
+          "title": "GDS blog",
+          "href": "https://gds.blog.gov.uk/"
+        },
+        {
+          "service_type": "youtube",
+          "title": "YouTube",
+          "href": "https://www.youtube.com/user/GovDigitalService"
+        },
+        {
+          "service_type": "twitter",
+          "title": "Digital Careers Gov",
+          "href": "https://twitter.com/DigiCareersGov"
+        },
+        {
+          "service_type": "blog",
+          "title": "Inside GOV.UK blog",
+          "href": "https://insidegovuk.blog.gov.uk/"
+        },
+        {
+          "service_type": "flickr",
+          "title": "Flickr",
+          "href": "https://www.flickr.com/photos/gdsteam/"
+        }
+        ]
+      },
+      "links": {},
+      "api_url": "https://www.gov.uk/api/content/government/organisations/government-digital-service",
+      "web_url": "https://www.gov.uk/government/organisations/government-digital-service"
+    }
+    ],
+    "taxons": [
+    {
+      "api_path": "/api/content/going-and-being-abroad/passports",
+      "base_path": "/going-and-being-abroad/passports",
+      "content_id": "27b9c5cd-b390-4332-89be-73491df35a41",
+      "description": "Eligibility, fees, applying, renewing and updating",
+      "document_type": "taxon",
+      "locale": "en",
+      "public_updated_at": "2018-03-08T14:49:08Z",
+      "schema_name": "taxon",
+      "title": "Passports",
+      "withdrawn": false,
+      "details": {
+        "internal_name": "Passports [M]",
+        "notes_for_editors": "",
+        "visible_to_departmental_editors": false
+      },
+      "phase": "alpha",
+      "links": {
+        "parent_taxons": [
+        {
+          "api_path": "/api/content/going-and-being-abroad",
+          "base_path": "/going-and-being-abroad",
+          "content_id": "9597c30a-605a-4e36-8bc1-47e5cdae41b3",
+          "document_type": "taxon",
+          "locale": "en",
+          "public_updated_at": "2018-06-07T13:21:49Z",
+          "schema_name": "taxon",
+          "title": "Going and being abroad",
+          "withdrawn": false,
+          "details": {
+            "internal_name": "Going and being abroad",
+            "notes_for_editors": "",
+            "visible_to_departmental_editors": true
+          },
+          "phase": "alpha",
+          "links": {
+            "root_taxon": [
+            {
+              "api_path": "/api/content/",
+              "base_path": "/",
+              "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+              "description": "",
+              "document_type": "homepage",
+              "locale": "en",
+              "public_updated_at": "2018-06-12T15:28:48Z",
+              "schema_name": "homepage",
+              "title": "GOV.UK homepage",
+              "withdrawn": false,
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/",
+              "web_url": "https://www.gov.uk/"
+            }
+            ]
+          },
+          "api_url": "https://www.gov.uk/api/content/going-and-being-abroad",
+          "web_url": "https://www.gov.uk/going-and-being-abroad"
+        }
+        ]
+      },
+      "api_url": "https://www.gov.uk/api/content/going-and-being-abroad/passports",
+      "web_url": "https://www.gov.uk/going-and-being-abroad/passports"
+    }
+    ],
+    "available_translations": [
+    {
+      "title": "Renew or replace your adult passport",
+      "public_updated_at": "2015-01-12T00:01:07Z",
+      "document_type": "guide",
+      "schema_name": "guide",
+      "base_path": "/renew-adult-passport",
+      "description": "How to apply, how long it takes, how much it costs, track your application, unexpired visas, replacing a damaged passport",
+      "api_path": "/api/content/renew-adult-passport",
+      "withdrawn": false,
+      "content_id": "82248bb1-c4d6-41e0-9494-d98123475626",
+      "locale": "en",
+      "api_url": "https://www.gov.uk/api/content/renew-adult-passport",
+      "web_url": "https://www.gov.uk/renew-adult-passport",
+      "links": {}
+    }
+    ]
+  },
+  "description": "How to apply, how long it takes, how much it costs, track your application, unexpired visas, replacing a damaged passport",
+  "details": {
+    "hide_chapter_navigation": true,
+    "parts": [
+    {
+      "title": "Overview",
+      "slug": "overview",
+      "body": "<p>It costs £75.50 to renew or replace your passport if you apply online or £85 if you fill out a paper form.</p>\n\n<p>You must be aged 16 or over (or turning 16 in the next 3 weeks) if you want an adult passport. There’s a different process to <a href=\"/get-a-child-passport\">get a passport for a child</a>.</p>\n\n<p>If you’re in the UK you can:</p>\n\n<ul>\n  <li>\n<a href=\"/renew-adult-passport/renew\">renew your passport</a> if it’s expired or will expire soon (including if you currently have a child passport)</li>\n  <li>\n<a href=\"/renew-adult-passport/replace\">replace your passport</a> if it’s been lost, stolen or damaged</li>\n  <li><a href=\"/changing-passport-information\">change the details on your passport</a></li>\n</ul>\n\n<p>There are different ways to <a href=\"/overseas-passports\">renew or replace your passport if you’re outside the UK</a>.</p>\n\n<h2 id=\"how-long-it-takes\">How long it takes</h2>\n\n<p>It should take 3 weeks to get your passport. <a href=\"/get-a-passport-urgently\">Use a different service</a> if you need it urgently.</p>\n\n<p>It can take longer if more information is needed or your application has not been filled in correctly.</p>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>Do not book travel until you have a valid passport - doing so is at your own risk. Your new passport will not have the same number as your old one.</p>\n</div>\n\n<h2 id=\"tracking-your-passport-application\">Tracking your passport application</h2>\n\n<p>You can <a href=\"/track-passport-application\">track your passport application</a> immediately if you apply online or after 3 weeks if you apply by post.</p>\n\n<h2 id=\"getting-your-new-passport\">Getting your new passport</h2>\n\n<p>Your new passport will be sent to you by courier or Royal Mail. They’ll either:</p>\n\n<ul>\n  <li>post it through your letterbox</li>\n  <li>hand it to you if you’re home</li>\n  <li>leave a card or post you a letter saying how you can get it (it won’t say the package is your passport)</li>\n</ul>\n"
+    },
+    {
+      "title": "Renew",
+      "slug": "renew",
+      "body": "<p>If your passport’s expired, you must renew it before you can travel.</p>\n\n<p>You can renew your passport at any time. When you renew your passport, time left on your existing passport is added to your new one, up to a maximum of 9 months.</p>\n\n<div role=\"note\" aria-label=\"Information\" class=\"application-notice info-notice\">\n<p>If your passport will expire soon you might need to renew it before travelling. Check the <a href=\"https://www.gov.uk/foreign-travel-advice\">entry requirements of the countries you’re visiting</a> before booking travel.</p>\n</div>\n\n<p>You must <a href=\"/renew-adult-passport/replace\">replace your passport if it’s been lost, stolen or damaged</a> rather than renew it.</p>\n\n<h2 id=\"renew-online\">Renew online</h2>\n\n<p>You can <a href=\"/apply-renew-passport\">renew your passport online</a>.</p>\n\n<h2 id=\"renew-using-a-paper-application-form\">Renew using a paper application form</h2>\n\n<p>You can get a paper application form by either:</p>\n\n<ul>\n  <li>going to a Post Office that has a <a href=\"/how-the-post-office-check-and-send-service-works\">Check and Send service</a>\n</li>\n  <li>calling the <a href=\"/passport-advice-line\">Passport Adviceline</a>\n</li>\n</ul>\n\n<p>You can use the Check and Send service if you’re using a paper form.</p>\n\n<h2 id=\"photos\">Photos</h2>\n\n<p>If you use the new online passport renewal service you’ll need someone to take a photo of you using a digital camera or smartphone.</p>\n\n<p>If you use the old ‘existing’ online service, send your application by post or use the Passport Check and Send service. You’ll need 2 identical new photos of yourself.</p>\n\n<p>Your application can be delayed if you do not <a href=\"/photos-for-passports\">follow the rules about passport photos</a>.</p>\n\n<h3 id=\"countersignatories\">Countersignatories</h3>\n\n<p>If you cannot be recognised from the photo in your existing passport, get your application form and 1 of your photos <a href=\"/countersigning-passport-applications\">signed by someone else</a> to prove your identity.</p>\n\n<h2 id=\"how-to-pay\">How to pay</h2>\n\n<p>You’ll need a credit or debit card to apply online.</p>\n\n<p>If you apply by post, you can either pay by:</p>\n\n<ul>\n  <li>debit or credit card - fill in the form in the application pack</li>\n  <li>cheque - made payable to ‘Her Majesty’s Passport Office’</li>\n</ul>\n\n<h3 id=\"what-it-costs\">What it costs</h3>\n\n<p>It costs £75.50 to renew your passport if you apply online or £85 if you fill out a paper form.</p>\n\n<h2 id=\"unexpired-visas\">Unexpired visas</h2>\n\n<p>Send your previous passport with the visa attached to it with your application. Your previous passport will be returned to you.</p>\n\n<p>You’ll be able to use the visa if you carry both passports.</p>\n"
+    },
+    {
+      "title": "Replace a lost, stolen or damaged passport",
+      "slug": "replace",
+      "body": "<p>You must replace your passport if it has more than reasonable wear and tear because you may not be allowed to travel with it.</p>\n\n<p>If you’re replacing a lost or stolen passport, you may have to attend an interview and your application may take longer.</p>\n\n<p>It costs £75.50 to replace your passport if you apply online or £85 if you fill out a paper form.</p>\n\n<h2 id=\"replace-a-lost-or-stolen-passport\">Replace a lost or stolen passport</h2>\n\n<p>You can <a href=\"/apply-renew-passport\">replace your passport online</a>.</p>\n\n<p>You can also apply with a paper form. You can get a paper application form:</p>\n\n<ul>\n  <li>from a Post Office</li>\n  <li>by calling the <a href=\"/passport-advice-line\">Passport Adviceline</a>\n</li>\n</ul>\n\n<p>You can use the <a href=\"/how-the-post-office-check-and-send-service-works\">Post Office Check and Send service</a> if you’re using a paper form. The address to send it to is on the form.</p>\n\n<h3 id=\"photos\">Photos</h3>\n\n<p>Send 2 identical new photos of yourself with your application.</p>\n\n<p>Your application can be delayed if you do not <a href=\"/photos-for-passports\">follow the rules about passport photos</a>.</p>\n\n<h3 id=\"countersignatories\">Countersignatories</h3>\n\n<p>You need to get your application form and 1 of your photos <a href=\"/countersigning-passport-applications\">signed by someone else</a> to prove your identity.</p>\n\n<h2 id=\"replace-a-damaged-passport\">Replace a damaged passport</h2>\n\n<p>You can <a href=\"/apply-renew-passport\">replace your passport online</a>.</p>\n\n<p>You can also apply with a paper form. You can get a paper application form:</p>\n\n<ul>\n  <li>from a Post Office</li>\n  <li>by calling the <a href=\"/passport-advice-line\">Passport Adviceline</a>\n</li>\n</ul>\n\n<p>You can use the <a href=\"/how-the-post-office-check-and-send-service-works\">Post Office Check and Send service</a> if you’re using a paper form. The address to send it to is on the form.</p>\n\n<h3 id=\"photos-1\">Photos</h3>\n\n<p>If you’re applying online to replace a damaged passport, you’ll need to <a href=\"/photos-for-passports/rules-for-digital-photos\">get a digital photo</a>.</p>\n\n<p>If you’re applying by post, send 2 identical new photos of yourself with your application.</p>\n\n<p>Your application can be delayed if you do not <a href=\"/photos-for-passports\">follow the rules about passport photos</a>.</p>\n\n<h3 id=\"countersignatories-1\">Countersignatories</h3>\n\n<p>If you’re applying with a paper form, you need to get your application form and 1 of your photos <a href=\"/countersigning-passport-applications\">signed by someone else</a>.</p>\n\n<p>You do not need to do this if you’re applying online.</p>\n\n<h2 id=\"how-to-pay\">How to pay</h2>\n\n<p>You need a credit or debit card to apply online.</p>\n\n<p>If you apply by post, you can either pay by:</p>\n\n<ul>\n  <li>debit or credit card - fill in the form in the application pack</li>\n  <li>cheque - made payable to ‘Her Majesty’s Passport Office’</li>\n</ul>\n\n"
+    }
+    ],
+    "external_related_links": []
+  }
+}


### PR DESCRIPTION
This PR includes an example of a guide that is not in a step by step navigation but has `hide_chapter_navigation` set to true, so we can test that this property has no effect if a guide is not in a step by step.
