### PR TITLE
[DO NOT MERGE] Rename Service Standard

### DIFF
--- a/examples/homepage/publisher_v2/service_manual_homepage.json
+++ b/examples/homepage/publisher_v2/service_manual_homepage.json
@@ -5,7 +5,7 @@
   "details": {
   },
   "base_path": "/service-manual",
-  "description": "Helping government teams create and run great digital services that meet the Digital Service Standard.",
+  "description": "Helping government teams create and run great digital services that meet the Government Service Standard.",
   "title": "Service manual",
   "routes": [
     {

--- a/examples/homepage/publisher_v2/service_manual_homepage.json
+++ b/examples/homepage/publisher_v2/service_manual_homepage.json
@@ -5,7 +5,7 @@
   "details": {
   },
   "base_path": "/service-manual",
-  "description": "Helping government teams create and run great digital services that meet the Government Service Standard.",
+  "description": "Helping government teams create and run great digital services that meet the Service Standard.",
   "title": "Service manual",
   "routes": [
     {

--- a/examples/service_manual_guide/frontend/point_page.json
+++ b/examples/service_manual_guide/frontend/point_page.json
@@ -43,7 +43,7 @@
         "description": null,
         "locale": "en",
         "public_updated_at": "2016-06-22T10:35:24.641Z",
-        "title": "The Government Service Standard",
+        "title": "The Service Standard",
         "web_url": "https://www.gov.uk/service-manual/service-standard"
       }
     ]

--- a/examples/service_manual_guide/frontend/point_page.json
+++ b/examples/service_manual_guide/frontend/point_page.json
@@ -43,7 +43,7 @@
         "description": null,
         "locale": "en",
         "public_updated_at": "2016-06-22T10:35:24.641Z",
-        "title": "The Digital Service Standard",
+        "title": "The Government Service Standard",
         "web_url": "https://www.gov.uk/service-manual/service-standard"
       }
     ]

--- a/examples/service_manual_homepage/frontend/service_manual_homepage.json
+++ b/examples/service_manual_homepage/frontend/service_manual_homepage.json
@@ -58,7 +58,7 @@
     ]
   },
   "base_path": "/service-manual",
-  "description": "Helping government teams create and run great digital services that meet the Digital Service Standard.",
+  "description": "Helping government teams create and run great digital services that meet the Government Service Standard.",
   "title": "Service manual",
   "updated_at": "2015-10-12T08:54:30+00:00",
   "schema_name": "service_manual_homepage",

--- a/examples/service_manual_homepage/frontend/service_manual_homepage.json
+++ b/examples/service_manual_homepage/frontend/service_manual_homepage.json
@@ -58,7 +58,7 @@
     ]
   },
   "base_path": "/service-manual",
-  "description": "Helping government teams create and run great digital services that meet the Government Service Standard.",
+  "description": "Helping government teams create and run great digital services that meet the Service Standard.",
   "title": "Service manual",
   "updated_at": "2015-10-12T08:54:30+00:00",
   "schema_name": "service_manual_homepage",

--- a/examples/service_manual_homepage/publisher_v2/service_manual_homepage.json
+++ b/examples/service_manual_homepage/publisher_v2/service_manual_homepage.json
@@ -5,7 +5,7 @@
   "details": {
   },
   "base_path": "/service-manual",
