### PR TITLE
Allow a high resolution URL to be set for images

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -532,7 +532,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -604,7 +604,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -277,7 +277,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -550,7 +550,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -627,7 +627,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -392,7 +392,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -499,7 +499,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -571,7 +571,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -310,7 +310,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -566,7 +566,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -656,7 +656,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -322,7 +322,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -819,7 +819,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -914,7 +914,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/organisation/publisher_v2/schema.json
+++ b/dist/formats/organisation/publisher_v2/schema.json
@@ -615,7 +615,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/organisations_homepage/frontend/schema.json
+++ b/dist/formats/organisations_homepage/frontend/schema.json
@@ -426,7 +426,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/organisations_homepage/notification/schema.json
+++ b/dist/formats/organisations_homepage/notification/schema.json
@@ -489,7 +489,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -222,7 +222,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/person/frontend/schema.json
+++ b/dist/formats/person/frontend/schema.json
@@ -440,7 +440,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/person/notification/schema.json
+++ b/dist/formats/person/notification/schema.json
@@ -511,7 +511,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/person/publisher_v2/schema.json
+++ b/dist/formats/person/publisher_v2/schema.json
@@ -236,7 +236,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -663,7 +663,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -730,7 +730,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -459,7 +459,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -581,7 +581,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -670,7 +670,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -309,7 +309,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -419,7 +419,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -482,7 +482,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -215,7 +215,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -535,7 +535,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -607,7 +607,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -280,7 +280,13 @@
             }
           ]
         },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",
           "format": "uri"
         }

--- a/formats/shared/definitions/_whitehall.jsonnet
+++ b/formats/shared/definitions/_whitehall.jsonnet
@@ -30,6 +30,12 @@
     ],
     properties: {
       url: {
+        description: "URL to the image. The image should be in a suitable resolution for display on the page.",
+        type: "string",
+        format: "uri",
+      },
+      high_resolution_url: {
+        description: "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
         type: "string",
         format: "uri",
       },


### PR DESCRIPTION
Currently, applications like Whitehall set `details.image.url` to a small sized image, for display on the frontend. For example, the [small lead image for a news story](https://www.gov.uk/government/news/government-announces-additional-funding-towards-mayflower-400-commemorations).

This image is 300px wide on the page, so Whitehall sends a 300px version. Since the introduction of the [machine readable metdata component](https://govuk-publishing-components.herokuapp.com/component-guide/machine_readable_metadata) we also expose the image in the meta tags to services like Facebook, Twitter, Google, and Slack. However, they often need a larger resolution image than what we're currently providing. This causes blurry pictures on Twitter:

<img width="631" alt="screen shot 2018-10-25 at 14 47 41" src="https://user-images.githubusercontent.com/233676/47504852-f4314900-d864-11e8-939d-fcd968510a58.png">

This PR adds a second attribute that contains a "high resolution" version. The component will use this instead of the smaller version.

https://trello.com/c/eqcMykln