### PR TITLE
Remove extra fields from organisation link details again

### DIFF
--- a/examples/travel_advice_index/frontend/index.json
+++ b/examples/travel_advice_index/frontend/index.json
@@ -49,14 +49,16 @@
         "schema_name": "travel_advice",
         "title": "Austria travel advice",
         "withdrawn": false,
-        "country": {
-          "slug": "austria",
-          "name": "Austria",
-          "synonyms": [
+        "details": {
+          "country": {
+            "slug": "austria",
+            "name": "Austria",
+            "synonyms": [
 
-          ]
+            ]
+          },
+          "change_description": "Latest update: Summary – there’s ongoing disruption to rail and road transport; you should monitor local media and check with your transport provider or the Austrian Railways (OBB) website"
         },
-        "change_description": "Latest update: Summary – there’s ongoing disruption to rail and road transport; you should monitor local media and check with your transport provider or the Austrian Railways (OBB) website",
         "links": {
         },
         "api_url": "http://www.dev.gov.uk/api/content/foreign-travel-advice/austria",


### PR DESCRIPTION
This one was missed in the previous PR https://github.com/alphagov/govuk-content-schemas/pull/820 and it's making https://github.com/alphagov/frontend/pull/1644 fail.

> In #819 we updated one example, but now that the change has been deployed we can update all of them.

> We can see from https://www.gov.uk/api/content/foreign-travel-advice that the links now follow that format.