### PR TITLE
Add tracking code to service sign in format

### DIFF
--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -339,6 +339,12 @@
         },
         "title": {
           "type": "string"
+        },
+        "tracking_code": {
+          "type": "string"
+        },
+        "tracking_name": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -389,6 +389,12 @@
         },
         "title": {
           "type": "string"
+        },
+        "tracking_code": {
+          "type": "string"
+        },
+        "tracking_name": {
+          "type": "string"
         }
       }
     },

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -198,6 +198,12 @@
         },
         "title": {
           "type": "string"
+        },
+        "tracking_code": {
+          "type": "string"
+        },
+        "tracking_name": {
+          "type": "string"
         }
       }
     },

--- a/examples/service_sign_in/frontend/service_sign_in.json
+++ b/examples/service_sign_in/frontend/service_sign_in.json
@@ -30,6 +30,8 @@
     "choose_sign_in": {
       "title": "Prove your identity to continue",
       "slug": "choose-sign-in",
+      "tracking_code": "UA-xxxxxx",
+      "tracking_name": "somethingClicky",
       "description": "<p>You can't file online until you've activated Government Gateway account using your Unique Taxpayer Reference(UTR).</p>",
       "options": [
         {

--- a/formats/service_sign_in.jsonnet
+++ b/formats/service_sign_in.jsonnet
@@ -35,6 +35,12 @@
         description: {
           "$ref": "#/definitions/body_html_and_govspeak",
         },
+        tracking_code: {
+          type: "string"
+        },
+        tracking_name: {
+          type: "string"
+        },
         options: {
           type: "array",
           additionalProperties: false,


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Adds the fields `tracking_code` and `tracking_name` to the service sign in `choose_sign_in` options hash, these can be passed to forms which track radio buttons across domains.

See https://github.com/alphagov/govuk_publishing_components/pull/539 and https://github.com/alphagov/government-frontend/pull/1102 for full implementation