### PR TITLE
Amend finder filters

### DIFF
--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -463,6 +463,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -522,6 +522,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -314,6 +314,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -483,6 +483,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -548,6 +548,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -328,6 +328,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "appear_in_find_eu_exit_guidance_business_finder": {
+          "type": "string"
+        },
         "content_purpose_supergroup": {
           "type": "array",
           "items": {

--- a/formats/shared/definitions/finder.jsonnet
+++ b/formats/shared/definitions/finder.jsonnet
@@ -72,6 +72,9 @@
       format: {
         type: "string",
       },
+      appear_in_find_eu_exit_guidance_business_finder: {
+        type: "string",
+      },
     },
   },
   finder_reject_filter: {


### PR DESCRIPTION
Adds to the permitted base filters for finders.
This allows us to filter arbitrary documents associated to a particular finder.

See: https://github.com/alphagov/rummager/pull/1330