### PR TITLE
Add tracking domain to service sign in

### DIFF
--- a/dist/formats/service_sign_in/frontend/schema.json
+++ b/dist/formats/service_sign_in/frontend/schema.json
@@ -343,6 +343,9 @@
         "tracking_code": {
           "type": "string"
         },
+        "tracking_domain": {
+          "type": "string"
+        },
         "tracking_name": {
           "type": "string"
         }

--- a/dist/formats/service_sign_in/notification/schema.json
+++ b/dist/formats/service_sign_in/notification/schema.json
@@ -393,6 +393,9 @@
         "tracking_code": {
           "type": "string"
         },
+        "tracking_domain": {
+          "type": "string"
+        },
         "tracking_name": {
           "type": "string"
         }

--- a/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -202,6 +202,9 @@
         "tracking_code": {
           "type": "string"
         },
+        "tracking_domain": {
+          "type": "string"
+        },
         "tracking_name": {
           "type": "string"
         }

--- a/examples/service_sign_in/frontend/service_sign_in.json
+++ b/examples/service_sign_in/frontend/service_sign_in.json
@@ -31,6 +31,7 @@
       "title": "Prove your identity to continue",
       "slug": "choose-sign-in",
       "tracking_code": "UA-xxxxxx",
+      "tracking_domain": "tax.service.gov.uk",
       "tracking_name": "somethingClicky",
       "description": "<p>You can't file online until you've activated Government Gateway account using your Unique Taxpayer Reference(UTR).</p>",
       "options": [

--- a/formats/service_sign_in.jsonnet
+++ b/formats/service_sign_in.jsonnet
@@ -38,6 +38,9 @@
         tracking_code: {
           type: "string"
         },
+        tracking_domain: {
+          type: "string"
+        },
         tracking_name: {
           type: "string"
         },


### PR DESCRIPTION
Adds an optional tracking domain attribute to service sign in format. This will allow a per page cross domain tracking configuration rather than relying on the urls in the various options.