### PR TITLE
Allow bulk_publishing parameter for Publishing API payloads

### DIFF
--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/calendar/publisher_v2/links.json
+++ b/dist/formats/calendar/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/calendar/publisher_v2/schema.json
+++ b/dist/formats/calendar/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -19,6 +19,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/external_content/publisher_v2/links.json
+++ b/dist/formats/external_content/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/external_content/publisher_v2/schema.json
+++ b/dist/formats/external_content/publisher_v2/schema.json
@@ -20,6 +20,9 @@
     "base_path": {
       "type": "null"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/gone/publisher_v2/links.json
+++ b/dist/formats/gone/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/gone/publisher_v2/schema.json
+++ b/dist/formats/gone/publisher_v2/schema.json
@@ -17,6 +17,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/knowledge_alpha/publisher_v2/links.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/organisation/publisher_v2/links.json
+++ b/dist/formats/organisation/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/organisations_homepage/publisher_v2/links.json
+++ b/dist/formats/organisations_homepage/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/person/publisher_v2/links.json
+++ b/dist/formats/person/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/redirect/publisher_v2/links.json
+++ b/dist/formats/redirect/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/redirect/publisher_v2/schema.json
+++ b/dist/formats/redirect/publisher_v2/schema.json
@@ -19,6 +19,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/role/publisher_v2/links.json
+++ b/dist/formats/role/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/role/publisher_v2/schema.json
+++ b/dist/formats/role/publisher_v2/schema.json
@@ -20,6 +20,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/role_appointment/publisher_v2/links.json
+++ b/dist/formats/role_appointment/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/dist/formats/role_appointment/publisher_v2/schema.json
@@ -19,6 +19,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/service_sign_in/publisher_v2/links.json
+++ b/dist/formats/service_sign_in/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -19,6 +19,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/step_by_step_nav/publisher_v2/links.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -20,6 +20,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path_optional"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -22,6 +22,9 @@
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
     "change_note": {
       "type": [
         "null",

--- a/formats/shared/default_properties/publisher.jsonnet
+++ b/formats/shared/default_properties/publisher.jsonnet
@@ -2,6 +2,9 @@
   access_limited: {
     "$ref": "#/definitions/access_limited",
   },
+  bulk_publishing: {
+    type: "boolean",
+  },
   change_note: {
     type: [
       "null",

--- a/lib/schema_generator/publisher_links_schema_generator.rb
+++ b/lib/schema_generator/publisher_links_schema_generator.rb
@@ -24,7 +24,8 @@ module SchemaGenerator
     def properties
       {
         "links" => links,
-        "previous_version" => { "type" => "string" }
+        "previous_version" => { "type" => "string" },
+        "bulk_publishing" => { "type" => "boolean" }
       }
     end
 


### PR DESCRIPTION
Loosely related to: https://trello.com/c/3GT17tkH/211-associate-content-with-ministers-l

Despite this field having been available in Publishing API for 2 years
it's not actually accepted at a schema level. Presumably, in the case of
PutContent, this means it's not been used in the last couple of years as
it would have returned a 422 response.

As it's quite a useful option to have I felt it was better to add it
into the schemas rather than remove the feature from Publishing API.