### PR TITLE
Add the CPM to dependentApplications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ def dependentApplications = [
   ['collections-publisher', true],
   ['collections', true],
   ['contacts', true],
+  ['content-performance-manager', true],
   ['content-store', true],
   ['content-tagger', true],
   ['email-alert-frontend', true],


### PR DESCRIPTION
The Content Performance Manager processes content, so enable running
it's tests on schema changes, which will hopefully help spot when the
CPM needs updating for schema changes.