### PR TITLE
Remove base_path requirement for some links (and add org examples)

### DIFF
--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -109,7 +109,7 @@
         },
         "ordered_contacts": {
           "description": "Contact details primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations.",
@@ -117,7 +117,7 @@
         },
         "ordered_foi_contacts": {
           "description": "FoI contact details primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_high_profile_groups": {
           "description": "High profile groups primarily for use with Whitehall organisations.",
@@ -727,6 +727,72 @@
       "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links_with_base_path"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
     },
     "frontend_links_with_base_path": {
       "type": "array",

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -109,7 +109,7 @@
         },
         "ordered_contacts": {
           "description": "Contact details primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations.",
@@ -117,7 +117,7 @@
         },
         "ordered_foi_contacts": {
           "description": "FoI contact details primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_high_profile_groups": {
           "description": "High profile groups primarily for use with Whitehall organisations.",
@@ -809,6 +809,72 @@
       "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links_with_base_path"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
     },
     "frontend_links_with_base_path": {
       "type": "array",

--- a/examples/organisation/frontend/attorney_general.json
+++ b/examples/organisation/frontend/attorney_general.json
@@ -1,0 +1,184 @@
+{
+  "title": "Attorney General's Office",
+  "base_path": "/government/organisations/attorney-generals-office",
+  "content_id": "f323e83c-868b-4bcb-b6e2-a8f9bb40397f",
+  "analytics_identifier": "D1197",
+  "description": null,
+  "document_type": "organisation",
+  "first_published_at": "2016-07-14T18:15:21.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2018-01-09T10:07:59.000+00:00",
+  "publishing_app": "whitehall",
+  "rendering_app": "collections",
+  "schema_name": "organisation",
+  "updated_at": "2018-03-27T18:42:06.661Z",
+  "details": {
+    "acronym": "AGO",
+    "body": "The Attorney General's Office (AGO) provides legal advice and support to the Attorney General and the Solicitor General (the Law Officers) who give legal advice to government. The AGO helps the Law Officers perform other duties in the public interest, such as looking at sentences which may be too low.\r\n\r\n",
+    "brand": "attorney-generals-office",
+    "logo": {
+      "formatted_title": "Attorney <br/>General&#39;s <br/>Office",
+      "crest": "single-identity"
+    },
+    "organisation_govuk_status": {
+      "status": "live"
+    },
+    "organisation_type": "ministerial_department",
+    "organisation_featuring_priority": "news",
+    "ordered_corporate_information_pages": [
+      {
+        "title": "Complaints procedure",
+        "href": "/complaints-procedure"
+      },
+      {
+        "title": "Jobs",
+        "href": "https://www.civilservicejobs.service.gov.uk/csr"
+      }
+    ],
+    "ordered_featured_links": [
+      {
+        "title": "Attorney General's guidance to the legal profession",
+        "href": "https://www.gov.uk/browse/justice/courts-sentencing-tribunals/attorney-general-guidance-to-the-legal-profession"
+      }
+    ],
+    "ordered_featured_documents": [
+      {
+        "title": "New head of the Serious Fraud Office announced",
+        "href": "/government/news/new-head-of-the-serious-fraud-office-announced",
+        "image": {
+          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/63252/Jeremy_Wright_FOR_WEBSITE.jpg",
+          "alt_text": "Attorney General Jeremy Wright QC MP"
+        },
+        "summary": "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
+        "public_updated_at": "2018-06-04T11:30:03.000+01:00",
+        "document_type": "Press release"
+      }
+    ],
+    "ordered_ministers": [
+      {
+        "name_prefix": "The Rt Hon",
+        "name": "Theresa May MP",
+        "role": "Prime Minister",
+        "href": "/government/people/theresa-may",
+        "role_href": "/government/ministers/prime-minister",
+        "image": {
+          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/6/PM_portrait_960x640.jpg",
+          "alt_text": "Theresa May MP"
+        }
+      },
+      {
+        "name": "Stuart Andrew MP",
+        "role": "Parliamentary Under Secretary of State",
+        "href": "/government/people/stuart-andrew",
+        "role_href": "/government/ministers/parliamentary-under-secretary-of-state--94"
+      }
+    ],
+    "social_media_links": [
+      {
+        "service_type": "twitter",
+        "title": "Twitter - @attorneygeneral",
+        "href": "https://twitter.com/@attorneygeneral"
+      }
+    ],
+    "ordered_board_members": [
+      {
+        "name": "Sir Jeremy Heywood",
+        "role": "Cabinet Secretary",
+        "href": "/government/people/jeremy-heywood"
+      }
+    ],
+    "ordered_promotional_features": [
+      {
+        "title": "Transparency",
+        "items": [
+          {
+            "title": "",
+            "href": "https://www.gov.uk/government/policies?keywords=&topics%5B%5D=government-efficiency-transparency-and-accountability&departments%5B%5D=all",
+            "summary": "Greater transparency across government is at the heart of our commitment to let you hold politicians and public bodies to account. ",
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/1/Transparency.jpg",
+              "alt_text": "Magnifying glass studying a graph"
+            },
+            "double_width": false,
+            "links": [
+              {
+                "title": "Single departmental plans",
+                "href": "https://www.gov.uk/government/collections/a-country-that-works-for-everyone-the-governments-plan"
+              },
+              {
+                "title": "Prime Minister's and Cabinet Office ministers' transparency publications",
+                "href": "https://www.gov.uk/government/collections/ministers-transparency-publications"
+              },
+              {
+                "title": "Government transparency data",
+                "href": "https://www.gov.uk/government/publications?keywords=&publication_filter_option=transparency-data&topics%5B%5D=all&departments%5B%5D=all&world_locations%5B%5D=all&direction=before&date=2013-05-01"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "available_translations": [],
+    "ordered_contacts": [
+      {
+        "content_id": "5bd25a81-41e6-4fb3-8fc1-24b79f213efd",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2015-03-06T16:38:24Z",
+        "title": "Department for International Trade",
+        "details": {
+          "title": "Department for International Trade",
+          "post_addresses": [
+            {
+              "title": "",
+              "street_address": "King Charles Street\r\nWhitehall",
+              "postal_code": "SW1A 2AH",
+              "world_location": "United Kingdom",
+              "locality": "London"
+            }
+          ],
+          "email_addresses": [
+            {
+              "title": "",
+              "email": "enquiries@trade.gov.uk"
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Custom Telephone",
+              "number": "+44 (0) 20 7215 5000"
+            }
+          ],
+          "contact_form_links": [
+            {
+              "title": "Enquiries for overseas companies looking to set up in the UK",
+              "link": "https://invest.great.gov.uk/int/contact/"
+            }
+          ]
+        },
+        "links": {}
+      }
+    ],
+    "ordered_high_profile_groups": [
+      {
+        "content_id": "49e09fa7-f65b-49d6-b4ab-0ca82a548e93",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2017-10-03T12:48:26Z",
+        "base_path": "/government/organisations/attorney-generals-office-1",
+        "title": "High Profile Group 1"
+      },
+      {
+        "content_id": "49e09fa7-f65b-49d6-b4ab-0ca82a548e94",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2017-10-03T12:48:26Z",
+        "base_path": "/government/organisations/attorney-generals-office-2",
+        "title": "High Profile Group 2"
+      }
+    ]
+  }
+}

--- a/examples/organisation/frontend/charity_commission.json
+++ b/examples/organisation/frontend/charity_commission.json
@@ -1,0 +1,88 @@
+{
+  "title": "The Charity Commission",
+  "base_path": "/government/organisations/charity-commission",
+  "content_id": "f323e83c-868b-4bcb-b6e2-a8f9bb40397a",
+  "analytics_identifier": "D1197",
+  "description": null,
+  "document_type": "organisation",
+  "first_published_at": "2016-07-14T18:15:21.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2018-01-09T10:07:59.000+00:00",
+  "publishing_app": "whitehall",
+  "rendering_app": "collections",
+  "schema_name": "organisation",
+  "updated_at": "2018-03-27T18:42:06.661Z",
+  "details": {
+    "body": "We register and regulate charities in England and Wales, to ensure that the public can support charities with confidence.\r\n",
+    "brand": "department-for-business-innovation-skills",
+    "logo": {
+      "formatted_title": "Charity Commission",
+      "image": {
+        "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/98/Home_page.jpg",
+        "alt_text": "The Charity Commission"
+      }
+    },
+    "foi_exempt": true,
+    "organisation_govuk_status": {
+      "status": "live"
+    },
+    "organisation_type": "non_ministerial_department",
+    "organisation_featuring_priority": "service",
+    "ordered_featured_links": [
+      {
+        "title": "Find a charity",
+        "href": "http://apps.charitycommission.gov.uk/showcharity/registerofcharities/RegisterHomePage.aspx"
+      },
+      {
+        "title": "Online services and contact forms",
+        "href": "https://www.gov.uk/government/organisations/charity-commission/about/about-our-services"
+      }
+    ],
+    "ordered_featured_documents": [
+      {
+        "title": "Charity annual return 2018",
+        "href": "/government/news/charity-annual-return-2018",
+        "image": {
+          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/63313/AR18_prepare_v1.1.png",
+          "alt_text": "Annual return service 2018"
+        },
+        "summary": "How you can prepare for the 2018 annual return service, which will be available this summer. ",
+        "public_updated_at": "2018-06-06T10:56:00.000+01:00",
+        "document_type": "News story"
+      }
+    ],
+    "social_media_links": [
+      {
+        "service_type": "twitter",
+        "title": "Twitter",
+        "href": "https://twitter.com/chtycommission"
+      },
+      {
+        "service_type": "youtube",
+        "title": "YouTube",
+        "href": "http://www.youtube.com/TheCharityCommission"
+      }
+    ]
+  },
+  "links": {
+    "available_translations": [],
+    "ordered_featured_policies": [
+      {
+        "api_path": "/api/content/government/policies/waste-and-recycling",
+        "base_path": "/government/policies/waste-and-recycling",
+        "content_id": "5d5e9324-7631-11e4-a3cb-005056011aef",
+        "description": "What the government’s doing about waste and recycling.",
+        "document_type": "policy",
+        "locale": "en",
+        "public_updated_at": "2015-05-14T16:39:48Z",
+        "schema_name": "policy",
+        "title": "Waste and recycling",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/policies/waste-and-recycling",
+        "web_url": "https://www.gov.uk/government/policies/waste-and-recycling"
+      }
+    ]
+  }
+}

--- a/examples/organisation/frontend/court.json
+++ b/examples/organisation/frontend/court.json
@@ -1,0 +1,715 @@
+{
+  "analytics_identifier": "CO1188",
+  "base_path": "/courts-tribunals/administrative-court",
+  "content_id": "b0bdfcf3-2763-4002-961e-a0b2d7825038",
+  "content_purpose_document_supertype": "organising-entities",
+  "content_purpose_supergroup": "other",
+  "content_purpose_subgroup": "other",
+  "document_type": "organisation",
+  "email_document_supertype": "other",
+  "first_published_at": "2016-03-29T13:21:12.000+00:00",
+  "government_document_supertype": "other",
+  "locale": "en",
+  "navigation_document_supertype": "other",
+  "phase": "live",
+  "public_updated_at": "2016-07-25T14:16:18.000+00:00",
+  "publishing_app": "whitehall",
+  "publishing_scheduled_at": null,
+  "rendering_app": "whitehall-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "organisation",
+  "search_user_need_document_supertype": "government",
+  "title": "Administrative Court",
+  "updated_at": "2018-10-01T17:50:45.260Z",
+  "user_journey_document_supertype": "finding",
+  "withdrawn_notice": {},
+  "publishing_request_id": "1923-1531218353.319-194.33.196.5-1623",
+  "links": {
+    "ordered_contacts": [
+      {
+        "content_id": "6db858d2-760b-499b-b5fa-e40e6e4d7f5c",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2016-03-29T16:42:16Z",
+        "schema_name": "contact",
+        "title": "General enquiries (Royal Courts of Justice)",
+        "withdrawn": false,
+        "details": {
+          "description": "Opening hours and facilities:\r\nhttps://courttribunalfinder.service.gov.uk/courts/administrative-court",
+          "contact_type": "General contact",
+          "title": "General enquiries (Royal Courts of Justice)",
+          "contact_form_links": [
+            {
+              "title": "General enquiries (Royal Courts of Justice)",
+              "link": "",
+              "description": ""
+            }
+          ],
+          "post_addresses": [
+            {
+              "title": "Administrative Court Office",
+              "street_address": "Royal Courts of Justice\r\nStrand",
+              "locality": "London",
+              "region": "",
+              "postal_code": "WC2A 2LL",
+              "world_location": "United Kingdom"
+            }
+          ],
+          "email_addresses": [
+            {
+              "title": "Administrative Court Office",
+              "email": ""
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "020 7947 6655 "
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "08aaee8b-101a-43d0-9b11-bb75898363be",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2016-03-29T16:46:00Z",
+        "schema_name": "contact",
+        "title": "General enquiries (Birmingham)",
+        "withdrawn": false,
+        "details": {
+          "description": "Opening hours and facilities:\r\nhttps://courttribunalfinder.service.gov.uk/courts/birmingham-civil-and-family-justice-centre",
+          "contact_type": "General contact",
+          "title": "General enquiries (Birmingham)",
+          "contact_form_links": [
+            {
+              "title": "General enquiries (Birmingham)",
+              "link": "",
+              "description": ""
+            }
+          ],
+          "post_addresses": [
+            {
+              "title": "Birmingham Civil and Family Justice Hearing Centre",
+              "street_address": "Priory Courts \r\n33 Bull Street",
+              "locality": "Birmingham",
+              "region": "West Midlands",
+              "postal_code": "B4 6DS",
+              "world_location": "United Kingdom"
+            }
+          ],
+          "email_addresses": [
+            {
+              "title": "Birmingham Civil and Family Justice Hearing Centre",
+              "email": ""
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "0121 250 6319 "
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "5d763701-c6ee-44b3-a74e-09d91866e244",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2016-03-29T16:49:20Z",
+        "schema_name": "contact",
+        "title": "General enquiries (Leeds)",
+        "withdrawn": false,
+        "details": {
+          "description": "Opening hours and facilities:\r\nhttps://courttribunalfinder.service.gov.uk/courts/leeds-combined-court-centre",
+          "contact_type": "General contact",
+          "title": "General enquiries (Leeds)",
+          "contact_form_links": [
+            {
+              "title": "General enquiries (Leeds)",
+              "link": "",
+              "description": ""
+            }
+          ],
+          "post_addresses": [
+            {
+              "title": "Leeds Combined Court Centre",
+              "street_address": "The Courthouse\r\n1 Oxford Row\r\n",
+              "locality": "Leeds",
+              "region": "West Yorkshire",
+              "postal_code": "LS1 3BG ",
+              "world_location": "United Kingdom"
+            }
+          ],
+          "email_addresses": [
+            {
+              "title": "Leeds Combined Court Centre",
+              "email": ""
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "0113 306 2578 "
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "f4b72bad-cd13-44e0-9693-4820ca3400c5",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2016-03-30T06:56:41Z",
+        "schema_name": "contact",
+        "title": "General enquiries (Manchester)",
+        "withdrawn": false,
+        "details": {
+          "description": "Opening hours and facilities:\r\nhttps://courttribunalfinder.service.gov.uk/courts/manchester-county-court-and-family-court",
+          "contact_type": "General contact",
+          "title": "General enquiries (Manchester)",
+          "contact_form_links": [
+            {
+              "title": "General enquiries (Manchester)",
+              "link": "",
+              "description": ""
+            }
+          ],
+          "post_addresses": [
+            {
+              "title": "Manchester County Court and Family Court",
+              "street_address": "Manchester Civil and Family Justice Centre\r\n1 Bridge Street West\r\n",
+              "locality": "Manchester",
+              "region": "Greater Manchester",
+              "postal_code": "M60 9DJ",
+              "world_location": "United Kingdom"
+            }
+          ],
+          "email_addresses": [
+            {
+              "title": "Manchester County Court and Family Court",
+              "email": ""
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "0161 240 5313 "
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "9af29fe3-5014-4f78-89fa-9ac4d457e4a3",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2016-03-29T17:12:12Z",
+        "schema_name": "contact",
+        "title": "General enquiries (Wales)",
+        "withdrawn": false,
+        "details": {
+          "description": "Opening hours and facilities:\r\nhttps://courttribunalfinder.service.gov.uk/courts/cardiff-civil-and-family-justice-centre",
+          "contact_type": "General contact",
+          "title": "General enquiries (Wales)",
+          "contact_form_links": [
+            {
+              "title": "General enquiries (Wales)",
+              "link": "",
+              "description": ""
+            }
+          ],
+          "post_addresses": [
+            {
+              "title": "Cardiff Civil and Family Justice Centre",
+              "street_address": "2 Park Street",
+              "locality": "Cardiff",
+              "region": "South Wales",
+              "postal_code": "CF10 1ET",
+              "world_location": "United Kingdom"
+            }
+          ],
+          "email_addresses": [
+            {
+              "title": "Cardiff Civil and Family Justice Centre",
+              "email": ""
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "02920 376460 "
+            }
+          ]
+        },
+        "links": {}
+      }
+    ],
+    "ordered_parent_organisations": [
+      {
+        "analytics_identifier": "EA73",
+        "api_path": "/api/content/government/organisations/hm-courts-and-tribunals-service",
+        "base_path": "/government/organisations/hm-courts-and-tribunals-service",
+        "content_id": "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2018-03-19T17:45:22Z",
+        "schema_name": "organisation",
+        "title": "HM Courts & Tribunals Service",
+        "withdrawn": false,
+        "details": {
+          "acronym": "HMCTS",
+          "body": "<div class=\"govspeak\"><p>HM Courts &amp; Tribunals Service is responsible for the administration of criminal, civil and family courts and tribunals in England and Wales.</p>\n\n<p><abbr title=\"HM Courts &amp; Tribunals Service\">HMCTS</abbr> is an executive agency, sponsored by the <a class=\"brand__color\" href=\"/government/organisations/ministry-of-justice\">Ministry of Justice</a>.</p>\n</div>",
+          "brand": "ministry-of-justice",
+          "logo": {
+            "formatted_title": "HM Courts &amp; <br/>Tribunals Service",
+            "crest": "single-identity"
+          },
+          "foi_exempt": false,
+          "ordered_corporate_information_pages": [
+            {
+              "title": "Statistics at HMCTS",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/statistics"
+            },
+            {
+              "title": "Equality and diversity",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/equality-and-diversity"
+            },
+            {
+              "title": "Complaints procedure",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/complaints-procedure"
+            },
+            {
+              "title": "Our governance",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/our-governance"
+            },
+            {
+              "title": "Corporate reports",
+              "href": "/government/publications?departments%5B%5D=hm-courts-and-tribunals-service&publication_type=corporate-reports"
+            },
+            {
+              "title": "Transparency data",
+              "href": "/government/publications?departments%5B%5D=hm-courts-and-tribunals-service&publication_type=transparency-data"
+            },
+            {
+              "title": "Procurement at HMCTS",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/procurement"
+            },
+            {
+              "title": "Jobs",
+              "href": "https://www.civilservicejobs.service.gov.uk/csr"
+            }
+          ],
+          "secondary_corporate_information_pages": "Read about the types of information we routinely publish in our <a class=\"brand__color\" href=\"/government/organisations/hm-courts-and-tribunals-service/about/publication-scheme\">Publication scheme</a>. Find out about our commitment to <a class=\"brand__color\" href=\"/government/organisations/hm-courts-and-tribunals-service/about/welsh-language-scheme\">publishing in Welsh</a>. Our <a class=\"brand__color\" href=\"/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
+          "ordered_featured_links": [
+            {
+              "title": "Court and tribunal forms",
+              "href": "https://hmctsformfinder.justice.gov.uk/HMCTS/FormFinder.do"
+            },
+            {
+              "title": "Find a court or tribunal",
+              "href": "https://courttribunalfinder.service.gov.uk/search/"
+            },
+            {
+              "title": "Fees and help with fees",
+              "href": "https://www.gov.uk/court-fees-what-they-are"
+            },
+            {
+              "title": "Wills, probate and inheritance",
+              "href": "https://www.gov.uk/wills-probate-inheritance"
+            },
+            {
+              "title": "Make a court claim for money",
+              "href": "https://www.gov.uk/make-court-claim-for-money"
+            },
+            {
+              "title": "Get a divorce",
+              "href": "https://www.gov.uk/divorce"
+            },
+            {
+              "title": "Appeal to the SSCS Tribunal",
+              "href": "https://www.gov.uk/social-security-child-support-tribunal"
+            },
+            {
+              "title": "Pay a court fine online",
+              "href": "https://www.gov.uk/pay-court-fine-online"
+            },
+            {
+              "title": "Sign up to our email news alerts",
+              "href": "https://public.govdelivery.com/accounts/UKHMCTS/subscriber/new?qsp=UKHMCTS_1"
+            }
+          ],
+          "ordered_featured_documents": [
+            {
+              "title": "Scotland Tribunals recognised as a Carer Positive Employer",
+              "href": "/government/news/scotland-tribunals-recognised-as-a-carer-positive-employer",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/65899/Scotland_carers_group_960x640.png",
+                "alt_text": "HMCTS staff holding certificate"
+              },
+              "summary": "<div class=\"govspeak\"><p>Chief executive Susan Acland-Hood visits Glasgow to hear about the support available for carers in our workforce.</p>\n</div>",
+              "public_updated_at": "2018-09-25T12:04:00.000+01:00",
+              "document_type": "News story"
+            },
+            {
+              "title": "Results of fully-video hearings pilot published",
+              "href": "/government/news/results-of-fully-video-hearings-pilot-published",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/65597/Video-hearing-laptop_960x640.png",
+                "alt_text": "Laptop woth video screens"
+              },
+              "summary": "<div class=\"govspeak\"><p>Court users taking part in the first fully-video hearings found them convenient and easy to understand, an independent report published today reveals.</p>\n</div>",
+              "public_updated_at": "2018-09-13T12:00:05.000+01:00",
+              "document_type": "Press release"
+            },
+            {
+              "title": "Implementing Video hearings (Party-to-State) - A Process Evaluation",
+              "href": "/government/publications/implementing-video-hearings-party-to-state-a-process-evaluation",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/65598/MOJ_960x640.png",
+                "alt_text": "Ministry of Justice building"
+              },
+              "summary": "<div class=\"govspeak\"><p>This report sets out the findings of an independent evaluation of the Video Hearings Pilot (party-to-state) 2018 carried out by HMCTS.</p>\n</div>",
+              "public_updated_at": "2018-09-13T12:00:06.000+01:00",
+              "document_type": "Independent report"
+            },
+            {
+              "title": "HMCTS reform roadshow events 2018 to 2019",
+              "href": "/government/news/hmcts-reform-roadshow-events-2018-to-2019",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/65474/Image_of_roadshow_event960_x_640.jpg",
+                "alt_text": "Image of roadshow presentation"
+              },
+              "summary": "<div class=\"govspeak\"><p>Information for legal professionals and court users to participate in events about our courts and tribunals reform programme.</p>\n</div>",
+              "public_updated_at": "2018-09-07T12:57:00.000+01:00",
+              "document_type": "News story"
+            },
+            {
+              "title": "Government announces easier court entrance for legal sector",
+              "href": "/government/news/government-announces-easier-court-entrance-for-legal-sector",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/64881/Court_Security_960x640.png",
+                "alt_text": "Court building security "
+              },
+              "summary": "<div class=\"govspeak\"><p>Legal professionals are encouraged to register with their local court in advance of a government pilot designed to reduce queues and grant them easier access.</p>\n</div>",
+              "public_updated_at": "2018-08-09T09:59:00.000+01:00",
+              "document_type": "Press release"
+            },
+            {
+              "title": "HMCTS Reform Programme",
+              "href": "/government/news/hmcts-reform-programme",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/63612/Lady_Justice_960x640.jpg",
+                "alt_text": "Lady Justice"
+              },
+              "summary": "<div class=\"govspeak\"><p>Read all the latest information and updates on the HM Courts &amp; Tribunals Service court reform programme.</p>\n</div>",
+              "public_updated_at": "2018-10-01T18:27:15.000+01:00",
+              "document_type": "News story"
+            }
+          ],
+          "ordered_promotional_features": [],
+          "ordered_ministers": [],
+          "ordered_board_members": [
+            {
+              "name_prefix": null,
+              "name": "Susan Acland-Hood",
+              "role": "Chief Executive and Board member, HM Courts & Tribunals Service",
+              "href": "/government/people/susan-acland-hood",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2543/Susan_6_April_2017_960x640.png",
+                "alt_text": "Susan Acland-Hood"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Tim Parker",
+              "role": "Independent Chair of Board",
+              "href": "/government/people/tim-parker",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3481/Tim_Parker960_x_640.jpg",
+                "alt_text": "Tim Parker"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Kevin Sadler",
+              "role": "Deputy Chief Executive and Board Member, HM Courts & Tribunals Service ",
+              "href": "/government/people/kevin-sadler",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2214/kevin-sadler.jpg",
+                "alt_text": "Kevin Sadler"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Andrew Baigent",
+              "role": "Chief Finance Officer and Board Member",
+              "href": "/government/people/andrew-baigent",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3206/Andrew_Baigent_960_x_640.jpg",
+                "alt_text": "Andrew Baigent"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Guy Tompkins",
+              "role": "Operations Director and Board Member",
+              "href": "/government/people/guy-tompkins",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2220/guy-tompkins-2.jpg",
+                "alt_text": "Guy Tompkins"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Kevin Gallagher",
+              "role": "Digital Director",
+              "href": "/government/people/kevin-gallagher",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2328/kevin-gallagher.jpg",
+                "alt_text": "Kevin Gallagher"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Richard Goodman",
+              "role": "Change Director",
+              "href": "/government/people/richard-goodman",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2737/richard-goodman.jpg",
+                "alt_text": "Richard Goodman"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Ed Owen",
+              "role": "Director of Communications",
+              "href": "/government/people/ed-owen",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3483/Ed_960x640.jpg",
+                "alt_text": "Ed Owen"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Sidonie Kingsmill",
+              "role": "Customer Director",
+              "href": "/government/people/sidonie-kingsmill",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2476/sidonie-kingsmill.jpg",
+                "alt_text": "Sidonie Kingsmill"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Victoria Cochrane",
+              "role": "Independent Chair of Audit Committee (Non-executive Board Member)",
+              "href": "/government/people/victoria-cochrane",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null
+            },
+            {
+              "name_prefix": null,
+              "name": "Ian Playford",
+              "role": "Independent Non-executive Board Member",
+              "href": "/government/people/ian-playford",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null
+            },
+            {
+              "name_prefix": null,
+              "name": "Sir Ernest Ryder",
+              "role": "Independent Judicial Board Member",
+              "href": "/government/people/lord-justice-ryder",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2487/lord-justice-ryder.jpg",
+                "alt_text": "Sir Ernest Ryder"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "District Judge Tim Jenkins",
+              "role": "Independent Judicial Board Member",
+              "href": "/government/people/tim-jenkins",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2889/Tim_Jenkins_960x640__002_.png",
+                "alt_text": "District Judge Tim Jenkins"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Liz  Doherty",
+              "role": "Ministry of Justice Representative Board Member",
+              "href": "/government/people/liz-doherty",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2435/Liz_Doherty_960x640__1_.jpg",
+                "alt_text": "Liz  Doherty"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Lady Justice Macur DBE",
+              "role": "Independent Judicial Board Member",
+              "href": "/government/people/justice-macur",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/1668/macur_j.jpg",
+                "alt_text": "Lady Justice Macur DBE"
+              }
+            }
+          ],
+          "ordered_military_personnel": [],
+          "ordered_traffic_commissioners": [],
+          "ordered_chief_professional_officers": [],
+          "ordered_special_representatives": [],
+          "important_board_members": 1,
+          "organisation_featuring_priority": "service",
+          "organisation_govuk_status": {
+            "status": "live",
+            "url": null,
+            "updated_at": null
+          },
+          "organisation_type": "executive_agency",
+          "social_media_links": [
+            {
+              "service_type": "email",
+              "title": "Email updates",
+              "href": "https://public.govdelivery.com/accounts/UKHMCTS/subscriber/topics?qsp=UKHMCTS_1"
+            },
+            {
+              "service_type": "blog",
+              "title": "Inside HMCTS",
+              "href": "https://insidehmcts.blog.gov.uk/"
+            },
+            {
+              "service_type": "twitter",
+              "title": "HMCTS CEO Twitter",
+              "href": "https://twitter.com/CEOofHMCTS"
+            },
+            {
+              "service_type": "twitter",
+              "title": "HMCTS Twitter",
+              "href": "https://twitter.com/HMCTSgovuk"
+            },
+            {
+              "service_type": "linkedin",
+              "title": "HMCTS LinkedIn",
+              "href": "https://www.linkedin.com/company/hm-courts-&-tribunals-service"
+            },
+            {
+              "service_type": "youtube",
+              "title": "HMCTS YouTube",
+              "href": "https://www.youtube.com/channel/UC5Altka7XMeXog5ZFzBT9dA"
+            }
+          ]
+        },
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-courts-and-tribunals-service",
+        "web_url": "https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Administrative Court",
+        "public_updated_at": "2016-07-25T14:16:18Z",
+        "analytics_identifier": "CO1188",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "base_path": "/courts-tribunals/administrative-court",
+        "api_path": "/api/content/courts-tribunals/administrative-court",
+        "withdrawn": false,
+        "content_id": "b0bdfcf3-2763-4002-961e-a0b2d7825038",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/courts-tribunals/administrative-court",
+        "web_url": "https://www.gov.uk/courts-tribunals/administrative-court",
+        "links": {}
+      }
+    ]
+  },
+  "description": null,
+  "details": {
+    "acronym": "",
+    "body": "<div class=\"govspeak\"><p>We review decisions made by people or bodies with a public law function, eg local authorities and regulatory bodies. We can:</p>\n\n<ul>\n  <li>carry out a <a rel=\"external\" href=\"https://www.judiciary.gov.uk/you-and-the-judiciary/judicial-review/\">judicial review</a> of decisions made by other courts, tribunals and public bodies</li>\n  <li>hear challenges to decisions made by certain people or bodies (eg ministers or local government) where legislation has given the right to challenge</li>\n</ul>\n\n<p>We also hear:</p>\n\n<ul>\n  <li>applications for ‘habeas corpus’, (a legal procedure where the court decides to rule on whether the detention of an individual is legal</li>\n  <li>applications to prevent someone who continues to initiate groundless legal proceedings (a ‘vexatious litigant’) from continuing to do so without first obtaining permission from a court</li>\n  <li>all applications under the Coroners Act 1988 (which deals with the appointment and conduct of coroners)</li>\n  <li>appeals ‘by way of case stated’ from the Crown Court or magistrates’ courts (where our opinion is sought on a particular point of law where a mistake may have been made)</li>\n  <li>applications for an order to imprison a person for contempt of court</li>\n  <li>appeals under the Extradition Act 2003 (which deals with extradition requests to and from the United Kingdom and bail)</li>\n  <li>appeals against decisions made by some professional bodies, eg the Nursing and Midwifery Council</li>\n  <li>applications for ‘restraint orders’ or ‘certificates of inadequacy’ where assets have been frozen or confiscated</li>\n</ul>\n\n<p>We also contain a specialist <a href=\"https://www.gov.uk/courts-tribunals/planning-court\">Planning Court</a> which handles judicial reviews of decisions about planning permission and other challenges to planning decisions.</p>\n\n<h2 id=\"who-we-are\">Who we are</h2>\n\n<p>We are a specialist court within the Queen’s Bench Division of the High Court of Justice.</p>\n\n<p>We are based at the Royal Courts of Justice, London and also at centres in Birmingham, Cardiff, Leeds and Manchester.</p>\n\n<p>Cases may be heard by one High Court judge or by a ‘Divisional Court’ which consists of 2 or more judges, normally a High Court Judge and a Lord Justice of Appeal.</p>\n\n<h2 id=\"court-information\">Court information</h2>\n\n<ul>\n  <li><a rel=\"external\" href=\"http://hmctsformfinder.justice.gov.uk/HMCTS/GetForms.do?court_forms_category=Administrative%20Court\">Forms and guidance</a></li>\n  <li><a href=\"https://www.gov.uk/government/publications/administrative-court-listings\">Administrative Court Listings</a></li>\n  <li>Upcoming hearings - <a rel=\"external\" href=\"http://www.justice.gov.uk/courts/court-lists/list-birmingham\">Birmingham</a>, <a rel=\"external\" href=\"http://www.justice.gov.uk/courts/court-lists/list-leeds\">Leeds</a>, <a rel=\"external\" href=\"http://www.justice.gov.uk/courts/court-lists/list-manchester\">Manchester</a>, <a rel=\"external\" href=\"http://www.justice.gov.uk/courts/court-lists/list-rcj\">Royal Courts of Justice</a>, <a rel=\"external\" href=\"http://www.justice.gov.uk/courts/court-lists/list-cardiff\">Wales</a>\n</li>\n  <li><a rel=\"external\" href=\"http://www.bailii.org/ew/cases/EWHC/Admin/\">Previous decisions</a></li>\n  <li><a rel=\"external\" href=\"http://www.justice.gov.uk/courts/procedure-rules/civil\">Civil Procedure Rules</a></li>\n  <li><a rel=\"external\" href=\"http://hmctsformfinder.justice.gov.uk/HMCTS/GetLeaflet.do?court_leaflets_id=2823\">Fees</a></li>\n  <li><a rel=\"external\" href=\"https://www.judiciary.gov.uk/publications/practice-direction-54d-administrative-court-venue/\">Practice directions</a></li>\n  <li><a rel=\"external\" href=\"http://www.justice.gov.uk/courts/procedure-rules/criminal/docs/2015/crim-proc-rules-2015-part-50.pdf\">Extradition</a></li>\n</ul>\n</div>",
+    "brand": null,
+    "logo": {
+      "formatted_title": "Administrative Court"
+    },
+    "foi_exempt": false,
+    "ordered_corporate_information_pages": [
+      {
+        "title": "Jobs",
+        "href": "https://www.civilservicejobs.service.gov.uk/csr"
+      }
+    ],
+    "secondary_corporate_information_pages": "",
+    "ordered_featured_links": [
+      {
+        "title": "Bring a case to the court",
+        "href": "http://www.gov.uk/guidance/administrative-court-bring-a-case-to-the-court"
+      },
+      {
+        "title": "Judicial review guide",
+        "href": "http://www.gov.uk/government/publications/administrative-court-judicial-review-guide"
+      }
+    ],
+    "ordered_featured_documents": [],
+    "ordered_promotional_features": [],
+    "ordered_ministers": [],
+    "ordered_board_members": [],
+    "ordered_military_personnel": [],
+    "ordered_traffic_commissioners": [],
+    "ordered_chief_professional_officers": [],
+    "ordered_special_representatives": [],
+    "important_board_members": 1,
+    "organisation_featuring_priority": "service",
+    "organisation_govuk_status": {
+      "status": "live",
+      "url": null,
+      "updated_at": null
+    },
+    "organisation_type": "court",
+    "social_media_links": []
+  }
+}

--- a/examples/organisation/frontend/number_10.json
+++ b/examples/organisation/frontend/number_10.json
@@ -1,0 +1,89 @@
+{
+  "title": "Prime Minister's Office, 10 Downing Street",
+  "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+  "content_id": "f323e83c-868b-4bcb-b6e2-a8f9bb40397b",
+  "analytics_identifier": "D1197",
+  "description": null,
+  "document_type": "organisation",
+  "first_published_at": "2016-07-14T18:15:21.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2018-01-09T10:07:59.000+00:00",
+  "publishing_app": "whitehall",
+  "rendering_app": "collections",
+  "schema_name": "organisation",
+  "updated_at": "2018-03-27T18:42:06.661Z",
+  "details": {
+    "body": "10 Downing Street is the official residence and the office of the British Prime Minister.",
+    "brand": "cabinet-office",
+    "logo": {
+      "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street",
+      "crest": "eo"
+    },
+    "organisation_govuk_status": {
+      "status": "live"
+    },
+    "organisation_type": "executive_office",
+    "organisation_featuring_priority": "news",
+    "ordered_featured_documents": [
+      {
+        "title": "Government calls on technology firms to help tackle the UK’s biggest challenges",
+        "href": "/government/news/government-calls-on-technology-firms-to-help-tackle-the-uks-biggest-challenges",
+        "image": {
+          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/62609/Dowden.jpg",
+          "alt_text": "Cabinet Office Minister Oliver Dowden"
+        },
+        "summary": "The government is launching competitions for tech firms to develop solutions to tackle the major social challenges of our modern age.",
+        "public_updated_at": "2018-05-10T00:00:01.000+01:00",
+        "document_type": "Press release"
+      }
+    ],
+    "ordered_ministers": [
+      {
+        "name_prefix": "The Rt Hon",
+        "name": "Theresa May MP",
+        "role": "Prime Minister",
+        "href": "/government/people/theresa-may",
+        "role_href": "/government/ministers/prime-minister",
+        "image": {
+          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/6/PM_portrait_960x640.jpg",
+          "alt_text": "Theresa May MP"
+        }
+      }
+    ],
+    "social_media_links": [
+      {
+        "service_type": "twitter",
+        "title": "Twitter - @10DowningStreet",
+        "href": "https://twitter.com/@10DowningStreet"
+      },
+      {
+        "service_type": "facebook",
+        "title": "Facebook",
+        "href": "https://www.facebook.com/10downingstreet"
+      }
+    ],
+    "ordered_promotional_features": []
+  },
+  "links": {
+    "available_translations": [],
+    "ordered_high_profile_groups": [
+      {
+        "content_id": "49e09fa7-f65b-49d6-b4ab-0ca82a548e93",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2017-10-03T12:48:26Z",
+        "base_path": "/government/organisations/attorney-generals-office-1",
+        "title": "High Profile Group 1"
+      },
+      {
+        "content_id": "49e09fa7-f65b-49d6-b4ab-0ca82a548e94",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2017-10-03T12:48:26Z",
+        "base_path": "/government/organisations/attorney-generals-office-2",
+        "title": "High Profile Group 2"
+      }
+    ]
+  }
+}

--- a/examples/organisation/frontend/tribunal.json
+++ b/examples/organisation/frontend/tribunal.json
@@ -1,0 +1,587 @@
+{
+  "analytics_identifier": "CO1134",
+  "base_path": "/courts-tribunals/employment-appeal-tribunal",
+  "content_id": "caeb418c-d11c-4352-92e9-47b21289f696",
+  "content_purpose_document_supertype": "organising-entities",
+  "content_purpose_supergroup": "other",
+  "content_purpose_subgroup": "other",
+  "document_type": "organisation",
+  "email_document_supertype": "other",
+  "first_published_at": "2015-05-29T12:01:59.000+00:00",
+  "government_document_supertype": "other",
+  "locale": "en",
+  "navigation_document_supertype": "other",
+  "phase": "live",
+  "public_updated_at": "2015-06-22T13:28:06.000+00:00",
+  "publishing_app": "whitehall",
+  "publishing_scheduled_at": null,
+  "rendering_app": "whitehall-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "organisation",
+  "search_user_need_document_supertype": "government",
+  "title": "Employment Appeal Tribunal",
+  "updated_at": "2018-10-01T17:52:25.635Z",
+  "user_journey_document_supertype": "finding",
+  "withdrawn_notice": {},
+  "publishing_request_id": "1923-1531220385.849-194.33.192.5-1719",
+  "links": {
+    "ordered_contacts": [
+      {
+        "content_id": "5036b271-1f4b-499f-bf8e-50d8927d8702",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2015-05-29T11:20:57Z",
+        "schema_name": "contact",
+        "title": "General enquiries (England and Wales)",
+        "withdrawn": false,
+        "details": {
+          "description": "",
+          "contact_type": "General contact",
+          "title": "General enquiries (England and Wales)",
+          "contact_form_links": [
+            {
+              "title": "General enquiries (England and Wales)",
+              "link": "",
+              "description": ""
+            }
+          ],
+          "post_addresses": [
+            {
+              "title": "Employment Appeal Tribunal (EAT)",
+              "street_address": "Second Floor\r\nFleetbank House\r\n2-6 Salisbury Square\r\n ",
+              "locality": "London",
+              "region": "",
+              "postal_code": "EC4Y 8AE",
+              "world_location": "United Kingdom"
+            }
+          ],
+          "email_addresses": [
+            {
+              "title": "Employment Appeal Tribunal (EAT)",
+              "email": "londoneat@hmcts.gsi.gov.uk"
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "020 7273 1041"
+            },
+            {
+              "title": "Fax",
+              "number": "01264 785 028 "
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "286f3494-ac3b-488b-833e-b072765e4831",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2018-07-12T13:11:18Z",
+        "schema_name": "contact",
+        "title": "General enquiries (Scotland)",
+        "withdrawn": false,
+        "details": {
+          "description": "",
+          "contact_type": "General contact",
+          "title": "General enquiries (Scotland)",
+          "contact_form_links": [
+            {
+              "title": "General enquiries (Scotland)",
+              "link": "",
+              "description": ""
+            }
+          ],
+          "post_addresses": [
+            {
+              "title": "Employment Appeal Tribunal (EAT)",
+              "street_address": "George House\r\n126 George Street",
+              "locality": "Edinburgh",
+              "region": "",
+              "postal_code": "EH2 4HH",
+              "world_location": "United Kingdom"
+            }
+          ],
+          "email_addresses": [
+            {
+              "title": "Employment Appeal Tribunal (EAT)",
+              "email": "edinburgheat@hmcts.gsi.gov.uk"
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "0131 225 3963"
+            },
+            {
+              "title": "Fax",
+              "number": "01264 785 030"
+            }
+          ]
+        },
+        "links": {}
+      }
+    ],
+    "ordered_parent_organisations": [
+      {
+        "analytics_identifier": "EA73",
+        "api_path": "/api/content/government/organisations/hm-courts-and-tribunals-service",
+        "base_path": "/government/organisations/hm-courts-and-tribunals-service",
+        "content_id": "6f757605-ab8f-4b62-84e4-99f79cf085c2",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2018-03-19T17:45:22Z",
+        "schema_name": "organisation",
+        "title": "HM Courts & Tribunals Service",
+        "withdrawn": false,
+        "details": {
+          "acronym": "HMCTS",
+          "body": "<div class=\"govspeak\"><p>HM Courts &amp; Tribunals Service is responsible for the administration of criminal, civil and family courts and tribunals in England and Wales.</p>\n\n<p><abbr title=\"HM Courts &amp; Tribunals Service\">HMCTS</abbr> is an executive agency, sponsored by the <a class=\"brand__color\" href=\"/government/organisations/ministry-of-justice\">Ministry of Justice</a>.</p>\n</div>",
+          "brand": "ministry-of-justice",
+          "logo": {
+            "formatted_title": "HM Courts &amp; <br/>Tribunals Service",
+            "crest": "single-identity"
+          },
+          "foi_exempt": false,
+          "ordered_corporate_information_pages": [
+            {
+              "title": "Statistics at HMCTS",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/statistics"
+            },
+            {
+              "title": "Equality and diversity",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/equality-and-diversity"
+            },
+            {
+              "title": "Complaints procedure",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/complaints-procedure"
+            },
+            {
+              "title": "Our governance",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/our-governance"
+            },
+            {
+              "title": "Corporate reports",
+              "href": "/government/publications?departments%5B%5D=hm-courts-and-tribunals-service&publication_type=corporate-reports"
+            },
+            {
+              "title": "Transparency data",
+              "href": "/government/publications?departments%5B%5D=hm-courts-and-tribunals-service&publication_type=transparency-data"
+            },
+            {
+              "title": "Procurement at HMCTS",
+              "href": "/government/organisations/hm-courts-and-tribunals-service/about/procurement"
+            },
+            {
+              "title": "Jobs",
+              "href": "https://www.civilservicejobs.service.gov.uk/csr"
+            }
+          ],
+          "secondary_corporate_information_pages": "Read about the types of information we routinely publish in our <a class=\"brand__color\" href=\"/government/organisations/hm-courts-and-tribunals-service/about/publication-scheme\">Publication scheme</a>. Find out about our commitment to <a class=\"brand__color\" href=\"/government/organisations/hm-courts-and-tribunals-service/about/welsh-language-scheme\">publishing in Welsh</a>. Our <a class=\"brand__color\" href=\"/government/organisations/hm-courts-and-tribunals-service/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
+          "ordered_featured_links": [
+            {
+              "title": "Court and tribunal forms",
+              "href": "https://hmctsformfinder.justice.gov.uk/HMCTS/FormFinder.do"
+            },
+            {
+              "title": "Find a court or tribunal",
+              "href": "https://courttribunalfinder.service.gov.uk/search/"
+            },
+            {
+              "title": "Fees and help with fees",
+              "href": "https://www.gov.uk/court-fees-what-they-are"
+            },
+            {
+              "title": "Wills, probate and inheritance",
+              "href": "https://www.gov.uk/wills-probate-inheritance"
+            },
+            {
+              "title": "Make a court claim for money",
+              "href": "https://www.gov.uk/make-court-claim-for-money"
+            },
+            {
+              "title": "Get a divorce",
+              "href": "https://www.gov.uk/divorce"
+            },
+            {
+              "title": "Appeal to the SSCS Tribunal",
+              "href": "https://www.gov.uk/social-security-child-support-tribunal"
+            },
+            {
+              "title": "Pay a court fine online",
+              "href": "https://www.gov.uk/pay-court-fine-online"
+            },
+            {
+              "title": "Sign up to our email news alerts",
+              "href": "https://public.govdelivery.com/accounts/UKHMCTS/subscriber/new?qsp=UKHMCTS_1"
+            }
+          ],
+          "ordered_featured_documents": [
+            {
+              "title": "Scotland Tribunals recognised as a Carer Positive Employer",
+              "href": "/government/news/scotland-tribunals-recognised-as-a-carer-positive-employer",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/65899/Scotland_carers_group_960x640.png",
+                "alt_text": "HMCTS staff holding certificate"
+              },
+              "summary": "<div class=\"govspeak\"><p>Chief executive Susan Acland-Hood visits Glasgow to hear about the support available for carers in our workforce.</p>\n</div>",
+              "public_updated_at": "2018-09-25T12:04:00.000+01:00",
+              "document_type": "News story"
+            },
+            {
+              "title": "Results of fully-video hearings pilot published",
+              "href": "/government/news/results-of-fully-video-hearings-pilot-published",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/65597/Video-hearing-laptop_960x640.png",
+                "alt_text": "Laptop woth video screens"
+              },
+              "summary": "<div class=\"govspeak\"><p>Court users taking part in the first fully-video hearings found them convenient and easy to understand, an independent report published today reveals.</p>\n</div>",
+              "public_updated_at": "2018-09-13T12:00:05.000+01:00",
+              "document_type": "Press release"
+            },
+            {
+              "title": "Implementing Video hearings (Party-to-State) - A Process Evaluation",
+              "href": "/government/publications/implementing-video-hearings-party-to-state-a-process-evaluation",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/65598/MOJ_960x640.png",
+                "alt_text": "Ministry of Justice building"
+              },
+              "summary": "<div class=\"govspeak\"><p>This report sets out the findings of an independent evaluation of the Video Hearings Pilot (party-to-state) 2018 carried out by HMCTS.</p>\n</div>",
+              "public_updated_at": "2018-09-13T12:00:06.000+01:00",
+              "document_type": "Independent report"
+            },
+            {
+              "title": "HMCTS reform roadshow events 2018 to 2019",
+              "href": "/government/news/hmcts-reform-roadshow-events-2018-to-2019",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/65474/Image_of_roadshow_event960_x_640.jpg",
+                "alt_text": "Image of roadshow presentation"
+              },
+              "summary": "<div class=\"govspeak\"><p>Information for legal professionals and court users to participate in events about our courts and tribunals reform programme.</p>\n</div>",
+              "public_updated_at": "2018-09-07T12:57:00.000+01:00",
+              "document_type": "News story"
+            },
+            {
+              "title": "Government announces easier court entrance for legal sector",
+              "href": "/government/news/government-announces-easier-court-entrance-for-legal-sector",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/64881/Court_Security_960x640.png",
+                "alt_text": "Court building security "
+              },
+              "summary": "<div class=\"govspeak\"><p>Legal professionals are encouraged to register with their local court in advance of a government pilot designed to reduce queues and grant them easier access.</p>\n</div>",
+              "public_updated_at": "2018-08-09T09:59:00.000+01:00",
+              "document_type": "Press release"
+            },
+            {
+              "title": "HMCTS Reform Programme",
+              "href": "/government/news/hmcts-reform-programme",
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/63612/Lady_Justice_960x640.jpg",
+                "alt_text": "Lady Justice"
+              },
+              "summary": "<div class=\"govspeak\"><p>Read all the latest information and updates on the HM Courts &amp; Tribunals Service court reform programme.</p>\n</div>",
+              "public_updated_at": "2018-10-01T18:27:15.000+01:00",
+              "document_type": "News story"
+            }
+          ],
+          "ordered_promotional_features": [],
+          "ordered_ministers": [],
+          "ordered_board_members": [
+            {
+              "name_prefix": null,
+              "name": "Susan Acland-Hood",
+              "role": "Chief Executive and Board member, HM Courts & Tribunals Service",
+              "href": "/government/people/susan-acland-hood",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2543/Susan_6_April_2017_960x640.png",
+                "alt_text": "Susan Acland-Hood"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Tim Parker",
+              "role": "Independent Chair of Board",
+              "href": "/government/people/tim-parker",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3481/Tim_Parker960_x_640.jpg",
+                "alt_text": "Tim Parker"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Kevin Sadler",
+              "role": "Deputy Chief Executive and Board Member, HM Courts & Tribunals Service ",
+              "href": "/government/people/kevin-sadler",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2214/kevin-sadler.jpg",
+                "alt_text": "Kevin Sadler"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Andrew Baigent",
+              "role": "Chief Finance Officer and Board Member",
+              "href": "/government/people/andrew-baigent",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3206/Andrew_Baigent_960_x_640.jpg",
+                "alt_text": "Andrew Baigent"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Guy Tompkins",
+              "role": "Operations Director and Board Member",
+              "href": "/government/people/guy-tompkins",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2220/guy-tompkins-2.jpg",
+                "alt_text": "Guy Tompkins"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Kevin Gallagher",
+              "role": "Digital Director",
+              "href": "/government/people/kevin-gallagher",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2328/kevin-gallagher.jpg",
+                "alt_text": "Kevin Gallagher"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Richard Goodman",
+              "role": "Change Director",
+              "href": "/government/people/richard-goodman",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2737/richard-goodman.jpg",
+                "alt_text": "Richard Goodman"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Ed Owen",
+              "role": "Director of Communications",
+              "href": "/government/people/ed-owen",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3483/Ed_960x640.jpg",
+                "alt_text": "Ed Owen"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Sidonie Kingsmill",
+              "role": "Customer Director",
+              "href": "/government/people/sidonie-kingsmill",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2476/sidonie-kingsmill.jpg",
+                "alt_text": "Sidonie Kingsmill"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Victoria Cochrane",
+              "role": "Independent Chair of Audit Committee (Non-executive Board Member)",
+              "href": "/government/people/victoria-cochrane",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null
+            },
+            {
+              "name_prefix": null,
+              "name": "Ian Playford",
+              "role": "Independent Non-executive Board Member",
+              "href": "/government/people/ian-playford",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null
+            },
+            {
+              "name_prefix": null,
+              "name": "Sir Ernest Ryder",
+              "role": "Independent Judicial Board Member",
+              "href": "/government/people/lord-justice-ryder",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2487/lord-justice-ryder.jpg",
+                "alt_text": "Sir Ernest Ryder"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "District Judge Tim Jenkins",
+              "role": "Independent Judicial Board Member",
+              "href": "/government/people/tim-jenkins",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2889/Tim_Jenkins_960x640__002_.png",
+                "alt_text": "District Judge Tim Jenkins"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Liz  Doherty",
+              "role": "Ministry of Justice Representative Board Member",
+              "href": "/government/people/liz-doherty",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2435/Liz_Doherty_960x640__1_.jpg",
+                "alt_text": "Liz  Doherty"
+              }
+            },
+            {
+              "name_prefix": null,
+              "name": "Lady Justice Macur DBE",
+              "role": "Independent Judicial Board Member",
+              "href": "/government/people/justice-macur",
+              "role_href": null,
+              "payment_type": null,
+              "attends_cabinet_type": null,
+              "image": {
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/1668/macur_j.jpg",
+                "alt_text": "Lady Justice Macur DBE"
+              }
+            }
+          ],
+          "ordered_military_personnel": [],
+          "ordered_traffic_commissioners": [],
+          "ordered_chief_professional_officers": [],
+          "ordered_special_representatives": [],
+          "important_board_members": 1,
+          "organisation_featuring_priority": "service",
+          "organisation_govuk_status": {
+            "status": "live",
+            "url": null,
+            "updated_at": null
+          },
+          "organisation_type": "executive_agency",
+          "social_media_links": [
+            {
+              "service_type": "email",
+              "title": "Email updates",
+              "href": "https://public.govdelivery.com/accounts/UKHMCTS/subscriber/topics?qsp=UKHMCTS_1"
+            },
+            {
+              "service_type": "blog",
+              "title": "Inside HMCTS",
+              "href": "https://insidehmcts.blog.gov.uk/"
+            },
+            {
+              "service_type": "twitter",
+              "title": "HMCTS CEO Twitter",
+              "href": "https://twitter.com/CEOofHMCTS"
+            },
+            {
+              "service_type": "twitter",
+              "title": "HMCTS Twitter",
+              "href": "https://twitter.com/HMCTSgovuk"
+            },
+            {
+              "service_type": "linkedin",
+              "title": "HMCTS LinkedIn",
+              "href": "https://www.linkedin.com/company/hm-courts-&-tribunals-service"
+            },
+            {
+              "service_type": "youtube",
+              "title": "HMCTS YouTube",
+              "href": "https://www.youtube.com/channel/UC5Altka7XMeXog5ZFzBT9dA"
+            }
+          ]
+        },
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/organisations/hm-courts-and-tribunals-service",
+        "web_url": "https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Employment Appeal Tribunal",
+        "public_updated_at": "2015-06-22T13:28:06Z",
+        "analytics_identifier": "CO1134",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "base_path": "/courts-tribunals/employment-appeal-tribunal",
+        "api_path": "/api/content/courts-tribunals/employment-appeal-tribunal",
+        "withdrawn": false,
+        "content_id": "caeb418c-d11c-4352-92e9-47b21289f696",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/courts-tribunals/employment-appeal-tribunal",
+        "web_url": "https://www.gov.uk/courts-tribunals/employment-appeal-tribunal",
+        "links": {}
+      }
+    ]
+  },
+  "description": null,
+  "details": {
+    "acronym": "",
+    "body": "<div class=\"govspeak\"><p>We’re responsible for handling appeals against decisions made by the Employment Tribunal where a legal mistake may have been made in the case. This might be because the Employment Tribunal:</p>\n\n<ul>\n  <li>got the law wrong</li>\n  <li>didn’t apply the correct law</li>\n  <li>didn’t follow the correct procedures and this affected the decision</li>\n  <li>had no evidence to support its decision</li>\n  <li>was unfairly biased towards the other party</li>\n</ul>\n\n<p>We also hear appeals and applications about decisions made by the Certification Officer and the Central Arbitration Committee.</p>\n\n<h2 id=\"who-we-are\">Who we are</h2>\n\n<p>We are an independent tribunal which settles legal disputes around employment law.</p>\n\n<h2 id=\"tribunal-information\">Tribunal information</h2>\n\n<ul>\n  <li><a rel=\"external\" href=\"http://hmctsformfinder.justice.gov.uk/HMCTS/GetForms.do?court_forms_category=Employment%20Appeal%20Tribunal\">Forms and further guidance</a></li>\n  <li><a rel=\"external\" href=\"http://www.employmentappeals.gov.uk/public/causelist.aspx\">Cause list</a></li>\n  <li><a rel=\"external\" href=\"https://www.judiciary.gov.uk/publications/?filter_type=publication&amp;search=&amp;tax-single-subject=-1&amp;tax-single-publication-type=-1&amp;tax-single-publication-jurisdiction=998&amp;date-range-after=&amp;date-range-before=\">Practice direction and statements</a></li>\n  <li><a href=\"https://www.gov.uk/employment-appeal-tribunal-decisions\">Previous decisions</a></li>\n  <li><a href=\"https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/complaints-procedure\">Complaints procedure</a></li>\n</ul>\n</div>",
+    "brand": null,
+    "logo": {
+      "formatted_title": "Employment Appeal Tribunal"
+    },
+    "foi_exempt": false,
+    "ordered_corporate_information_pages": [
+      {
+        "title": "Jobs",
+        "href": "https://www.civilservicejobs.service.gov.uk/csr"
+      }
+    ],
+    "secondary_corporate_information_pages": "",
+    "ordered_featured_links": [
+      {
+        "title": "Appeal to the tribunal",
+        "href": "https://www.gov.uk/appeal-employment-appeal-tribunal"
+      }
+    ],
+    "ordered_featured_documents": [],
+    "ordered_promotional_features": [],
+    "ordered_ministers": [],
+    "ordered_board_members": [],
+    "ordered_military_personnel": [],
+    "ordered_traffic_commissioners": [],
+    "ordered_chief_professional_officers": [],
+    "ordered_special_representatives": [],
+    "important_board_members": 1,
+    "organisation_featuring_priority": "service",
+    "organisation_govuk_status": {
+      "status": "live",
+      "url": null,
+      "updated_at": null
+    },
+    "organisation_type": "tribunal_ndpb",
+    "social_media_links": []
+  }
+}

--- a/examples/organisation/frontend/wales_office.json
+++ b/examples/organisation/frontend/wales_office.json
@@ -1,0 +1,171 @@
+{
+  "title": "Office of the Secretary of State for Wales",
+  "base_path": "/government/organisations/office-of-the-secretary-of-state-for-wales",
+  "content_id": "f323e83c-868b-4bcb-b6e2-a8f9bb40397c",
+  "analytics_identifier": "D1197",
+  "description": null,
+  "document_type": "organisation",
+  "first_published_at": "2016-07-14T18:15:21.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2018-01-09T10:07:59.000+00:00",
+  "publishing_app": "whitehall",
+  "rendering_app": "collections",
+  "schema_name": "organisation",
+  "updated_at": "2018-03-27T18:42:06.661Z",
+  "details": {
+    "body": "The Office of the Secretary of State for Wales supports the Welsh Secretary",
+    "brand": "wales-office",
+    "logo": {
+      "formatted_title": "Office of the Secretary of State for Wales<br/>Swyddfa Ysgrifennydd Gwladol Cymru",
+      "crest": "single-identity"
+    },
+    "organisation_govuk_status": {
+      "status": "live"
+    },
+    "organisation_type": "non_ministerial_department",
+    "ordered_featured_links": [
+      {
+        "title": "Wales Office Featured Link",
+        "href": "/wales/link/1"
+      }
+    ],
+    "ordered_featured_documents": [
+      {
+        "title": "Welsh Secretary hails outstanding individuals in the Queen's Birthday Honours list",
+        "href": "/government/news/welsh-secretary-hails-outstanding-individuals-in-the-queens-birthday-honours-list",
+        "image": {
+          "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/feature/image/63372/GOV.UK_honours_web.jpg",
+          "alt_text": "Queen's Birthday Honours"
+        },
+        "summary": "Alun Cairns: \"I'm proud to see people from all walks of Welsh life honoured today\".",
+        "public_updated_at": "2018-06-08T23:23:11.000+01:00",
+        "document_type": "Press release"
+      }
+    ],
+    "social_media_links": [
+      {
+        "service_type": "twitter",
+        "title": "Twitter",
+        "href": "https://twitter.com/UKGovWales"
+      },
+      {
+        "service_type": "twitter",
+        "title": "Trydar",
+        "href": "https://twitter.com/LlywDUCymru"
+      }
+    ],
+    "ordered_military_personnel": [
+      {
+        "name": "Air Chief Marshal Sir  Stuart Peach GBE KCB ADC DL",
+        "role": "Chief of the Defence Staff",
+        "href": "/government/people/stuart-peach"
+      }
+    ]
+  },
+  "links": {
+    "available_translations": [
+      {
+        "title": "Swyddfa Ysgrifennydd Gwladol Cymru",
+        "public_updated_at": "2017-04-10T09:43:55Z",
+        "analytics_identifier": "D24",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "base_path": "/government/organisations/office-of-the-secretary-of-state-for-wales.cy",
+        "api_path": "/api/content/government/organisations/office-of-the-secretary-of-state-for-wales.cy",
+        "withdrawn": false,
+        "content_id": "4f9fe232-e7a2-48e8-99b1-8f7828680493",
+        "locale": "cy",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/office-of-the-secretary-of-state-for-wales.cy",
+        "web_url": "https://www.gov.uk/government/organisations/office-of-the-secretary-of-state-for-wales.cy",
+        "links": {}
+      },
+      {
+        "title": "Office of the Secretary of State for Wales",
+        "public_updated_at": "2017-04-10T09:43:55Z",
+        "analytics_identifier": "D24",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "base_path": "/government/organisations/office-of-the-secretary-of-state-for-wales",
+        "api_path": "/api/content/government/organisations/office-of-the-secretary-of-state-for-wales",
+        "withdrawn": false,
+        "content_id": "4f9fe232-e7a2-48e8-99b1-8f7828680493",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/office-of-the-secretary-of-state-for-wales",
+        "web_url": "https://www.gov.uk/government/organisations/office-of-the-secretary-of-state-for-wales",
+        "links": {}
+      }
+    ],
+    "ordered_contacts": [],
+    "ordered_foi_contacts": [
+      {
+        "content_id": "c9253289-a38e-422b-b16d-90e4b3b373d2",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2017-02-07T13:12:46Z",
+        "schema_name": "contact",
+        "title": "FOI requests",
+        "withdrawn": false,
+        "details": {
+          "title": "FOI stuff",
+          "description": "FOI requests\r\n\r\nare possible",
+          "post_addresses": [
+            {
+              "title": "Office of the Secretary of State for Wales",
+              "street_address": "Gwydyr House\r\nWhitehall",
+              "locality": "",
+              "postal_code": "SW1A 2NP"
+            },
+            {
+              "title": "Office of the Secretary of State for Wales Cardiff",
+              "street_address": "White House\r\nCardiff",
+              "locality": "",
+              "postal_code": "W1 3BZ"
+            }
+          ],
+          "email_addresses": [
+            {
+              "email": "walesofficefoi@walesoffice.gsi.gov.uk"
+            },
+            {
+              "email": "foiwales@walesoffice.gsi.gov.uk"
+            }
+          ],
+          "contact_form_links": [
+            {
+              "title": "",
+              "link": "/foi_contact_link",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "c9253289-a38e-422b-b16d-90e4b3b373d3",
+        "document_type": "contact",
+        "locale": "en",
+        "public_updated_at": "2017-02-07T13:12:46Z",
+        "schema_name": "contact",
+        "title": "FOI requests 2",
+        "withdrawn": false,
+        "details": {
+          "description": "Something here\r\n\r\nSomething there",
+          "post_addresses": [
+            {
+              "title": "The Welsh Office",
+              "street_address": "Green House\r\nBracknell",
+              "locality": "",
+              "postal_code": "B2 3ZZ"
+            }
+          ],
+          "email_addresses": [
+            {
+              "email": "welshofficefoi@walesoffice.gsi.gov.uk"
+            }
+          ],
+          "contact_form_links": []
+        }
+      }
+    ]
+  }
+}

--- a/lib/schema_generator/format.rb
+++ b/lib/schema_generator/format.rb
@@ -267,6 +267,7 @@ module SchemaGenerator
 
     class Links
       ALLOWED_KEYS = %w(description required minItems maxItems).freeze
+      LINKS_WITHOUT_BASE_PATHS = %w(ordered_contacts ordered_foi_contacts world_locations).freeze
 
       attr_reader :links
 
@@ -294,7 +295,7 @@ module SchemaGenerator
           # however apps aren't coded for this so fail on this, therefore
           # this legacy fix is included.
           # @FIXME remove need for this check
-          definition = k == "world_locations" ? "frontend_links" : "frontend_links_with_base_path"
+          definition = LINKS_WITHOUT_BASE_PATHS.include?(k) ? "frontend_links" : "frontend_links_with_base_path"
           link = v.merge({ "$ref" => "#/definitions/#{definition}" })
             .delete_if { |field| %w(required minItems).include?(field) }
           hash[k] = link


### PR DESCRIPTION
This adds examples for:

- courts and tribunals pages which are served from under "/courts-tribunals/"
- examples for specific org pages (served from under "/government/organisations/") which enable us to reduce the code in the tests for org pages

Org pages link to several things that don't have base_paths, such as organisation contacts and foi contacts.  The new examples fail the tests unless we can generate linked items without base paths which only currently happens for linked items that are `world_locations`

In theory there is no restriction on which content types are linked, so this check feels a bit like a false safety net because a content item without a base path could be added to any link section.  In practice, this doesn't seem to happen.

I tried removing the requirement for a base path from this section, but a lot of downstream tests failed on apps that use govuk_schemas to generate example content items.  I don't have time to fix them all at the moment so I'll reuse the existing pattern here instead.

https://trello.com/c/IRoHCQ3N/143-render-courts-and-tribunals-pages-from-collections