### PR TITLE
Adding a corner case example guide

### DIFF
--- a/examples/guide/frontend/no-part-guide-with-step-navs-and-hide-navigation.json
+++ b/examples/guide/frontend/no-part-guide-with-step-navs-and-hide-navigation.json
@@ -1,0 +1,522 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/correct-marriage-registration",
+  "content_id": "cea526cf-bb4e-496a-ae46-9ba87c37e114",
+  "document_type": "guide",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2012-10-16T14:29:50.000+00:00",
+  "publishing_app": "publisher",
+  "rendering_app": "frontend",
+  "schema_name": "guide",
+  "title": "Correct a marriage registration",
+  "updated_at": "2017-02-21T16:44:29.494Z",
+  "withdrawn_notice": {
+  },
+  "links": {
+    "part_of_step_navs": [
+    {
+      "api_path": "/api/content/learn-to-drive-a-car",
+      "base_path": "/learn-to-drive-a-car",
+      "content_id": "e01e924b-9c7c-4c71-8241-66a575c2f61f",
+      "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test",
+      "document_type": "step_by_step_nav",
+      "locale": "en",
+      "public_updated_at": "2018-04-03T13:47:57Z",
+      "schema_name": "step_by_step_nav",
+      "title": "Learn to drive a car: step by step",
+      "withdrawn": false,
+      "details": {
+        "step_by_step_nav": {
+          "title": "Learn to drive a car: step by step",
+          "introduction": [
+          {
+            "content_type": "text/govspeak",
+            "content": "Check what you need to do to learn to drive."
+          }
+          ],
+          "steps": [
+          {
+            "title": "Check you're allowed to drive",
+            "contents": [
+            {
+              "type": "paragraph",
+              "text": "Most people can start learning to drive when they’re 17."
+            },
+            {
+              "type": "list",
+              "contents": [
+              {
+                "text": "Check what age you can drive",
+                "href": "/vehicles-can-drive"
+              },
+              {
+                "text": "Requirements for driving legally",
+                "href": "/legal-obligations-drivers-riders"
+              },
+              {
+                "text": "Driving eyesight rules",
+                "href": "/driving-eyesight-rules"
+              }
+              ]
+            }
+            ],
+            "optional": false
+          },
+          {
+            "title": "Get a provisional licence",
+            "contents": [
+            {
+              "type": "list",
+              "contents": [
+              {
+                "text": "Apply for your first provisional driving licence",
+                "href": "/apply-first-provisional-driving-licence",
+                "context": "£34 to £43"
+              }
+              ]
+            }
+            ],
+            "optional": false
+          },
+          {
+            "title": "Driving lessons and practice",
+            "contents": [
+            {
+              "type": "paragraph",
+              "text": "You need a provisional driving licence to take lessons or practice."
+            },
+            {
+              "type": "list",
+              "contents": [
+              {
+                "text": "The Highway Code",
+                "href": "/guidance/the-highway-code"
+              },
+              {
+                "text": "Taking driving lessons",
+                "href": "/driving-lessons-learning-to-drive"
+              },
+              {
+                "text": "Find driving schools, lessons and instructors",
+                "href": "/find-driving-schools-and-lessons"
+              },
+              {
+                "text": "Practise vehicle safety questions",
+                "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions"
+              }
+              ]
+            }
+            ],
+            "optional": false
+          },
+          {
+            "title": "Prepare for your theory test",
+            "contents": [
+            {
+              "type": "list",
+              "contents": [
+              {
+                "text": "Theory test revision and practice",
+                "href": "/theory-test/revision-and-practice"
+              },
+              {
+                "text": "Take a practice theory test",
+                "href": "/take-practice-theory-test"
+              },
+              {
+                "text": "Theory and hazard perception test app",
+                "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app"
+              }
+              ]
+            }
+            ],
+            "optional": false,
+            "logic": "and"
+          },
+          {
+            "title": "Book and manage your theory test",
+            "contents": [
+            {
+              "type": "paragraph",
+              "text": "You need a provisional driving licence to book your theory test."
+            },
+            {
+              "type": "list",
+              "contents": [
+              {
+                "text": "Book your theory test",
+                "href": "/book-theory-test",
+                "context": "£23"
+              },
+              {
+                "text": "What to take to your test",
+                "href": "/theory-test/what-to-take"
+              },
+              {
+                "text": "Change your theory test appointment",
+                "href": "/change-theory-test"
+              },
+              {
+                "text": "Check your theory test appointment details",
+                "href": "/check-theory-test"
+              },
+              {
+                "text": "Cancel your theory test",
+                "href": "/cancel-theory-test"
+              }
+              ]
+            }
+            ],
+            "optional": false
+          },
+          {
+            "title": "Book and manage your driving test",
+            "contents": [
+            {
+              "type": "paragraph",
+              "text": "You must pass your theory test before you can book your driving test."
+            },
+            {
+              "type": "list",
+              "contents": [
+              {
+                "text": "Book your driving test",
+                "href": "/book-driving-test",
+                "context": "£62 to £75"
+              },
+              {
+                "text": "What to take to your test",
+                "href": "/driving-test/what-to-take"
+              },
+              {
+                "text": "Change your driving test appointment",
+                "href": "/change-driving-test"
+              },
+              {
+                "text": "Check your driving test appointment details",
+                "href": "/check-driving-test"
+              },
+              {
+                "text": "Cancel your driving test",
+                "href": "/cancel-driving-test"
+              }
+              ]
+            }
+            ],
+            "optional": false
+          },
+          {
+            "title": "When you pass",
+            "contents": [
+            {
+              "type": "paragraph",
+              "text": "You can start driving as soon as you pass your driving test."
+            },
+            {
+              "type": "paragraph",
+              "text": "You must have an insurance policy that allows you to drive without supervision."
+            },
+            {
+              "type": "list",
+              "contents": [
+              {
+                "text": "Find out about Pass Plus training courses",
+                "href": "/pass-plus"
+              }
+              ]
+            }
+            ],
+            "optional": false
+          }
+          ]
+        }
+      },
+      "links": {
+        "pages_part_of_step_nav": [
+        {
+          "api_path": "/api/content/driving-test",
+          "base_path": "/driving-test",
+          "content_id": "3bf0efc2-476c-4a9a-bd8a-872fb5c8e4d0",
+          "description": "When to book your car driving test, what to take with you, what happens during the test, major and minor faults, and what happens if your test is cancelled",
+          "document_type": "guide",
+          "locale": "en",
+          "public_updated_at": "2016-02-22T16:36:11Z",
+          "schema_name": "guide",
+          "title": "Driving test: cars",
+          "withdrawn": false,
+          "links": {},
+          "api_url": "https://www.gov.uk/api/content/driving-test",
+          "web_url": "https://www.gov.uk/driving-test"
+        }
+        ]
+      },
+      "api_url": "https://www.gov.uk/api/content/learn-to-drive-a-car",
+      "web_url": "https://www.gov.uk/learn-to-drive-a-car"
+    }
+    ],
+    "mainstream_browse_pages": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/births-deaths-marriages/register-offices",
+        "base_path": "/browse/births-deaths-marriages/register-offices",
+        "content_id": "553aa169-abde-4733-a84b-61fac93fe75e",
+        "description": "Birth certificates, registering a death, marriage, family history and correcting certificates",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-06-24T13:56:39Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Certificates, register offices, changes of name or gender",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/browse/births-deaths-marriages/register-offices",
+        "web_url": "http://www.dev.gov.uk/browse/births-deaths-marriages/register-offices"
+      }
+    ],
+    "meets_user_needs": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/needs/apply-to-correct-a-marriage-certificate",
+        "base_path": "/needs/apply-to-correct-a-marriage-certificate",
+        "content_id": "138ec0d6-2962-4cff-a465-ffad48ee00bf",
+        "description": null,
+        "document_type": "need",
+        "locale": "en",
+        "public_updated_at": "2015-06-24T13:56:39Z",
+        "schema_name": "need",
+        "title": "As a citizen, I need to apply to correct a marriage certificate, so that it is an accurate record (102183)",
+        "withdrawn": false,
+        "details": {
+          "applies_to_all_organisations": false,
+          "benefit": "it is an accurate record",
+          "goal": "apply to correct a marriage certificate",
+          "justifications": [
+            "It's something only government does",
+            "The government is legally obliged to provide it",
+            "It's inherent to a person's or an organisation's rights and obligations",
+            "It's something that people can do or it's something people need to know before they can do something that's regulated by/related to government"
+          ],
+          "met_when": [
+            "knows who can apply",
+            "knows how to apply",
+            "knows how much it costs",
+            "knows how long it will take"
+          ],
+          "role": "citizen",
+          "need_id": "102183"
+        },
+        "links": {
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/needs/apply-to-correct-a-marriage-certificate",
+        "web_url": "http://www.dev.gov.uk/needs/apply-to-correct-a-marriage-certificate"
+      }
+    ],
+    "ordered_related_items": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/certifying-a-document",
+        "base_path": "/certifying-a-document",
+        "content_id": "19786269-f057-405b-bea4-941b3b194ca4",
+        "description": "Certify a document as a true copy of the original by getting it signed and dated by a professional person, like a solicitor",
+        "document_type": "answer",
+        "locale": "en",
+        "public_updated_at": "2015-08-27T15:40:46Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Certifying a document",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/births-deaths-marriages/register-offices",
+              "base_path": "/browse/births-deaths-marriages/register-offices",
+              "content_id": "553aa169-abde-4733-a84b-61fac93fe75e",
+              "description": "Birth certificates, registering a death, marriage, family history and correcting certificates",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:39Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Certificates, register offices, changes of name or gender",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/births-deaths-marriages",
+                    "base_path": "/browse/births-deaths-marriages",
+                    "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+                    "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Births, deaths, marriages and care",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/births-deaths-marriages",
+                    "web_url": "http://www.dev.gov.uk/browse/births-deaths-marriages"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/births-deaths-marriages/register-offices",
+              "web_url": "http://www.dev.gov.uk/browse/births-deaths-marriages/register-offices"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/certifying-a-document",
+        "web_url": "http://www.dev.gov.uk/certifying-a-document"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/order-copy-birth-death-marriage-certificate",
+        "base_path": "/order-copy-birth-death-marriage-certificate",
+        "content_id": "17a26e6f-1f1d-4585-a9f6-433272730101",
+        "description": "Order an official birth, marriage or death certificate from the General Register Office (GRO) if you need a copy or want to research your family tree",
+        "document_type": "transaction",
+        "locale": "en",
+        "public_updated_at": "2015-06-09T15:45:02Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Order a copy of a birth, death or marriage certificate",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/births-deaths-marriages/register-offices",
+              "base_path": "/browse/births-deaths-marriages/register-offices",
+              "content_id": "553aa169-abde-4733-a84b-61fac93fe75e",
+              "description": "Birth certificates, registering a death, marriage, family history and correcting certificates",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:39Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Certificates, register offices, changes of name or gender",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/births-deaths-marriages",
+                    "base_path": "/browse/births-deaths-marriages",
+                    "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+                    "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:39Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Births, deaths, marriages and care",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "http://www.dev.gov.uk/api/content/browse/births-deaths-marriages",
+                    "web_url": "http://www.dev.gov.uk/browse/births-deaths-marriages"
+                  }
+                ]
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/births-deaths-marriages/register-offices",
+              "web_url": "http://www.dev.gov.uk/browse/births-deaths-marriages/register-offices"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/order-copy-birth-death-marriage-certificate",
+        "web_url": "http://www.dev.gov.uk/order-copy-birth-death-marriage-certificate"
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "EA66",
+        "api_path": "/api/content/government/organisations/hm-passport-office",
+        "base_path": "/government/organisations/hm-passport-office",
+        "content_id": "3a96a1e0-21e3-4aae-8e84-f90860ed3dbf",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2014-10-15T14:35:28Z",
+        "schema_name": "placeholder",
+        "title": "HM Passport Office",
+        "withdrawn": false,
+        "details": {
+          "brand": "home-office",
+          "logo": {
+            "formatted_title": "HM Passport<br/>Office",
+            "crest": "ho"
+          }
+        },
+        "links": {
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/government/organisations/hm-passport-office",
+        "web_url": "http://www.dev.gov.uk/government/organisations/hm-passport-office"
+      }
+    ],
+    "parent": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/births-deaths-marriages/register-offices",
+        "base_path": "/browse/births-deaths-marriages/register-offices",
+        "content_id": "553aa169-abde-4733-a84b-61fac93fe75e",
+        "description": "Birth certificates, registering a death, marriage, family history and correcting certificates",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-06-24T13:56:39Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Certificates, register offices, changes of name or gender",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/births-deaths-marriages",
+              "base_path": "/browse/births-deaths-marriages",
+              "content_id": "f5fe5c9e-e5f1-4b76-9b07-a0af649c440c",
+              "description": "Parenting, civil partnerships, divorce and lasting power of attorney",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-04-08T10:48:39Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Births, deaths, marriages and care",
+              "withdrawn": false,
+              "links": {
+              },
+              "api_url": "http://www.dev.gov.uk/api/content/browse/births-deaths-marriages",
+              "web_url": "http://www.dev.gov.uk/browse/births-deaths-marriages"
+            }
+          ]
+        },
+        "api_url": "http://www.dev.gov.uk/api/content/browse/births-deaths-marriages/register-offices",
+        "web_url": "http://www.dev.gov.uk/browse/births-deaths-marriages/register-offices"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Correct a marriage registration",
+        "public_updated_at": "2012-10-16T14:29:50Z",
+        "analytics_identifier": null,
+        "document_type": "guide",
+        "schema_name": "guide",
+        "base_path": "/correct-marriage-registration",
+        "description": "If there are any errors on a marriage certificate you can correct the original registration with the register office or GRO - find out what corrections can be made, who can apply, how long it takes, what they look like",
+        "api_path": "/api/content/correct-marriage-registration",
+        "withdrawn": false,
+        "content_id": "cea526cf-bb4e-496a-ae46-9ba87c37e114",
+        "locale": "en",
+        "api_url": "http://www.dev.gov.uk/api/content/correct-marriage-registration",
+        "web_url": "http://www.dev.gov.uk/correct-marriage-registration",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "If there are any errors on a marriage certificate you can correct the original registration with the register office or GRO - find out what corrections can be made, who can apply, how long it takes, what they look like",
+  "details": {
+    "parts": [
+
+    ],
+    "external_related_links": [
+
+    ],
+    "hide_chapter_navigation": true
+  }
+}


### PR DESCRIPTION
This adds an example guide that has no parts, is in a step by step navigation, and has `hide_chapter_navigation` set to true, for testing purposes.

In practice this should never happen but I believe it was related to an intermittent error with the 'random but valid items do not error' test in government-frontend.

Trello card: https://trello.com/c/RNsA7E4Q/763-hide-chapter-navigation-on-mainstream-guides
