### PR TITLE
Remove extra fields from finder link details hash

### DIFF
--- a/examples/specialist_document/frontend/aaib-reports.json
+++ b/examples/specialist_document/frontend/aaib-reports.json
@@ -98,12 +98,6 @@
         "title": "Air Accidents Investigation Branch reports",
         "withdrawn": false,
         "details": {
-          "document_noun": "report",
-          "filter": {
-            "document_type": "aaib_report"
-          },
-          "format_name": "Air Accidents Investigation Branch report",
-          "show_summaries": true,
           "facets": [
             {
               "key": "aircraft_category",
@@ -211,8 +205,7 @@
               "display_as_result_metadata": false,
               "filterable": false
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/asylum-support-decision.json
+++ b/examples/specialist_document/frontend/asylum-support-decision.json
@@ -69,13 +69,6 @@
         "title": "Asylum support tribunal decisions",
         "withdrawn": false,
         "details": {
-          "document_noun": "decision",
-          "filter": {
-            "document_type": "asylum_support_decision"
-          },
-          "format_name": "Asylum support tribunal decision",
-          "show_summaries": true,
-          "summary": "<p>Find decisions on appeals against the Home Office heard by the First-tier Tribunal (Asylum Support).</p>",
           "facets": [
             {
               "key": "tribunal_decision_categories",
@@ -352,8 +345,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/cma-cases.json
+++ b/examples/specialist_document/frontend/cma-cases.json
@@ -116,12 +116,6 @@
         "title": "Competition and Markets Authority cases",
         "withdrawn": false,
         "details": {
-          "document_noun": "case",
-          "filter": {
-            "document_type": "cma_case"
-          },
-          "format_name": "Competition and Markets Authority case",
-          "show_summaries": false,
           "facets": [
             {
               "key": "case_type",
@@ -452,8 +446,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/countryside-stewardship-grants.json
+++ b/examples/specialist_document/frontend/countryside-stewardship-grants.json
@@ -144,13 +144,6 @@
         "title": "Countryside Stewardship grants",
         "withdrawn": false,
         "details": {
-          "document_noun": "grant",
-          "filter": {
-            "document_type": "countryside_stewardship_grant"
-          },
-          "format_name": "Countryside Stewardship grant",
-          "show_summaries": false,
-          "summary": "<p>Find options, supplements and capital items to include in your application for Countryside Stewardship. See <a href=\"government/collections/countryside-stewardship-information-for-agreement-holders\">information for agreement holders</a> for earlier versions.</p>",
           "facets": [
             {
               "key": "grant_type",
@@ -312,8 +305,7 @@
                 }
               ]
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/drug-device-alerts.json
+++ b/examples/specialist_document/frontend/drug-device-alerts.json
@@ -175,12 +175,6 @@
         "title": "Alerts and recalls for drugs and medical devices",
         "withdrawn": false,
         "details": {
-          "document_noun": "alert",
-          "filter": {
-            "document_type": "medical_safety_alert"
-          },
-          "format_name": "Medical safety alert",
-          "show_summaries": true,
           "facets": [
             {
               "key": "alert_type",
@@ -315,8 +309,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/drug-safety-update.json
+++ b/examples/specialist_document/frontend/drug-safety-update.json
@@ -100,12 +100,6 @@
         "title": "Drug Safety Update",
         "withdrawn": false,
         "details": {
-          "document_noun": "update",
-          "filter": {
-            "document_type": "drug_safety_update"
-          },
-          "format_name": "Drug Safety Update",
-          "show_summaries": true,
           "facets": [
             {
               "key": "therapeutic_area",
@@ -218,8 +212,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/employment-tribunal-decision.json
+++ b/examples/specialist_document/frontend/employment-tribunal-decision.json
@@ -57,13 +57,6 @@
         "title": "Employment tribunal decisions",
         "withdrawn": false,
         "details": {
-          "document_noun": "decision",
-          "filter": {
-            "document_type": "employment_tribunal_decision"
-          },
-          "format_name": "Employment tribunal decision",
-          "show_summaries": true,
-          "summary": "<p>Find decisions on Employment Tribunal cases in England, Wales and Scotland.</p>",
           "facets": [
             {
               "key": "tribunal_decision_country",
@@ -327,8 +320,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/eu-withdrawal-act-2018-statutory-instruments.json
+++ b/examples/specialist_document/frontend/eu-withdrawal-act-2018-statutory-instruments.json
@@ -118,14 +118,8 @@
       "title": "EU Withdrawal Act 2018 statutory instruments",
       "withdrawn": false,
       "details": {
-        "document_noun": "statutory instrument",
-        "filter": {
-          "document_type": "statutory_instrument"
-        },
-        "format_name": "EU Withdrawal Act 2018 statutory instrument",
-        "show_summaries": false,
-        "summary": "<p>Find proposed negative statutory instruments created under the EU (Withdrawal) Act 2018.</p><p>‘Proposed negative’ means the government is proposing that the statutory instruments don’t need to be debated in parliament.</p>",
-        "facets": [{
+        "facets": [
+          {
             "key": "laid_date",
             "name": "Laid on",
             "short_name": "Laid on",
@@ -247,8 +241,7 @@
               }
             ]
           }
-        ],
-        "default_documents_per_page": 50
+        ]
       },
       "links": {},
       "api_url": "https://www-origin.integration.publishing.service.gov.uk/api/content/eu-withdrawal-act-2018-statutory-instruments",

--- a/examples/specialist_document/frontend/european-structural-investment-funds.json
+++ b/examples/specialist_document/frontend/european-structural-investment-funds.json
@@ -137,13 +137,6 @@
         "title": "European Structural and Investment Funds (ESIF)",
         "withdrawn": false,
         "details": {
-          "document_noun": "call",
-          "filter": {
-            "document_type": "european_structural_investment_fund"
-          },
-          "format_name": "ESIF call for proposals",
-          "show_summaries": false,
-          "summary": "<p>Applies to: England (see guidance for <a rel=\"external\" href=\"http://www.scotland.gov.uk/Topics/Business-Industry/support/17404\">Scotland</a>, <a rel=\"external\" href=\"http://wefo.wales.gov.uk/programmes/post2013/?skip=1&amp;lang=en\">Wales</a> and <a rel=\"external\" href=\"https://www.dfpni.gov.uk/topics/finance/european-funding-2014-2020\">Northern Ireland</a>)</p><p>Apply to run projects backed by the European Structural and Investment Fund (ESIF). ESIF includes money from the European Social Fund (ESF), European Regional Development Fund (ERDF) and European Agricultural Fund for Rural Development (EAFRD).</p>",
           "facets": [
             {
               "key": "fund_state",
@@ -300,9 +293,7 @@
               "display_as_result_metadata": true,
               "filterable": false
             }
-          ],
-          "default_order": "-closing_date",
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/export-health-certificates.json
+++ b/examples/specialist_document/frontend/export-health-certificates.json
@@ -354,12 +354,6 @@
         "title": "Export health certificates",
         "withdrawn": false,
         "details": {
-          "document_noun": "export health certificate",
-          "filter": {
-            "document_type": "export_health_certificate"
-          },
-          "format_name": "Export health certificate",
-          "show_summaries": false,
           "facets": [
             {
               "key": "destination_country",
@@ -627,8 +621,7 @@
                 }
               ]
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {},
         "api_url": "http://www.dev.gov.uk/api/content/export-health-certificates",

--- a/examples/specialist_document/frontend/international-development-funding.json
+++ b/examples/specialist_document/frontend/international-development-funding.json
@@ -122,12 +122,6 @@
         "title": "International development funding",
         "withdrawn": false,
         "details": {
-          "document_noun": "fund",
-          "filter": {
-            "document_type": "international_development_fund"
-          },
-          "format_name": "International development funding",
-          "show_summaries": true,
           "facets": [
             {
               "key": "fund_state",
@@ -407,8 +401,7 @@
                 }
               ]
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/maib-reports.json
+++ b/examples/specialist_document/frontend/maib-reports.json
@@ -76,12 +76,6 @@
         "title": "Marine Accident Investigation Branch reports",
         "withdrawn": false,
         "details": {
-          "document_noun": "report",
-          "filter": {
-            "document_type": "maib_report"
-          },
-          "format_name": "Marine Accident Investigation Branch report",
-          "show_summaries": true,
           "facets": [
             {
               "key": "vessel_type",
@@ -152,8 +146,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/raib-reports.json
+++ b/examples/specialist_document/frontend/raib-reports.json
@@ -56,12 +56,6 @@
         "title": "Rail Accident Investigation Branch reports",
         "withdrawn": false,
         "details": {
-          "document_noun": "report",
-          "filter": {
-            "document_type": "raib_report"
-          },
-          "format_name": "Rail Accident Investigation Branch report",
-          "show_summaries": false,
           "facets": [
             {
               "key": "railway_type",
@@ -128,8 +122,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/residential-property-tribunal-decision.json
+++ b/examples/specialist_document/frontend/residential-property-tribunal-decision.json
@@ -47,12 +47,6 @@
         "title": "Residential property tribunal decisions",
         "withdrawn": false,
         "details": {
-          "document_noun": "decision",
-          "filter": {
-            "document_type": "residential_property_tribunal_decision"
-          },
-          "format_name": "Residential property tribunal decision",
-          "show_summaries": true,
           "facets": [
             {
               "key": "tribunal_decision_category",
@@ -286,8 +280,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "phase": "beta",
         "links": {},

--- a/examples/specialist_document/frontend/tax-tribunal-decision.json
+++ b/examples/specialist_document/frontend/tax-tribunal-decision.json
@@ -65,13 +65,6 @@
         "title": "Tax and Chancery tribunal decisions",
         "withdrawn": false,
         "details": {
-          "document_noun": "decision",
-          "filter": {
-            "document_type": "tax_tribunal_decision"
-          },
-          "format_name": "Tax and Chancery tribunal decision",
-          "show_summaries": true,
-          "summary": "<p>Find decisions on tax, financial services, pensions, charity and land registration appeals to the Upper Tribunal (Tax and Chancery Chamber).</p>",
           "facets": [
             {
               "key": "tribunal_decision_category",
@@ -123,9 +116,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_order": "-tribunal_decision_decision_date",
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },

--- a/examples/specialist_document/frontend/utaac-decision.json
+++ b/examples/specialist_document/frontend/utaac-decision.json
@@ -60,13 +60,6 @@
         "title": "Administrative appeals tribunal decisions",
         "withdrawn": false,
         "details": {
-          "document_noun": "decision",
-          "filter": {
-            "document_type": "utaac_decision"
-          },
-          "format_name": "Administrative appeals tribunal decision",
-          "show_summaries": true,
-          "summary": "<p>Find decisions on appeals to the Upper Tribunal (Administrative Appeals Chamber), including social security and child support appeals.</p><p>This includes decisions made from January 2016 onwards. You can find details of <a rel=\"external\" href=\"http://administrativeappeals.decisions.tribunals.gov.uk/Aspx/default.aspx\">decisions made in 2015 or earlier</a> on the Courts and Tribunals Judiciary website.</p>",
           "facets": [
             {
               "key": "tribunal_decision_categories",
@@ -2471,8 +2464,7 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ],
-          "default_documents_per_page": 50
+          ]
         },
         "links": {
         },


### PR DESCRIPTION
We are aiming to reduce the number of fields included in link expansion so that the payload size is smaller, and we are only including the ones we actually need. This commit updates the content schema examples for the `specialist_document`s affected to make sure apps won't break.

Related PR: https://github.com/alphagov/publishing-api/pull/1380

Trello card: https://trello.com/c/HHBxFrJr/612-do-not-expand-unnecessary-links-for-finder