### PR TITLE
Make base_path optional for nested links

### DIFF
--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -410,7 +410,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -469,7 +469,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -587,7 +587,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -653,7 +653,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -421,7 +421,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -498,7 +498,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/organisation/frontend/schema.json
+++ b/dist/formats/organisation/frontend/schema.json
@@ -763,7 +763,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/organisation/notification/schema.json
+++ b/dist/formats/organisation/notification/schema.json
@@ -845,7 +845,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -442,7 +442,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -512,7 +512,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -436,7 +436,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -512,7 +512,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -390,7 +390,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -449,7 +449,7 @@
             "type": "object",
             "patternProperties": {
               "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links_with_base_path"
+                "$ref": "#/definitions/frontend_links"
               }
             }
           },

--- a/formats/shared/definitions/frontend_links.jsonnet
+++ b/formats/shared/definitions/frontend_links.jsonnet
@@ -54,7 +54,7 @@
           type: "object",
           patternProperties: {
             "^[a-z_]+$": {
-              "$ref": "#/definitions/frontend_links_with_base_path",
+              "$ref": "#/definitions/frontend_links",
             }
           }
         },


### PR DESCRIPTION
As described in https://github.com/alphagov/govuk_publishing_components/pull/595#discussion_r229322211, https://github.com/alphagov/govuk-content-schemas/pull/818 made the `base_path` optional in the `links` for certain schemas. However, those same schemas will still need a `base_path` if they're in nested links.