### PR TITLE
Remove original org for news/dataset editions

### DIFF
--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -59,10 +59,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "original_primary_publishing_organisation": {
-          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -56,10 +56,6 @@
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
-        "original_primary_publishing_organisation": {
-          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/formats/news_article.jsonnet
+++ b/formats/news_article.jsonnet
@@ -59,7 +59,6 @@
     primary_publishing_organisation: {
       description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
       maxItems: 1,
-    },
-    original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+    }
   }
 }

--- a/formats/statistical_data_set.jsonnet
+++ b/formats/statistical_data_set.jsonnet
@@ -39,7 +39,6 @@
     primary_publishing_organisation: {
       description: "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
       maxItems: 1,
-    },
-    original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+    }
   }
 }


### PR DESCRIPTION
https://trello.com/c/b5RLbDyJ/118-users-can-add-a-primary-organisation

We originally added this to support editions links for the new Content
Publisher, but we've since decided not to support this particular
edition link for the forseeable future.