### PR TITLE
Iterate contacts schema

### DIFF
--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -308,9 +308,6 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "title"
-      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
@@ -357,6 +354,7 @@
           "type": "string"
         },
         "description": {
+          "description": "DEPRECATED: this has the same name and data as the top level descriptions field, which should be used instead",
           "type": [
             "string",
             "null"
@@ -367,7 +365,6 @@
           "items": {
             "type": "object",
             "required": [
-              "title",
               "email"
             ],
             "additionalProperties": false,
@@ -482,7 +479,6 @@
           "items": {
             "type": "object",
             "required": [
-              "title",
               "street_address",
               "postal_code",
               "world_location"
@@ -490,6 +486,10 @@
             "additionalProperties": false,
             "properties": {
               "description": {
+                "type": "string"
+              },
+              "iso2_country_code": {
+                "description": "The ISO 3166-1 alpha-2 code for the world location, used to determine how address is rendered",
                 "type": "string"
               },
               "locality": {
@@ -543,6 +543,7 @@
           "type": "string"
         },
         "title": {
+          "description": "DEPRECATED: this has the same name and data as the top level title field, which should be used instead",
           "type": "string"
         }
       }

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -374,9 +374,6 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "title"
-      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
@@ -423,6 +420,7 @@
           "type": "string"
         },
         "description": {
+          "description": "DEPRECATED: this has the same name and data as the top level descriptions field, which should be used instead",
           "type": [
             "string",
             "null"
@@ -433,7 +431,6 @@
           "items": {
             "type": "object",
             "required": [
-              "title",
               "email"
             ],
             "additionalProperties": false,
@@ -548,7 +545,6 @@
           "items": {
             "type": "object",
             "required": [
-              "title",
               "street_address",
               "postal_code",
               "world_location"
@@ -556,6 +552,10 @@
             "additionalProperties": false,
             "properties": {
               "description": {
+                "type": "string"
+              },
+              "iso2_country_code": {
+                "description": "The ISO 3166-1 alpha-2 code for the world location, used to determine how address is rendered",
                 "type": "string"
               },
               "locality": {
@@ -609,6 +609,7 @@
           "type": "string"
         },
         "title": {
+          "description": "DEPRECATED: this has the same name and data as the top level title field, which should be used instead",
           "type": "string"
         }
       }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -168,9 +168,6 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "title"
-      ],
       "additionalProperties": false,
       "properties": {
         "contact_form_links": {
@@ -214,6 +211,7 @@
           "type": "string"
         },
         "description": {
+          "description": "DEPRECATED: this has the same name and data as the top level descriptions field, which should be used instead",
           "type": [
             "string",
             "null"
@@ -224,7 +222,6 @@
           "items": {
             "type": "object",
             "required": [
-              "title",
               "email"
             ],
             "additionalProperties": false,
@@ -339,7 +336,6 @@
           "items": {
             "type": "object",
             "required": [
-              "title",
               "street_address",
               "postal_code",
               "world_location"
@@ -347,6 +343,10 @@
             "additionalProperties": false,
             "properties": {
               "description": {
+                "type": "string"
+              },
+              "iso2_country_code": {
+                "description": "The ISO 3166-1 alpha-2 code for the world location, used to determine how address is rendered",
                 "type": "string"
               },
               "locality": {
@@ -400,6 +400,7 @@
           "type": "string"
         },
         "title": {
+          "description": "DEPRECATED: this has the same name and data as the top level title field, which should be used instead",
           "type": "string"
         }
       }

--- a/examples/contact/frontend/contact.json
+++ b/examples/contact/frontend/contact.json
@@ -67,8 +67,6 @@
   "description": "Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud",
   "details": {
     "slug": "customs-excise-and-vat-fraud-reporting",
-    "title": "Customs, Excise and VAT fraud reporting",
-    "description": "Contact HMRC to report all types of smuggling, misuse of red diesel, customs, excise and VAT fraud",
     "quick_links": [
       {
         "title": "Report smuggling ",

--- a/examples/contact/frontend/contact_with_email_and_no_other_contacts.json
+++ b/examples/contact/frontend/contact_with_email_and_no_other_contacts.json
@@ -62,8 +62,6 @@
   "description": "Contact HMRC for help with Film Tax Relief, Animation Tax Relief, High-end Television Tax Relief and Video Games Development Relief",
   "details": {
     "slug": "creative-industry-tax-reliefs",
-    "title": "Creative Industry Tax Reliefs",
-    "description": "Contact HMRC for help with Film Tax Relief, Animation Tax Relief, High-end Television Tax Relief and Video Games Development Relief",
     "quick_links": [
       {
         "title": "Creative Industry Tax Reliefs",

--- a/examples/contact/frontend/contact_with_webchat.json
+++ b/examples/contact/frontend/contact_with_webchat.json
@@ -117,8 +117,6 @@
   "description": "Contact HMRC for help with questions about Income Tax, including PAYE coding notices, Marriage Allowance and changing your personal details",
   "details": {
     "slug": "income-tax-enquiries-for-individuals-pensioners-and-employees",
-    "title": "Income Tax: general enquiries",
-    "description": "Contact HMRC for help with questions about Income Tax, including PAYE coding notices, Marriage Allowance and changing your personal details",
     "quick_links": [
       {
         "title": "Claim a tax refund ",

--- a/examples/contact/frontend/contact_with_welsh.json
+++ b/examples/contact/frontend/contact_with_welsh.json
@@ -100,8 +100,6 @@
   "description": "Cysylltwch â CThEM am help gyda Threth Incwm, Hunanasesiad, credydau treth, Yswiriant Gwladol, Budd-dal Plant, TWE a mwy",
   "details": {
     "slug": "welsh-language-helplines",
-    "title": "Treth Incwm, Hunanasesiad a mwy",
-    "description": "Cysylltwch â CThEM am help gyda Threth Incwm, Hunanasesiad, credydau treth, Yswiriant Gwladol, Budd-dal Plant, TWE a mwy",
     "quick_links": [
       {
         "title": "Defnyddio gwasanaethau’r llywodraeth yn Gymraeg",

--- a/examples/contact/publisher_v2/whitehall-contact.json
+++ b/examples/contact/publisher_v2/whitehall-contact.json
@@ -3,9 +3,8 @@
   "schema_name": "contact",
   "document_type": "contact",
   "title": "Government Digital Service",
+  "description": "Government Digital Service",
   "details": {
-    "title": "Government Digital Service",
-    "description": "Government Digital Service",
     "contact_type": "general",
     "feature_on_homepage": true,
     "post_addresses": [

--- a/formats/contact.jsonnet
+++ b/formats/contact.jsonnet
@@ -221,6 +221,10 @@
               description: {
                 type: "string",
               },
+              iso2_country_code: {
+                type: "string",
+                description: "The ISO 3166-1 alpha-2 code for the world location, used to determine how address is rendered",
+              }
             },
           },
         },

--- a/formats/contact.jsonnet
+++ b/formats/contact.jsonnet
@@ -117,7 +117,6 @@
             type: "object",
             additionalProperties: false,
             required: [
-              "title",
               "email",
             ],
             properties: {

--- a/formats/contact.jsonnet
+++ b/formats/contact.jsonnet
@@ -7,21 +7,20 @@
     details: {
       type: "object",
       additionalProperties: false,
-      required: [
-        "title"
-      ],
       properties: {
         slug: {
           type: "string",
         },
         title: {
           type: "string",
+          description: "DEPRECATED: this has the same name and data as the top level title field, which should be used instead",
         },
         description: {
           type: [
             "string",
             "null",
           ],
+          description: "DEPRECATED: this has the same name and data as the top level descriptions field, which should be used instead",
         },
         quick_links: {
           type: "array",

--- a/formats/contact.jsonnet
+++ b/formats/contact.jsonnet
@@ -195,7 +195,6 @@
             type: "object",
             additionalProperties: false,
             required: [
-              "title",
               "street_address",
               "postal_code",
               "world_location",


### PR DESCRIPTION
Trello: https://trello.com/c/gEAMmD0g/386-ability-to-embed-a-contact-via-markdown

This makes a number of changes to the contacts schema:

- It deprecates putting title and description as part of details of a contact, this is unnecessary since we have title and description fields outside the details field and these are being populated with the same data.
- It stops requiring title for contact email and postal addresses - Whitehall is currently getting round this requirement by sending empty strings and it'd be better if they were just omitted.
- It adds a field for the iso2_country_code field which can be used as part of [Contact govspeak](https://github.com/alphagov/govspeak/pull/130) feature to determine how an address is formatted.