-  "description": "Helping government teams create and run great digital services that meet the Digital Service Standard.",
+  "description": "Helping government teams create and run great digital services that meet the Government Service Standard.",
   "title": "Service manual",
   "routes": [
     {

--- a/examples/service_manual_homepage/publisher_v2/service_manual_homepage.json
+++ b/examples/service_manual_homepage/publisher_v2/service_manual_homepage.json
@@ -5,7 +5,7 @@
   "details": {
   },
   "base_path": "/service-manual",
-  "description": "Helping government teams create and run great digital services that meet the Government Service Standard.",
+  "description": "Helping government teams create and run great digital services that meet the Service Standard.",
   "title": "Service manual",
   "routes": [
     {

--- a/examples/service_manual_service_standard/frontend/service_manual_service_standard.json
+++ b/examples/service_manual_service_standard/frontend/service_manual_service_standard.json
@@ -10,7 +10,7 @@
   "publishing_app": "service-manual-publisher",
   "rendering_app": "service-manual-frontend",
   "schema_name": "service_manual_service_standard",
-  "title": "Government Service Standard",
+  "title": "Service Standard",
   "updated_at": "2016-06-30T13:28:53.128Z",
   "withdrawn_notice": {
   },
@@ -73,7 +73,7 @@
     "available_translations": [
       {
         "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
-        "title": "Government Service Standard",
+        "title": "Service Standard",
         "api_path": "/api/content/service-manual/service-standard",
         "base_path": "/service-manual/service-standard",
         "description": null,
@@ -89,7 +89,7 @@
       }
     ]
   },
-  "description": "The Government Service Standard is a set of 18 criteria to help government create and run good digital services.",
+  "description": "The Service Standard is a set of 18 criteria to help government create and run good digital services.",
   "details": {
     "body": "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
     "poster_url": "http://example.com/service-standard-poster.pdf"

--- a/examples/service_manual_service_standard/frontend/service_manual_service_standard.json
+++ b/examples/service_manual_service_standard/frontend/service_manual_service_standard.json
@@ -10,7 +10,7 @@
   "publishing_app": "service-manual-publisher",
   "rendering_app": "service-manual-frontend",
   "schema_name": "service_manual_service_standard",
-  "title": "Digital Service Standard",
+  "title": "Government Service Standard",
   "updated_at": "2016-06-30T13:28:53.128Z",
   "withdrawn_notice": {
   },
@@ -73,7 +73,7 @@
     "available_translations": [
       {
         "content_id": "00f693d4-866a-4fe6-a8d6-09cd7db8980b",
-        "title": "Digital Service Standard",
+        "title": "Government Service Standard",
         "api_path": "/api/content/service-manual/service-standard",
         "base_path": "/service-manual/service-standard",
         "description": null,
@@ -89,7 +89,7 @@
       }
     ]
   },
-  "description": "The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.",
+  "description": "The Government Service Standard is a set of 18 criteria to help government create and run good digital services.",
   "details": {
     "body": "All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.",
     "poster_url": "http://example.com/service-standard-poster.pdf"

--- a/examples/service_manual_service_standard/publisher_v2/service_manual_service_standard.json
+++ b/examples/service_manual_service_standard/publisher_v2/service_manual_service_standard.json
@@ -5,8 +5,8 @@
   "update_type": "major",
   "base_path": "/service-manual/service-standard",
   "public_updated_at": "2015-10-09T08:17:10+00:00",
-  "title": "Government Service Standard",
-  "description": "Government Service Standard",
+  "title": "Service Standard",
+  "description": "Service Standard",
   "phase": "beta",
   "routes": [
     {

--- a/examples/service_manual_service_standard/publisher_v2/service_manual_service_standard.json
+++ b/examples/service_manual_service_standard/publisher_v2/service_manual_service_standard.json
@@ -5,8 +5,8 @@
   "update_type": "major",
   "base_path": "/service-manual/service-standard",
   "public_updated_at": "2015-10-09T08:17:10+00:00",
-  "title": "Digital Service Standard",
-  "description": "Digital Service Standard",
+  "title": "Government Service Standard",
+  "description": "Government Service Standard",
   "phase": "beta",
   "routes": [
     {

--- a/examples/service_manual_service_toolkit/frontend/service_manual_service_toolkit.json
+++ b/examples/service_manual_service_toolkit/frontend/service_manual_service_toolkit.json
@@ -9,9 +9,9 @@
         "description": "Meet the standards for government services",
         "links": [
           {
-            "title": "The Digital Service Standard",
+            "title": "The Government Service Standard",
             "url": "https://www.gov.uk/service-manual/service-standard",
-            "description": "Learn about the 18 point standard that government services must meet"
+            "description": "Learn about the 14 point standard that government services must meet"
           },
           {
             "title": "Service Manual",

--- a/examples/service_manual_service_toolkit/frontend/service_manual_service_toolkit.json
+++ b/examples/service_manual_service_toolkit/frontend/service_manual_service_toolkit.json
@@ -9,7 +9,7 @@
         "description": "Meet the standards for government services",
         "links": [
           {
-            "title": "The Government Service Standard",
+            "title": "The Service Standard",
             "url": "https://www.gov.uk/service-manual/service-standard",
             "description": "Learn about the 14 point standard that government services must meet"
           },

--- a/examples/service_manual_service_toolkit/publisher_v2/service_manual_service_toolkit.json
+++ b/examples/service_manual_service_toolkit/publisher_v2/service_manual_service_toolkit.json
@@ -9,9 +9,9 @@
         "description": "Meet the standards for government services",
         "links": [
           {
-            "title": "The Digital Service Standard",
+            "title": "The Government Service Standard",
             "url": "https://www.gov.uk/service-manual/service-standard",
-            "description": "Learn about the 18 point standard that government services must meet"
+            "description": "Learn about the 14 point standard that government services must meet"
           },
           {
             "title": "Service Manual",

--- a/examples/service_manual_service_toolkit/publisher_v2/service_manual_service_toolkit.json
+++ b/examples/service_manual_service_toolkit/publisher_v2/service_manual_service_toolkit.json
@@ -9,7 +9,7 @@
         "description": "Meet the standards for government services",
         "links": [
           {
-            "title": "The Government Service Standard",
+            "title": "The Service Standard",
             "url": "https://www.gov.uk/service-manual/service-standard",
             "description": "Learn about the 14 point standard that government services must meet"
           },

--- a/examples/service_manual_topic/frontend/service_manual_topic.json
+++ b/examples/service_manual_topic/frontend/service_manual_topic.json
@@ -13,7 +13,7 @@
         "content_id": "053d245d-b1cd-4807-9dbc-ce78654121d1",
         "title": "Service manual",
         "base_path": "/service-manual",
-        "description": "Helping government teams create and run great digital services that meet the Government Service Standard.",
+        "description": "Helping government teams create and run great digital services that meet the Service Standard.",
         "api_url": "https://www.gov.uk/api/content/service-manual",
         "web_url": "https://www.gov.uk/service-manual",
         "locale": "en",

--- a/examples/service_manual_topic/frontend/service_manual_topic.json
+++ b/examples/service_manual_topic/frontend/service_manual_topic.json
@@ -13,7 +13,7 @@
         "content_id": "053d245d-b1cd-4807-9dbc-ce78654121d1",
         "title": "Service manual",
         "base_path": "/service-manual",
-        "description": "Helping government teams create and run great digital services that meet the Digital Service Standard.",
+        "description": "Helping government teams create and run great digital services that meet the Government Service Standard.",
         "api_url": "https://www.gov.uk/api/content/service-manual",
         "web_url": "https://www.gov.uk/service-manual",
         "locale": "en",


### PR DESCRIPTION
The Digital Service Standard is being renamed to the Government Service Standard. The number of points in the standard will also be reduced from 18 to 14.

Whilst these are only examples, changing these allows us to be consistent in the tests in service manual frontend and service manual publisher, which rely on these example schemas.