### PR TITLE
Add env var to force use of system jsonnet libraries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,7 @@ node {
     }
 
     stage("bundle install") {
+      env.JSONNET_USE_SYSTEM_LIBRARIES = 1
       govuk.bundleApp();
     }
 


### PR DESCRIPTION
https://ci.integration.publishing.service.gov.uk/job/govuk-content-schemas/job/master/811/console

Miniportile is used to retrieve jsonnet from github.
The progress reporter in miniportile can't handle a nil content-length response which github sends with `content-encoding: Chunked`.
There's a fix https://github.com/flavorjones/mini_portile/pull/86
which needs approval for release but we don't know when this will happen.

I've compiled and installed the system libraries on our CI agents to support this temporary measure.