### PR TITLE
Update the travel advice index example to support new style links

### DIFF
--- a/examples/travel_advice_index/frontend/index.json
+++ b/examples/travel_advice_index/frontend/index.json
@@ -22,14 +22,16 @@
         "schema_name": "travel_advice",
         "title": "Afghanistan travel advice",
         "withdrawn": false,
-        "country": {
-          "slug": "afghanistan",
-          "name": "Afghanistan",
-          "synonyms": [
-
-          ]
+        "details": {
+          "country": {
+            "slug": "afghanistan",
+            "name": "Afghanistan",
+            "synonyms": [
+  
+            ]
+          },
+          "change_description": "Latest update: Summary - on 26 October 2015 a serious earthquake struck causing casualties around the country and affecting communications networks; if someone you know is likely to have been involved and you're unable to contact them, contact the British Embassy in Kabul"
         },
-        "change_description": "Latest update: Summary - on 26 October 2015 a serious earthquake struck causing casualties around the country and affecting communications networks; if someone you know is likely to have been involved and you're unable to contact them, contact the British Embassy in Kabul",
         "links": {
         },
         "api_url": "http://www.dev.gov.uk/api/content/foreign-travel-advice/afghanistan",


### PR DESCRIPTION
As per https://github.com/alphagov/frontend/pull/1643 we allow the frontend to support both the old style and new style of `details` multi-level links.

I've done this for only one child travel advice to ensure that it copes with both kinds of formats, once that's all deployed, we can change all of them.