### PR TITLE
 Remove postal code from required contact fields

### DIFF
--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -480,7 +480,6 @@
             "type": "object",
             "required": [
               "street_address",
-              "postal_code",
               "world_location"
             ],
             "additionalProperties": false,

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -546,7 +546,6 @@
             "type": "object",
             "required": [
               "street_address",
-              "postal_code",
               "world_location"
             ],
             "additionalProperties": false,

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -337,7 +337,6 @@
             "type": "object",
             "required": [
               "street_address",
-              "postal_code",
               "world_location"
             ],
             "additionalProperties": false,

--- a/formats/contact.jsonnet
+++ b/formats/contact.jsonnet
@@ -196,7 +196,6 @@
             additionalProperties: false,
             required: [
               "street_address",
-              "postal_code",
               "world_location",
             ],
             properties: {


### PR DESCRIPTION
We can't rely on this as a required field at the moment as Whitehall
currently has 448 (see below) items with a street address and no
postal code. There is not any validation to require the post code.

Most unfortunate is that often the region, locality and postal code are
bunged into the street address field.

```
irb(main):001:0> Contact.find_each.select { |c| c.postal_code.empty? && c.street_address.present? }.count
=> 448
```