### PR TITLE
Stop requiring government/political for news

### DIFF
--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -337,9 +337,7 @@
     "details": {
       "type": "object",
       "required": [
-        "body",
-        "government",
-        "political"
+        "body"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -414,9 +414,7 @@
     "details": {
       "type": "object",
       "required": [
-        "body",
-        "government",
-        "political"
+        "body"
       ],
       "additionalProperties": false,
       "properties": {

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -219,9 +219,7 @@
     "details": {
       "type": "object",
       "required": [
-        "body",
-        "government",
-        "political"
+        "body"
       ],
       "additionalProperties": false,
       "properties": {

--- a/formats/news_article.jsonnet
+++ b/formats/news_article.jsonnet
@@ -11,8 +11,6 @@
       additionalProperties: false,
       required: [
         "body",
-        "government",
-        "political",
       ],
       properties: {
         body: {


### PR DESCRIPTION
https://trello.com/c/msxsnIdE/415-stop-sending-political-government-fields-to-publishing-api

Currently each news article must specify whether t is political and
irrespective have an associated government. The logic to do this in
Whitehall is complex and was implemented in a rush when there was a
change of government; we don't want to do this in Content Publisher.

Rather than send junk or inaccurate data to the Publishing API, it seems
we can avoid specifying these fields without causing issues downstream.

  * https://github.com/alphagov/finder-frontend/blob/master/app/views/finders/_results.mustache
  * https://github.com/alphagov/government-frontend/blob/7942c6f20dfac7f99c572b9a20e3c4fb7463c8c4/app/presenters/content_item/political.rb
  * https://github.com/alphagov/govuk_publishing_components/blob/master/lib/govuk_publishing_components/presenters/meta_tags.rb

Indeed, with the current implementation in Whitehall, we need to
manually republish all political content when the government changes.